### PR TITLE
Feature er/improve csv export

### DIFF
--- a/backend/experiment/models/experiment.py
+++ b/backend/experiment/models/experiment.py
@@ -83,12 +83,12 @@ class Experiment(models.Model):
                 'participant_country': profile['country_code'],
                 'session_start': session.started_at.isoformat(),
                 'session_end': session_finished,
-                'json_data': session.load_json_data()
+                'session_data': session.load_json_data()
             }
             row.update(profile['profile'])
             fieldnames.update(row.keys())
             if session.result_set.count() == 0:
-                # some experiments may have only profile questions                
+                # some sessions may have only profile questions
                 rows.append(row)
             else:
                 for result in session.result_set.all():
@@ -99,7 +99,8 @@ class Experiment(models.Model):
                         'result_score': result.score,
                         'result_comment': result.comment,
                         'expected_response': result.expected_response,
-                        'given_response': result.given_response
+                        'given_response': result.given_response,
+                        'result_data': result.load_json_data()
                     }
                     this_row.update(result_data)
                     fieldnames.update(result_data.keys())


### PR DESCRIPTION
This pull requests fixes a bug that would only return one session, if that session had no results (only profile questions) Now it adds that session to the csv and proceeds to the next one.
This branch also includes the json_data from the session and the json_data from the result (which includes the decision time) to the csv export.
The json data could be further integrated so that each key would have its own column in the csv. (do we want that?)
Note: I already merged this branch into feature-er/categorization to be able to do a proper csv export from the pilot version on the acceptance server.
