### PR TITLE
Fix country codes

### DIFF
--- a/backend/experiment/api/util/location.py
+++ b/backend/experiment/api/util/location.py
@@ -50,12 +50,6 @@ def get_country_code(ip_address):
     with urllib.request.urlopen(location_url) as url:
         try:
             return url.read().decode()
-            # Old format?
-            # data = json.loads(url.read().decode())
-            # if data.get('status') == 'ok':
-            #     return data.get('country')
-            # else:
-            #     return None
         except:
             return None
 


### PR DESCRIPTION
Closes #300 

In development, `ip2country` converts my **private** IP address to country code 'AU' :smile:. **Public** IP addresses seem to be converted properly.

I've also noticed that when a new participant is created in the database, actually two participants are created, one by `/experiment/id/<slug>` request, and one by `/experiment/participant` request. It seems that only the former is used further, and the latter remains unused. We should probably create a separate issue to look into that. 
