### PR TITLE
replace calls to merge_json_data

### DIFF
--- a/backend/experiment/rules/eurovision_2020.py
+++ b/backend/experiment/rules/eurovision_2020.py
@@ -80,7 +80,7 @@ class Eurovision2020(Hooked):
         }
 
         # Save, overwriting existing plan if one exists.
-        session.merge_json_data({'plan': plan})
+        session.save_json_data({'plan': plan})
         # session.save() is required for persistence
         session.save()
 

--- a/backend/experiment/rules/kuiper_2020.py
+++ b/backend/experiment/rules/kuiper_2020.py
@@ -81,7 +81,7 @@ class Kuiper2020(Hooked):
         print(plan)
 
         # Save, overwriting existing plan if one exists.
-        session.merge_json_data({'plan': plan})
+        session.save_json_data({'plan': plan})
         # session.save() is required for persistence
         session.save()
 


### PR DESCRIPTION
This fix should get the migrated Hooked experiments up and running again.