### PR TITLE
add timer to PlayCard

### DIFF
--- a/backend/experiment/actions/playback.py
+++ b/backend/experiment/actions/playback.py
@@ -14,6 +14,7 @@ class Playback(object):
             - playhead: from where the audio file should play (offset in seconds from start)
             - mute: whether audio should be muted
             - auto_play: whether sound will start automatically
+            - stop_audio_after: after how many seconds playback audio should be stopped
             - show_animation: whether to show an animation during playback 
             - (multiplayer) label_style: player index number style: NUMERIC, ALPHABETIC, ROMAN or empty (no label)
             - play_once: the sound can only be played once

--- a/backend/experiment/rules/matching_pairs.py
+++ b/backend/experiment/rules/matching_pairs.py
@@ -109,6 +109,7 @@ class MatchingPairs(Base):
         playback = Playback(
             sections=player_sections,
             player_type='MATCHINGPAIRS',
+            play_config={'stop_audio_after': 4}
         )
         trial = Trial(
             title='Matching pairs',

--- a/frontend/src/components/PlayButton/PlayCard.js
+++ b/frontend/src/components/PlayButton/PlayCard.js
@@ -1,15 +1,38 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 
 import Histogram from "../Histogram/Histogram";
+import Timer from "../../util/timer";
 
-const PlayCard = ({ onClick, registerUserClicks, playing, inactive, turned }) => {
+const PlayCard = ({ onClick, registerUserClicks, playing, section, onFinish, stopAudioAfter }) => {
+    // automatic timer
+    const startTime = 0;
+    const [time, setTime] = useState(startTime);
+    
+    useEffect(() => {
+        if (!playing) {
+            return;
+        }
+
+        // Create timer and return stop function
+        return Timer({
+            time: startTime,
+            duration: stopAudioAfter,
+            onTick: (t) => {
+                setTime(Math.min(t, stopAudioAfter));
+            },
+            onFinish: () => {
+                onFinish && onFinish();
+            },
+        });
+    }, [playing, stopAudioAfter, onFinish]);
+    
     return (
-        <div className={classNames("aha__play-card", {turned: turned}, {disabled: inactive})} onClick={event => {
+        <div className={classNames("aha__play-card", {turned: section.turned}, {disabled: section.inactive})} onClick={event => {
             registerUserClicks(event.clientX, event.clientY);
             onClick();
         }}>
-                { turned ?
+                { section.turned ?
                     <Histogram 
                         className="front"
                         running={playing}

--- a/frontend/src/components/Playback/MatchingPairs.js
+++ b/frontend/src/components/Playback/MatchingPairs.js
@@ -9,6 +9,8 @@ const MatchingPairs = ({
     playerIndex,
     setPlayerIndex,
     lastPlayerIndex,
+    finishedPlaying,
+    stopAudioAfter,
     submitResult
 }) => {
     const xPosition = useRef(-1);
@@ -91,8 +93,9 @@ const MatchingPairs = ({
                 }}
                 registerUserClicks={registerUserClicks}
                 playing={playerIndex === index}
-                inactive={sections[index].inactive}
-                turned={sections[index].turned}
+                section={sections[index]}
+                onFinish={finishedPlaying}
+                stopAudioAfter={stopAudioAfter}
                 />
             )
             )}

--- a/frontend/src/components/Playback/Playback.js
+++ b/frontend/src/components/Playback/Playback.js
@@ -142,6 +142,7 @@ const Playback = ({
     // Local logic for onfinished playing
     const onFinishedPlaying = useCallback(() => {
         setPlayerIndex(-1);
+        audio.stop();
         finishedPlaying && finishedPlaying();
     }, [finishedPlaying]);
 
@@ -205,6 +206,7 @@ const Playback = ({
                 return (
                     <MatchingPairs
                         {...attrs}
+                        stopAudioAfter={playConfig.stop_audio_after}
                     />
                 );
             default:


### PR DESCRIPTION
Introduces a Timer on the cards in the Matching Pairs game. Close #335 and close #346. Not quite happy yet with the fact that the `useEffect` hook for the Timer is just copy and paste from the Circle component - any suggestions of how to outfactor this welcome.