### PR TITLE
set str(filename) for serialization in moves

### DIFF
--- a/backend/experiment/rules/matching_pairs.py
+++ b/backend/experiment/rules/matching_pairs.py
@@ -161,7 +161,7 @@ class MatchingPairs(Base):
         elif result.question_key == 'matching_pairs':
             moves = data.get('result').get('moves')
             for m in moves:
-                m['filename'] = Section.objects.get(pk=m.get('selectedSection')).filename
+                m['filename'] = str(Section.objects.get(pk=m.get('selectedSection')).filename)
             score = sum([int(m['score']) for m in moves if 
                                m.get('score') and m['score']!= None]) + 100
         else:


### PR DESCRIPTION
Close #458 . Based on the issue description, I figured out that the problem was the saving of the `section.filename` in the moves array - with the `FileField` in place, this breaks if it's not converted to `str` first.