### PR TITLE
reduce nomatch reset to 700ms

### DIFF
--- a/frontend/src/components/Playback/MatchingPairs.js
+++ b/frontend/src/components/Playback/MatchingPairs.js
@@ -11,7 +11,7 @@ const MatchingPairs = ({
     stopAudioAfter,
     submitResult,
 }) => {
-    const finishDelay = 1500;
+    // const finishDelay = 1500;
     const xPosition = useRef(-1);
     const yPosition = useRef(-1);
     const score = useRef(undefined);
@@ -66,11 +66,11 @@ const MatchingPairs = ({
                 default:
                     turnedCards[0].nomatch = true;
                     turnedCards[1].nomatch = true;
-                    // reset nomatch cards for coming turns
+                    // reset nomatch cards for coming turns after animations have finished
                     setTimeout(() => {
                         turnedCards[0].nomatch = false;
                         turnedCards[1].nomatch = false;                        
-                      }, finishDelay);
+                      }, 700);
                     break;  
             }   
 


### PR DESCRIPTION
When you have a no match score the cards get the nomatch class to initiate the shaking animation, these classes need to be removed because the cards will go back on the board. This PR reduces the reset time to 700ms (was 1500ms).
This will prevent that only one card will shake when you click through the turns really fast. 