### PR TITLE
Fix requesting sections twice in Categorization experiment

### DIFF
--- a/frontend/src/components/Playback/Playback.js
+++ b/frontend/src/components/Playback/Playback.js
@@ -49,9 +49,9 @@ const Playback = ({
     }, [playerIndex]);
 
     // Preload first section
-    useEffect(() => {
-        return audio.loadUntilAvailable(MEDIA_ROOT + sections[0].url, () => {});
-    }, [sections]);
+    // useEffect(() => {
+    //     return audio.loadUntilAvailable(MEDIA_ROOT + sections[0].url, () => {});
+    // }, [sections]);
 
     // Cancel events
     const cancelAudioListeners = useCallback(() => {


### PR DESCRIPTION
Closes #223 

@BeritJanssen and @Evert-R 
This is caused by preloading of the first section in `useEffect` of `Playback.js`. The section is loaded again in `playSection()` when the Play button is clicked. I disabled the preloading and the Categorization, BeatAlignment, Eurovision and Tunetwins experiments seem to work fine. Do you foresee any potential problems with other experiments?