### PR TITLE
Config: Configure test workflow to run on pushes to all branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test suite
 
 on:
   push:
-    branches:
-      - main
-      - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test suite
 
 on:
   push:
-  pull_request:
 
 jobs:
   backend-test:

--- a/README.md
+++ b/README.md
@@ -45,5 +45,3 @@ To stop the containers, press `ctrl-c` or (in another terminal) run
 
 ## Production build
 A production build should define its own `docker-compose.yaml`, making use of the `Dockerfile` of the `backend` and `frontend` environments. It should also define a custom .env file, with safe passwords for the SQL database and the Python backend. Instead of mounting the entire backend and frontend directory and using the development servers, the backend should serve with gunicorn, and the frontend should use a build script to compile static html, css and JavaScript.
-
-# docker-compose --env-file .env-github-actions run client yarn test --watchAll=false


### PR DESCRIPTION
Before, the `test` workflow would only run when pushing to `develop` or `main`, or on the `pull_request` trigger. Now, the `test` workflow will be triggered on a push to _any_ branch as per the varying preferences in the team.