### PR TITLE
Docs: Add instructions for installing Python dependencies

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -88,6 +88,32 @@ from .views import MyView
 
 Check the client documentation for instructions for adding the view to the client.
 
+## Install packages
+
+If you want to install new packages, you can do so by adding the dependencies to:
+* `requirements.in/base.txt` for packages that are needed in both *development* **and** *production*
+* `requirements.in/dev.txt` for packages that are only needed in *development*
+* `requirements.in/prod.txt` for packages that are only needed in *production*
+
+Then, run the following `pip-compile` commands to generate the `requirements.txt` files:
+
+```bash
+# Install all packages for development
+docker compose run --rm server pip-compile --output-file=requirements/dev.txt requirements.in/dev.txt
+
+# Install all packages for production
+docker compose run --rm server pip-compile --output-file=requirements/prod.txt requirements.in/prod.txt
+```
+
+Lastly, rebuild the server image:
+
+```bash
+docker compose build server
+
+# or, if you want to run the server immediately
+docker compose up server --build -d
+```
+
 ## Troubleshooting
 
 #### Bad request

--- a/backend/README.md
+++ b/backend/README.md
@@ -88,32 +88,6 @@ from .views import MyView
 
 Check the client documentation for instructions for adding the view to the client.
 
-## Install packages
-
-If you want to install new packages, you can do so by adding the dependencies to:
-* `requirements.in/base.txt` for packages that are needed in both *development* **and** *production*
-* `requirements.in/dev.txt` for packages that are only needed in *development*
-* `requirements.in/prod.txt` for packages that are only needed in *production*
-
-Then, run the following `pip-compile` commands to generate the `requirements.txt` files:
-
-```bash
-# Install all packages for development
-docker compose run --rm server pip-compile --output-file=requirements/dev.txt requirements.in/dev.txt
-
-# Install all packages for production
-docker compose run --rm server pip-compile --output-file=requirements/prod.txt requirements.in/prod.txt
-```
-
-Lastly, rebuild the server image:
-
-```bash
-docker compose build server
-
-# or, if you want to run the server immediately
-docker compose up server --build -d
-```
-
 ## Troubleshooting
 
 #### Bad request

--- a/scripts/compile-requirements
+++ b/scripts/compile-requirements
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Compile requirements for development and production in one container instance
+docker compose run --rm server /bin/bash -c "\
+pip-compile --output-file=requirements/dev.txt requirements.in/dev.txt && \
+pip-compile --output-file=requirements/prod.txt requirements.in/prod.txt \
+"


### PR DESCRIPTION
This PR documents how to add python dependencies to the Django backend. Instead of reading markdown, you might want to look at it here: https://github.com/Amsterdam-Music-Lab/MUSCLE/tree/docs/add-python-deps/backend#install-packages

* Does the added entry in `backend/README.md` accurately and correctly describe the process of adding and installing new Python dependencies?
* Should it be documented in `backend/README.md`, or perhaps in the `README.md` in the root of the repository or perhaps even in the [Wiki](https://github.com/Amsterdam-Music-Lab/MUSCLE/wiki)?

## Update

- I've moved the documentation to the wiki: https://github.com/Amsterdam-Music-Lab/MUSCLE/wiki/X.-Installing-python-packages
- I've added a script that automatically runs the two `pip-compile` commands