### PR TITLE
CI: Add linting jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo docker-compose --env-file .env-github-actions run server bash -c "flake8"
+      - name: Lint Backend
+        continue-on-error: true
+        run: sudo docker-compose --env-file .env-github-actions run server bash -c "flake8"
 
   frontend-test:
     name: Test Frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
 
   backend-test:
+    name: Test Backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +21,7 @@ jobs:
       - run: sudo docker-compose --env-file .env-github-actions run server bash -c "flake8"
 
   frontend-test:
+    name: Test Frontend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
 
 jobs:
+
   backend-test:
     runs-on: ubuntu-latest
     steps:
@@ -17,8 +18,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Frontend Tests
         run: sudo docker-compose --env-file .env-github-actions run client yarn test --watchAll=false
-      - run: sudo docker-compose --env-file .env-github-actions run server bash -c "python manage.py test"
-      - run: sudo docker-compose --env-file .env-github-actions run client yarn test --watchAll=false
 
   frontend-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ jobs:
       - name: Run Backend Tests
         run: sudo docker-compose --env-file .env-github-actions run server bash -c "python manage.py test"
 
+  backend-lint:
+    name: Lint Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo docker-compose --env-file .env-github-actions run server bash -c "flake8"
+
   frontend-test:
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +27,7 @@ jobs:
         run: sudo docker-compose --env-file .env-github-actions run client yarn test --watchAll=false
 
   frontend-lint:
+    name: Lint Frontend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Frontend Tests
         run: sudo docker-compose --env-file .env-github-actions run client yarn test --watchAll=false
+      - run: sudo docker-compose --env-file .env-github-actions run server bash -c "python manage.py test"
+      - run: sudo docker-compose --env-file .env-github-actions run client yarn test --watchAll=false
+
+  frontend-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo docker-compose --env-file .env-github-actions run client yarn lint

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -28,6 +28,8 @@ django-debug-toolbar==3.2.2
     # via -r requirements.in/dev.txt
 django-inline-actions==2.4.0
     # via -r requirements.in/base.txt
+flake8==4.0.1
+    # via -r requirements.in/dev.txt
 idna==3.3
     # via requests
 iptocc==2.1.2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,8 @@
     "scss-watch": "sass src/index.scss src/index.css; sass --watch src/index.scss src/index.css",
     "storybook": "REACT_APP_API_ROOT=http://localhost:8000 && storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint:ts": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint src/**/*.js"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This PR adds linting jobs for both the frontend (`eslint`) and backend (`flake8`). The question right now is whether our linting settings/preferences are configured correctly and to our liking. Additionally, the linting job for the backend "fails", although I allowed it to fail. Maybe we can alter the `flake8` configuration so that it won't fail anymore, or we can allow it to fail and slowly fix all issues.