### PR TITLE
Fixed: Fix incorrect plural name of Experiment Series(s)

### DIFF
--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -24,6 +24,10 @@ class ExperimentSeries(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        verbose_name_plural = "Experiment Series"
+
+
 class Experiment(models.Model):
     """Root entity for configuring experiments"""
 
@@ -86,7 +90,7 @@ class Experiment(models.Model):
         }
 
     def export_table(self, session_keys, result_keys, export_options):
-        """Export filtered tabular data for admin        
+        """Export filtered tabular data for admin
             session_keys : session fieldnames to be included
             result_keys : result fieldnames to be included
             export_options : export options (see admin/forms.py)
@@ -195,7 +199,7 @@ class Experiment(models.Model):
             return score['final_score__max']
 
         return 0
-    
+
 class Feedback(models.Model):
     text = models.TextField()
     experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE)

--- a/backend/experiment/tests/test_model_functions.py
+++ b/backend/experiment/tests/test_model_functions.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from experiment.models import Experiment
+from experiment.models import Experiment, ExperimentSeries
 
 class TestModelExperiment(TestCase):
     @classmethod

--- a/backend/experiment/tests/test_model_functions.py
+++ b/backend/experiment/tests/test_model_functions.py
@@ -12,3 +12,11 @@ class TestModelExperiment(TestCase):
         keys1 = [q.key for q in rules1.questions]
         keys2 = [q.key for q in rules2.questions]
         assert keys1 != keys2
+
+class TestModelExperimentSeries(TestCase):
+
+    def test_verbose_name_plural(self):
+        # Get the ExperimentSeries Meta class
+        meta = ExperimentSeries._meta
+        # Check if verbose_name_plural is correctly set
+        self.assertEqual(meta.verbose_name_plural, "Experiment Series")


### PR DESCRIPTION
This PR fixes the incorrect plural naming of the _Experiment Series_ model, which is currently displayed as _Experiment Seriess_, but should be displayed as _Experiment Series_.

## Screenshot of local environment

(For what it's worth)

<img width="738" alt="afbeelding" src="https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/6d5ce77a-c1d0-41be-b5c4-a90618658a3d">

Fixes #635 