### PR TITLE
Fixed: Fix absolute import issue

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,5 +4,6 @@ RUN yarn set version stable
 WORKDIR /client
 COPY package.json /client/
 COPY yarn.lock /client/
+COPY jsconfig.json /client/
 RUN yarn
 COPY . /client/

--- a/frontend/DockerfileDevelop
+++ b/frontend/DockerfileDevelop
@@ -4,5 +4,6 @@ RUN yarn set version stable
 WORKDIR /client
 COPY package.json /client/
 COPY yarn.lock /client/
+COPY jsconfig.json /client/
 RUN yarn
 COPY /public /client/public

--- a/frontend/src/components/CountDown/CountDown.js
+++ b/frontend/src/components/CountDown/CountDown.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import Timer from "../../util/timer";
+import Timer from "util/timer";
 import classNames from "classnames";
 
 // CountDown to zero


### PR DESCRIPTION
`jsconfig.js` was not copied to the Docker container before, which broke absolute imports, e.g. `import Timer from 'util/timer';`