### PR TITLE
stripped down tutorial intro no CSS

### DIFF
--- a/backend/experiment/rules/__init__.py
+++ b/backend/experiment/rules/__init__.py
@@ -13,6 +13,7 @@ from .kuiper_2020 import Kuiper2020
 from .listening_conditions import ListeningConditions
 from .matching_pairs import MatchingPairs
 from .matching_pairs_icmpc import MatchingPairsICMPC
+from .matching_pairs_tutorial import MatchingPairsTutorial
 from .musical_preferences import MusicalPreferences
 from .rhythm_discrimination import RhythmDiscrimination
 from .rhythm_experiment_series import RhythmExperimentSeries
@@ -43,6 +44,7 @@ EXPERIMENT_RULES = {
     BST.ID: BST,
     MatchingPairs.ID: MatchingPairs,
     MatchingPairsICMPC.ID: MatchingPairsICMPC,
+    MatchingPairsTutorial.ID: MatchingPairsTutorial,
     MusicalPreferences.ID: MusicalPreferences,
     RhythmDiscrimination.ID: RhythmDiscrimination,
     RhythmExperimentSeries.ID: RhythmExperimentSeries,

--- a/backend/experiment/rules/matching_pairs_tutorial.py
+++ b/backend/experiment/rules/matching_pairs_tutorial.py
@@ -1,0 +1,123 @@
+import random
+
+from django.utils.translation import gettext_lazy as _
+from django.template.loader import render_to_string
+
+from .base import Base
+from experiment.actions import Consent, Explainer, Final, Playlist, StartSession, Step, Trial
+from experiment.actions.playback import Playback
+from experiment.questions.demographics import EXTRA_DEMOGRAPHICS
+from experiment.questions.utils import question_by_key
+from result.utils import prepare_result
+
+from section.models import Section
+
+class MatchingPairsTutorial(Base):
+    ID = 'MATCHING_PAIRS_TUTORIAL'
+    num_pairs = 3
+    contact_email = 'aml.tunetwins@gmail.com'
+
+    def __init__(self):
+        self.questions = [
+            #question_by_key('dgf_gender_identity'),
+            #question_by_key('dgf_generation'),
+            #question_by_key('dgf_musical_experience', EXTRA_DEMOGRAPHICS),
+            #question_by_key('dgf_country_of_origin'),
+            #question_by_key('dgf_education', drop_choices=['isced-2', 'isced-5'])
+        ]
+
+    def first_round(self, experiment):
+        # 1. Consent Removed (not needed to teach game)
+
+        # 2. Choose playlist.
+        playlist = Playlist(experiment.playlists.all())
+
+        # 3. Start session.
+        start_session = StartSession()
+
+        explainer = Explainer(
+            instruction='',
+            steps=[
+                Step(description=_('You are about to start the Matching Pairs Tutorial'))
+            ],
+            step_numbers=False)
+
+        return [
+            playlist,
+            explainer,
+            start_session
+        ]
+    
+    def next_round(self, session):
+        if session.rounds_passed() < 1:       
+            trials = self.get_questionnaire(session)
+            if trials:
+                intro_questions = Explainer(
+                    instruction=_('Before starting the game, we would like to ask you %i demographic questions.' % (len(trials))),
+                    steps=[]
+                )
+                return [intro_questions, *trials]
+            else:
+                trial = self.get_matching_pairs_trial(session)
+                return [trial]
+        else:
+            session.final_score += session.result_set.filter(
+                question_key='matching_pairs').last().score
+            session.save()
+            social_info = self.social_media_info(session.experiment, session.final_score)
+            social_info['apps'].append('clipboard')
+            score = Final(
+                session,
+                title='',
+                final_text='',
+                button={
+                    'text': 'Play again',
+                },
+                #rank=self.rank(session, exclude_unfinished=False)
+                #social=social_info,
+                #feedback_info=self.feedback_info()
+            )
+            cont = self.get_matching_pairs_trial(session)
+            return [score, cont]
+
+    def get_matching_pairs_trial(self, session):
+        json_data = session.load_json_data()
+        pairs = json_data.get('pairs', [])
+        if len(pairs) < self.num_pairs:
+            pairs = list(session.playlist.section_set.order_by().distinct('group').values_list('group', flat=True))
+            random.shuffle(pairs)
+        selected_pairs = pairs[:self.num_pairs]
+        session.save_json_data({'pairs': pairs[self.num_pairs:]})
+        originals = session.playlist.section_set.filter(group__in=selected_pairs, tag='Original')  
+        degradations = json_data.get('degradations')
+        if not degradations:
+            degradations = ['Original', '1stDegradation', '2ndDegradation']
+            random.shuffle(degradations)
+        degradation_type = degradations.pop()
+        session.save_json_data({'degradations': degradations})
+        if degradation_type == 'Original':
+            player_sections = player_sections = list(originals) * 2
+        else:
+            degradations = session.playlist.section_set.filter(group__in=selected_pairs, tag=degradation_type)
+            player_sections = list(originals) + list(degradations)
+        random.shuffle(player_sections)
+        playback = Playback(
+            sections=player_sections,
+            player_type='MATCHINGPAIRS',
+            play_config={'stop_audio_after': 5}
+        )
+        trial = Trial(
+            title='Tune twins',
+            playback=playback,
+            feedback_form=None,
+            result_id=prepare_result('matching_pairs', session),
+            config={'show_continue_button': False}
+        )
+        return trial
+
+    def calculate_score(self, result, data):
+        moves = data.get('result').get('moves')
+        for m in moves:
+            m['filename'] = str(Section.objects.get(pk=m.get('selectedSection')).filename)
+        score = data.get('result').get('score')
+        return score

--- a/backend/experiment/rules/matching_pairs_tutorial.py
+++ b/backend/experiment/rules/matching_pairs_tutorial.py
@@ -1,29 +1,14 @@
-import random
-
 from django.utils.translation import gettext_lazy as _
-from django.template.loader import render_to_string
 
-from .base import Base
 from experiment.actions import Consent, Explainer, Final, Playlist, StartSession, Step, Trial
-from experiment.actions.playback import Playback
-from experiment.questions.demographics import EXTRA_DEMOGRAPHICS
-from experiment.questions.utils import question_by_key
-from result.utils import prepare_result
+from .matching_pairs import MatchingPairs
 
-from section.models import Section
-
-class MatchingPairsTutorial(Base):
+class MatchingPairsTutorial(MatchingPairs):
     ID = 'MATCHING_PAIRS_TUTORIAL'
     num_pairs = 3
-    contact_email = 'aml.tunetwins@gmail.com'
 
     def __init__(self):
         self.questions = [
-            #question_by_key('dgf_gender_identity'),
-            #question_by_key('dgf_generation'),
-            #question_by_key('dgf_musical_experience', EXTRA_DEMOGRAPHICS),
-            #question_by_key('dgf_country_of_origin'),
-            #question_by_key('dgf_education', drop_choices=['isced-2', 'isced-5'])
         ]
 
     def first_round(self, experiment):
@@ -47,13 +32,13 @@ class MatchingPairsTutorial(Base):
             explainer,
             start_session
         ]
-    
+
     def next_round(self, session):
         if session.rounds_passed() < 1:       
             trials = self.get_questionnaire(session)
             if trials:
                 intro_questions = Explainer(
-                    instruction=_('Before starting the game, we would like to ask you %i demographic questions.' % (len(trials))),
+                    instruction=_('Log %i demographic questions:' % (len(trials))),
                     steps=[]
                 )
                 return [intro_questions, *trials]
@@ -64,60 +49,14 @@ class MatchingPairsTutorial(Base):
             session.final_score += session.result_set.filter(
                 question_key='matching_pairs').last().score
             session.save()
-            social_info = self.social_media_info(session.experiment, session.final_score)
-            social_info['apps'].append('clipboard')
             score = Final(
                 session,
                 title='',
                 final_text='',
                 button={
-                    'text': 'Play again',
-                },
-                #rank=self.rank(session, exclude_unfinished=False)
-                #social=social_info,
-                #feedback_info=self.feedback_info()
+                    'text': 'Play again?',
+                }
             )
             cont = self.get_matching_pairs_trial(session)
             return [score, cont]
 
-    def get_matching_pairs_trial(self, session):
-        json_data = session.load_json_data()
-        pairs = json_data.get('pairs', [])
-        if len(pairs) < self.num_pairs:
-            pairs = list(session.playlist.section_set.order_by().distinct('group').values_list('group', flat=True))
-            random.shuffle(pairs)
-        selected_pairs = pairs[:self.num_pairs]
-        session.save_json_data({'pairs': pairs[self.num_pairs:]})
-        originals = session.playlist.section_set.filter(group__in=selected_pairs, tag='Original')  
-        degradations = json_data.get('degradations')
-        if not degradations:
-            degradations = ['Original', '1stDegradation', '2ndDegradation']
-            random.shuffle(degradations)
-        degradation_type = degradations.pop()
-        session.save_json_data({'degradations': degradations})
-        if degradation_type == 'Original':
-            player_sections = player_sections = list(originals) * 2
-        else:
-            degradations = session.playlist.section_set.filter(group__in=selected_pairs, tag=degradation_type)
-            player_sections = list(originals) + list(degradations)
-        random.shuffle(player_sections)
-        playback = Playback(
-            sections=player_sections,
-            player_type='MATCHINGPAIRS',
-            play_config={'stop_audio_after': 5}
-        )
-        trial = Trial(
-            title='Tune twins',
-            playback=playback,
-            feedback_form=None,
-            result_id=prepare_result('matching_pairs', session),
-            config={'show_continue_button': False}
-        )
-        return trial
-
-    def calculate_score(self, result, data):
-        moves = data.get('result').get('moves')
-        for m in moves:
-            m['filename'] = str(Section.objects.get(pk=m.get('selectedSection')).filename)
-        score = data.get('result').get('score')
-        return score


### PR DESCRIPTION
First attempt at seeing if I can help out more on the small Congo related tasks.

Attempted #609 , with the following:

- Copied matching pairs to make matching pairs tutorial file
- Added in call to rules in init 
- removed unnecessary code other that start and do it again (looking at this level of minimalism for congo work)

Not sure if

- data will save, no need for it to, but have not totally figured out save structure

New Issues

- Will need to make a new issue to fix the CSS so it's a 2x3 grid, but didn't want to make a hack solution to this on the front end that just creates code duplication, will file this right away for future. If you have suggestions on best ways to do it (was going to just make Matching Pairs.js/scss duplicate tutorial set of files, then change all the calls from the new matching_pairs_tutorial.py file, but that didn't seem like the most elegant want to do it. 

Please let me know if these kinds of small fixes with my limited webdev skills are ultimately going to help out or just make more work for everyone. 

Also did this by cloning off main (as I got errors when I ran off of development).

