### PR TITLE
CI: Enable publish storybook to github pages

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -39,7 +39,6 @@ jobs:
           path: ./frontend/storybook-static
 
   deploy-gh-pages:
-    if: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -39,6 +39,8 @@ jobs:
           path: ./frontend/storybook-static
 
   deploy-gh-pages:
+    # only deploy on develop branch
+    if: github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR makes sure Storybook is only deployed to Github Pages on the `develop` branch. We can change this later to `main` if we would like to, but I think it's interesting for people to see what we are working on before it's even on production.