### PR TITLE
Fix problem with "sync" playback in SongSync

### DIFF
--- a/backend/experiment/actions/playback.py
+++ b/backend/experiment/actions/playback.py
@@ -24,6 +24,7 @@ class Playback(BaseAction):
             - show_animation: whether to show an animation during playback 
             - (multiplayer) label_style: player index number style: NUMERIC, ALPHABETIC, ROMAN or empty (no label)
             - play_once: the sound can only be played once
+            - resume_play: if the playback should resume from where a previous view left off
     '''
 
     TYPE_AUTOPLAY = 'AUTOPLAY'
@@ -45,6 +46,7 @@ class Playback(BaseAction):
             'show_animation': False,
             'mute': False,
             'play_once': False,
+            'resume_play': False
         }
         if play_config:
             self.play_config.update(play_config)

--- a/backend/experiment/actions/wrappers.py
+++ b/backend/experiment/actions/wrappers.py
@@ -96,7 +96,8 @@ def song_sync(session, section, title, response_time=15, play_method='BUFFER'):
                         play_config={
             'ready_time': 0,
             'playhead': silence_time + (random.randint(100, 150) / 10 if not continuation_correctness else 0),
-            'show_animation': True
+            'show_animation': True,
+            'resume_play': True
         }),
         config=trial_config,
         title=title

--- a/backend/result/score.py
+++ b/backend/result/score.py
@@ -56,6 +56,7 @@ def song_sync_recognition_score(result, data):
         return math.ceil(timeout - time)
         
 def song_sync_continuation_score(result, data):
+    ''' modify previous result and return None'''
     previous_result = result.session.get_previous_result(['recognize'])
     if check_expected_response(result) != result.given_response:
         previous_result.score *= -1

--- a/frontend/src/components/Playback/Autoplay.js
+++ b/frontend/src/components/Playback/Autoplay.js
@@ -1,30 +1,16 @@
 import React, { useRef, useEffect } from "react";
 
-import { playAudio } from "../../util/audioControl";
-
 import Circle from "../Circle/Circle";
 import ListenCircle from "../ListenCircle/ListenCircle";
 
-const AutoPlay = ({instruction, playConfig, sections, time, startedPlaying, finishedPlaying, responseTime, className=''}) => {
+const AutoPlay = ({instruction, playConfig, playSection, time, startedPlaying, finishedPlaying, responseTime, className=''}) => {
     // player state
     
     const running = useRef(playConfig.auto_play);
-    
-    const section = sections[0];
-
-    const onCircleTimerTick = (t) => {
-        time.current = t;
-    };
 
     // Handle view logic
     useEffect(() => {        
-        let latency = 0;
-        // Play audio at start time            
-        if (!playConfig.mute) {            
-            latency = playAudio(playConfig, section);          
-            // Compensate for audio latency and set state to playing
-            setTimeout(startedPlaying(), latency);
-        }
+        playSection(0)
     }, [playConfig, startedPlaying]);
 
     // Render component
@@ -36,7 +22,6 @@ const AutoPlay = ({instruction, playConfig, sections, time, startedPlaying, fini
                     duration={responseTime}
                     color="white"
                     animateCircle={playConfig.show_animation}
-                    onTick={onCircleTimerTick}
                     onFinish={() => {
                         // Stop audio
                         finishedPlaying();

--- a/frontend/src/components/Playback/Playback.js
+++ b/frontend/src/components/Playback/Playback.js
@@ -23,7 +23,7 @@ const Playback = ({
     sections,
     instruction,
     onPreloadReady,
-    preloadMessage,
+    preloadMessage = '',
     autoAdvance,
     responseTime,
     playConfig = {},
@@ -104,10 +104,7 @@ const Playback = ({
                         pauseAudio(playConfig);
                         return;
                     }
-                    // if the current player has resume_play set to true,
-                    // retrieve previous player's decisionTime from sessionStorage
-                    const playheadShift = playConfig.resume_play ? 
-                        parseFloat(window.sessionStorage.getItem('decisionTime')) : 0;
+                    const playheadShift = getPlayheadShift();
                     let latency = playAudio(playConfig, sections[index], playheadShift);
 
                     // Cancel active events
@@ -134,6 +131,14 @@ const Playback = ({
             },
             [playAudio, pauseAudio, sections, activeAudioEndedListener, cancelAudioListeners, startedPlaying, onAudioEnded]
     );
+
+    const getPlayheadShift = () => {
+        /* if the current Playback view has resume_play set to true,
+        retrieve previous Playback view's decisionTime from sessionStorage
+        */
+        return playConfig.resume_play ? 
+        parseFloat(window.sessionStorage.getItem('decisionTime')) : 0;
+    }
 
     // Local logic for onfinished playing
     const onFinishedPlaying = useCallback(() => {

--- a/frontend/src/components/Playback/Playback.js
+++ b/frontend/src/components/Playback/Playback.js
@@ -27,7 +27,6 @@ const Playback = ({
     autoAdvance,
     responseTime,
     playConfig = {},
-    time,
     submitResult,
     startedPlaying,
     finishedPlaying,
@@ -105,7 +104,11 @@ const Playback = ({
                         pauseAudio(playConfig);
                         return;
                     }
-                    let latency = playAudio(playConfig, sections[index]);
+                    // if the current player has resume_play set to true,
+                    // retrieve previous player's decisionTime from sessionStorage
+                    const playheadShift = playConfig.resume_play ? 
+                        parseFloat(window.sessionStorage.getItem('decisionTime')) : 0;
+                    let latency = playAudio(playConfig, sections[index], playheadShift);
 
                     // Cancel active events
                     cancelAudioListeners();
@@ -161,7 +164,6 @@ const Playback = ({
             autoAdvance,
             responseTime,
             playConfig,
-            time,
             startedPlaying,
             playerIndex,
             finishedPlaying: onFinishedPlaying,

--- a/frontend/src/components/Trial/Trial.js
+++ b/frontend/src/components/Trial/Trial.js
@@ -50,14 +50,12 @@ const Trial = ({
             }
 
             if (feedback_form) {
-                const decisionTime = getTimeSince(startTime.current);
-                // keep decisionTime in sessionStorage to be used by subsequent renders
-                window.sessionStorage.setItem('decisionTime', decisionTime);
+                
                 if (feedback_form.is_skippable) {
                     form.map((formElement => (formElement.value = formElement.value || '')))
                 }
                 await onResult({
-                    decision_time: decisionTime,
+                    decision_time: getAndStoreDecisionTime(),
                     form,
                     config
                 });
@@ -96,6 +94,13 @@ const Trial = ({
                 return false;
         }
 
+    }
+
+    const getAndStoreDecisionTime = () => {
+        const decisionTime = getTimeSince(startTime.current);
+        // keep decisionTime in sessionStorage to be used by subsequent renders
+        window.sessionStorage.setItem('decisionTime', decisionTime);
+        return decisionTime;
     }
 
     const finishedPlaying = useCallback(() => {

--- a/frontend/src/components/Trial/Trial.js
+++ b/frontend/src/components/Trial/Trial.js
@@ -30,8 +30,6 @@ const Trial = ({
     // This is used to keep track of the time a participant spends in this Trial view
     const startTime = useRef(getCurrentTime());
 
-    // Time ref, stores the time without updating the view
-    const time = useRef(0);
     const startTimer = useCallback(() => {
         startTime.current = getCurrentTime();
     }, []);
@@ -45,7 +43,6 @@ const Trial = ({
             }
             submitted.current = true;
 
-            const decision_time = getTimeSince(startTime.current);
             const form = feedback_form ? feedback_form.form : [{}];
 
             if (result.type === "time_passed") {
@@ -53,11 +50,14 @@ const Trial = ({
             }
 
             if (feedback_form) {
+                const decisionTime = getTimeSince(startTime.current);
+                // keep decisionTime in sessionStorage to be used by subsequent renders
+                window.sessionStorage.setItem('decisionTime', decisionTime);
                 if (feedback_form.is_skippable) {
                     form.map((formElement => (formElement.value = formElement.value || '')))
                 }
                 await onResult({
-                    decision_time,
+                    decision_time: decisionTime,
                     form,
                     config
                 });
@@ -135,7 +135,6 @@ const Trial = ({
                     responseTime={config.response_time}
                     playConfig={playback.play_config}
                     sections={playback.sections}
-                    time={time}
                     submitResult={makeResult}
                     startedPlaying={startTimer}
                     finishedPlaying={finishedPlaying}

--- a/frontend/src/util/audioControl.js
+++ b/frontend/src/util/audioControl.js
@@ -1,15 +1,16 @@
 import * as audio from "./audio";
 import * as webAudio from "./webAudio";
 
-export const playAudio = (playConfig, section) => {    
+export const playAudio = (playConfig, section, playheadShift=0) => {    
     let latency = 0;
+    const playhead = playConfig.playhead + playheadShift
 
     if (playConfig.play_method === 'BUFFER') {
         
         // Determine latency for current audio device
         latency = webAudio.getTotalLatency()
         // Play audio
-        webAudio.playBufferFrom(section.id, Math.max(0, playConfig.playhead || 0));
+        webAudio.playBufferFrom(section.id, playhead);
 
         return latency
     } else {        
@@ -25,7 +26,7 @@ export const playAudio = (playConfig, section) => {
         audio.setVolume(1);
 
         // Play audio
-        audio.playFrom(Math.max(0, playConfig.playhead || 0));
+        audio.playFrom(Math.max(0, playhead));
         
         return latency
     }


### PR DESCRIPTION
Close #662. The current solution saves `decisionTime` in `window.sessionStorage` every time the player clicks a form during a `Trial`. For every playback view, we can now set whether we want to `resume_play` from where a previous player left off.

Will experiment with whether this could also be achieved with a useState hook at the `Experiment` level, but this approach works for the time being.