### PR TITLE
Fixed: Sentry CORS issues

### DIFF
--- a/backend/aml/base_settings.py
+++ b/backend/aml/base_settings.py
@@ -155,8 +155,6 @@ CORS_ALLOW_CREDENTIALS = True
 SESSION_SAVE_EVERY_REQUEST = False # Do not set to True, because it will break session-based participant_id
 
 CSRF_USE_SESSIONS = False
-CORS_ALLOW_CREDENTIALS = True
-
 
 LOCALE_PATHS = [os.path.join(BASE_DIR, 'locale')]
 

--- a/backend/aml/base_settings.py
+++ b/backend/aml/base_settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+from corsheaders.defaults import default_headers
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -150,7 +151,10 @@ CORS_ORIGIN_WHITELIST = os.getenv(
 CORS_ORIGIN_ALLOW_ALL = False
 CORS_ALLOW_CREDENTIALS = True
 
-
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'sentry-trace',
+    'baggage',
+]
 
 SESSION_SAVE_EVERY_REQUEST = False # Do not set to True, because it will break session-based participant_id
 


### PR DESCRIPTION
This PR whitelists two CORS headers:
- `baggage`
- `sentry-trace`

Currently, the frontend adds these headers to requests towards the Django API for Sentry to be able to correlate errors in the frontend and backend. For example, something that might fail in the frontend might have something to do with something failing in the backend. As these events are now connected, Sentry can display the whole erroneous flow in its Dashboard, making it easier for us to debug.

See also: https://docs.sentry.io/platforms/javascript/usage/distributed-tracing/