### PR TITLE
Fixed: Failed backend test due to empty code coverage badge commit & push step issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           sudo docker-compose --env-file .env-github-actions run server bash -c "genbadge coverage -i coverage.xml -o coverage-backend-badge-new.svg -n \"Backend Code Coverage\""
       # Push coverage badge to separate branch (only for main and develop branches)
       - name: Push Backend Coverage Badge to separate branch
+        continue-on-error: true
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         run: |
           if git ls-remote --heads origin code-coverage-badges; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
           git add backend/coverage-backend-badge.svg
           git commit -m "Add backend coverage badge for commit $GITHUB_SHA"
           git push origin code-coverage-badges
+          # Check if there are any changes
+          if git diff --staged --quiet; then
+            echo "No changes in coverage badge. Skipping commit and push."
+          else
+            git commit -m "Add backend coverage badge for commit $GITHUB_SHA"
+            git push origin code-coverage-badges
+          fi
 
   backend-lint:
     name: Lint Backend


### PR DESCRIPTION
The backend test job is currently failing on the `develop` branch because it tries to push a commit and push a generated code coverage badge to the `code-coverage-badges` branch. However, as the generated code coverage badge is identical to the existing one (code coverage percentage hasn't changed in the last commits and thus so hasn't the badge), it tries to commit "nothing". This causes git to throw an error, resulting in the step to fail.

This PR then fixes this in two ways:
- First, `continue-on-error: true` is set to `true` for this step, which means Github Actions won't see it as a failed step and thus as a failed job
- Second, a check is made as to whether the newly generated code coverage badge is different from the currently existing one. If it's identical, it will skip the commit & push and echo that there is nothing to commit and push. If it's different, it will proceed with the commit & push.

Note: if this still doesn't work after merging it to `develop` and if I'm not present for the coming days/week, please just remove or comment out the whole step that tries to push the code coverage badge to the `code-coverage-badges` branch (line `25-49` in `.github/workflows/ci.yml`.