### PR TITLE
CI: Add Teams Notifications workflow

### DIFF
--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -1,0 +1,36 @@
+name: Teams Notifications
+
+on:
+  issues:
+    types: [assigned]
+  pull_request:
+    types: [assigned, closed]
+  workflow_run:
+    workflows: ["Test suite"]
+    types:
+      - completed
+
+jobs:
+  notify_teams:
+    runs-on: ubuntu-latest
+    if: always() # This ensures that the notification runs even if the workflow fails
+    steps:
+      - name: Notify Teams on Issue Assignment
+        if: github.event_name == 'issues'
+        run: |
+          curl -H "Content-Type: application/json" -d "{\"text\": \"🚀 Issue Assigned: ${{ github.event.issue.title }} assigned to ${{ github.event.issue.assignee.login }}\"}" ${{ secrets.TEAMS_WEBHOOK_URL }}
+
+      - name: Notify Teams on Pull Request Assignment
+        if: github.event_name == 'pull_request' && github.event.action == 'assigned'
+        run: |
+          curl -H "Content-Type: application/json" -d "{\"text\": \"🚀 PR Assigned: ${{ github.event.pull_request.title }} assigned to ${{ github.event.pull_request.assignee.login }}\"}" ${{ secrets.TEAMS_WEBHOOK_URL }}
+
+      - name: Notify Teams on Pull Request Merged
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        run: |
+          curl -H "Content-Type: application/json" -d "{\"text\": \"🎉 PR Merged: ${{ github.event.pull_request.title }}\"}" ${{ secrets.TEAMS_WEBHOOK_URL }}
+
+      - name: Notify Teams on Pipeline Failure
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
+        run: |
+          curl -H "Content-Type: application/json" -d "{\"text\": \"⚠️ Pipeline Failed: ${{ github.event.workflow_run.name }} failed\"}" ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/teams-notifications.yml
+++ b/.github/workflows/teams-notifications.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [assigned]
   pull_request:
-    types: [assigned, closed]
+    types: [assigned, closed, opened]
   workflow_run:
     workflows: ["Test suite"]
     types:


### PR DESCRIPTION
This PR intends to configure notifications that will be pushed to the newly created experimental teams channel named [_Github activity (experimental)_](https://teams.microsoft.com/l/channel/19%3Ab803ff74120a4438ad6d937bfce24c64%40thread.tacv2/Github%20activity%20(experimental)?groupId=5c5b7168-27f0-450f-80a6-1a7e2635e09a&tenantId=) for certain events, such as:

- An issue gets assigned to someone
- A pull requests is assigned or closed or opened
- The tests pipeline fails

## Request: feedback

This is just an experiment for now. Please let me know if you think this is an overkill of notifications and we can cancel this little project again, or let me know which notifications you _are_ interested in receiving - there's [a whole bunch of events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) we can hook into.