### PR TITLE
Close and recreate audiocontext for every play

### DIFF
--- a/frontend/src/util/webAudio.js
+++ b/frontend/src/util/webAudio.js
@@ -107,6 +107,10 @@ export const stopBuffer = () => {
 
 // play buffer by section.id
 export const playBuffer = (id) => {
+    // temporary solution for ios17
+    // https://devcodef1.com/news/1068842/fixing-ios-17-web-audio-issue
+    audioContext.close();
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
     source = audioContext.createBufferSource();
     source.buffer = buffers[id];
     source.connect(audioContext.destination);    
@@ -115,10 +119,14 @@ export const playBuffer = (id) => {
 
 // Play buffer from given time
 export const playBufferFrom = (id, time) => {
+    // temporary solution for ios17
+    // https://devcodef1.com/news/1068842/fixing-ios-17-web-audio-issue
+    audioContext.close();
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
     source = audioContext.createBufferSource();
     source.buffer = buffers[id];          
     source.connect(audioContext.destination);    
-    source.start(0, time);
+    source.start(0, time);    
 }
 
 // Suspend webaudio (frees up resources)

--- a/frontend/src/util/webAudio.js
+++ b/frontend/src/util/webAudio.js
@@ -111,6 +111,7 @@ export const playBuffer = (id) => {
     // https://devcodef1.com/news/1068842/fixing-ios-17-web-audio-issue
     audioContext.close();
     audioContext = new (window.AudioContext || window.webkitAudioContext)();
+
     source = audioContext.createBufferSource();
     source.buffer = buffers[id];
     source.connect(audioContext.destination);    
@@ -123,6 +124,7 @@ export const playBufferFrom = (id, time) => {
     // https://devcodef1.com/news/1068842/fixing-ios-17-web-audio-issue
     audioContext.close();
     audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    
     source = audioContext.createBufferSource();
     source.buffer = buffers[id];          
     source.connect(audioContext.destination);    


### PR DESCRIPTION
This PR closes and recreates the audiocontext of webaudio after each played sound.
https://devcodef1.com/news/1068842/fixing-ios-17-web-audio-issue

Hopefully this resolves issue #628
https://github.com/Amsterdam-Music-Lab/MUSCLE/issues/628

If not, this PR can be discarded, for efficiency reasons. 
(I cannot test this myself on IOS17)