### PR TITLE
Feature/teletunes questions

### DIFF
--- a/backend/experiment/actions/utils.py
+++ b/backend/experiment/actions/utils.py
@@ -1,4 +1,5 @@
 from os.path import join
+import random
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
@@ -88,3 +89,6 @@ def get_last_n_turnpoints(session, num_turnpoints):
     all_results = session.result_set.filter(comment__iendswith='turnpoint').order_by('-created_at').all()
     cutoff = min(all_results.count(), num_turnpoints)
     return all_results[:cutoff]
+
+def randomize_playhead(min_jitter, max_jitter, silence_time, continuation_correctness):
+    return silence_time + (random.uniform(min_jitter, max_jitter) if not continuation_correctness else 0)

--- a/backend/experiment/actions/wrappers.py
+++ b/backend/experiment/actions/wrappers.py
@@ -9,6 +9,7 @@ from .trial import Trial
 from result.utils import prepare_result
 
 from experiment.actions.styles import STYLE_BOOLEAN_NEGATIVE_FIRST
+from experiment.actions.utils import randomize_playhead
 
 
 def two_alternative_forced(session, section, choices, expected_response=None, style={}, comment='', scoring_rule=None, title='', config=None):
@@ -103,7 +104,7 @@ def song_sync(session, section, title, play_method='BUFFER',
                               'Did the track come back in the right place?'),
                           play_config={
             'ready_time': 0,
-            'playhead': silence_time + (random.uniform(min_jitter, max_jitter) if not continuation_correctness else 0),
+            'playhead': randomize_playhead(min_jitter, max_jitter, silence_time, continuation_correctness),
             'show_animation': True,
             'resume_play': True
         }),

--- a/backend/experiment/rules/tele_tunes.py
+++ b/backend/experiment/rules/tele_tunes.py
@@ -1,3 +1,6 @@
+from experiment.questions.musicgens import MUSICGENS_17_W_VARIANTS
+from experiment.questions.demographics import DEMOGRAPHICS
+from experiment.questions.utils import copy_shuffle
 from .hooked import Hooked
 
 
@@ -11,3 +14,12 @@ class HookedTeleTunes(Hooked):
     min_jitter = 5
     max_jitter = 10
     consent_file = 'consent_teletunes.html'
+
+    def __init__(self):
+        self.questions = [
+            # 1. Demographic questions (7 questions)
+            *copy_shuffle(DEMOGRAPHICS),
+            # 2. Musicgens questions with variants
+            *copy_shuffle(MUSICGENS_17_W_VARIANTS)
+        ]
+

--- a/backend/experiment/tests/test_actions.py
+++ b/backend/experiment/tests/test_actions.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+from experiment.actions.utils import randomize_playhead
+
+class TestActions(TestCase):
+
+    def test_randomize_playhead(self):
+        silence_time = 4
+        min_jitter = 5
+        max_jitter = 10
+        unjittered_playhead = randomize_playhead(min_jitter, max_jitter, silence_time, True)
+        assert unjittered_playhead == silence_time
+        jittered_playhead = randomize_playhead(min_jitter, max_jitter, silence_time, False)
+        assert jittered_playhead >= silence_time + min_jitter


### PR DESCRIPTION
I thought that assigning questions through the admin would work for all experiments now, but it turns out it only works for those which use the `experiment.rules.base.get_questionnaire` function. Most Hooked experiments get a single question after each round, and use the `experiment.rules.base.get_single_question` function instead. Since we don't want to fully randomize the questions here, but first get demographic, then musicgens questions, I reasoned it would be faster for now to hard-code the questions "old style", and add an issue for the `get_single_question` function ( #679 ), as we still need to figure a way to do "randomization in blocks" through the admin interface also.

The branch also adds a test for the playhead shift in song_sync rounds, checking that indeed, the playhead advances by `silence_time` if the track should continue where it left off, and otherwise `silcence_time` + a random jitter between min and max values.

