### PR TITLE
Added: Add upload and export functionality to PlaylistAdmin

### DIFF
--- a/backend/section/admin.py
+++ b/backend/section/admin.py
@@ -26,6 +26,7 @@ class SectionAdmin(admin.ModelAdmin):
     # Prevent large inner join
     list_select_related = ()
 
+
 admin.site.register(Section, SectionAdmin)
 
 # @admin.register(Playlist)

--- a/backend/section/admin.py
+++ b/backend/section/admin.py
@@ -50,7 +50,7 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
     list_display = ('name', 'section_count', 'experiment_count')
     search_fields = ['name', 'section__song__artist', 'section__song__name']
     inline_actions = ['add_sections',
-                      'edit_sections', 'export_json', 'export_csv']
+                      'edit_sections', 'export_csv']
 
     def save_model(self, request, obj, form, change):
 
@@ -160,19 +160,6 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
                      'sections': sections}
         )
 
-    def export_json(self, request, obj, parent_obj=None):
-        """Export playlist data in JSON, force download"""
-
-        response = JsonResponse(
-            obj.export_admin(), json_dumps_params={'indent': 4})
-
-        # force download attachment
-        response['Content-Disposition'] = 'attachment; filename="playlist_' + \
-            str(obj.id)+'.json"'
-        return response
-
-    export_json.short_description = "Export JSON"
-
     def export_csv(self, request, obj, parent_obj=None):
         """Export playlist sections to csv, force download"""
 
@@ -193,15 +180,10 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
         obj = self.get_object(request, pk)
         return self.export_csv(request, obj)
 
-    def export_json_view(self, request, pk):
-        obj = self.get_object(request, pk)
-        return self.export_json(request, obj)
-
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [
             path('<int:pk>/export_csv/', self.export_csv_view, name='section_playlist_export_csv'),
-            path('<int:pk>/export_json/', self.export_json_view, name='section_playlist_export_json'),
         ]
         return custom_urls + urls
 

--- a/backend/section/forms.py
+++ b/backend/section/forms.py
@@ -16,6 +16,7 @@ class AddSections(forms.Form):
     files = forms.FileField(widget=MultipleFileInput(attrs={'accept':'.wav,.mp3,.aiff,.flac,.ogg'}),
                             validators=[audio_file_validator()])
 
+
 class PlaylistAdminForm(forms.ModelForm):
     csv_file = forms.FileField(required=False, help_text='Upload a CSV file (overrides the text input above)', label='CSV file', widget=forms.FileInput(attrs={'accept':'.csv'}))
 

--- a/backend/section/forms.py
+++ b/backend/section/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from .models import Playlist
 
 from .validators import audio_file_validator
 
@@ -12,5 +13,26 @@ class AddSections(forms.Form):
     name = forms.CharField(max_length=128, required=False)
     tag = forms.CharField(max_length=128, required=False)
     group = forms.CharField(max_length=128, required=False)
-    files = forms.FileField(widget=MultipleFileInput(attrs={'accept':'.wav,.mp3,.aiff,.flac,.ogg'}), 
+    files = forms.FileField(widget=MultipleFileInput(attrs={'accept':'.wav,.mp3,.aiff,.flac,.ogg'}),
                             validators=[audio_file_validator()])
+
+class PlaylistAdminForm(forms.ModelForm):
+    csv_file = forms.FileField(required=False, help_text='Upload a CSV file (overrides the text input above)', label='CSV file', widget=forms.FileInput(attrs={'accept':'.csv'}))
+
+    class Meta:
+        model = Playlist
+        fields = '__all__'
+
+    def save(self, commit=True):
+        playlist = super().save(commit=False)
+
+        # Handle uploaded CSV file
+        csv_file = self.cleaned_data.get('csv_file')
+        if csv_file:
+            # Read and process the CSV file
+            playlist.csv = csv_file.read().decode('utf-8')
+
+        if commit:
+            playlist.save()
+
+        return playlist

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -2,6 +2,7 @@ import datetime
 import random
 import csv
 
+from django import forms
 from django.db import models
 from django.utils import timezone
 from django.urls import reverse
@@ -25,7 +26,7 @@ class Playlist(models.Model):
 
     def save(self, *args, **kwargs):
         """Update playlist csv field on every save"""
-        if self.process_csv is False:  
+        if self.process_csv is False:
             self.csv = self.update_admin_csv()
         super(Playlist, self).save(*args, **kwargs)
 
@@ -154,8 +155,8 @@ class Playlist(models.Model):
         self.section_set.filter(pk__in=delete_ids).delete()
 
         # Reset process csv option and save playlist
-        self.process_csv = False        
-        self.save()        
+        self.process_csv = False
+        self.save()
 
         return {
             'status': self.CSV_OK,
@@ -190,15 +191,15 @@ class Playlist(models.Model):
                 'sections': [section.export_admin() for section in self.section_set.all()],
             },
         }
-    
+
     def export_sections(self):
         # export section objects
         return self.section_set.all()
-    
+
     def update_admin_csv(self):
         """Update csv data for admin"""
         csvfile = CsvStringBuilder()
-        writer = csv.writer(csvfile)            
+        writer = csv.writer(csvfile)
         for section in self.section_set.all():
             if section.song:
                 this_artist = section.song.artist
@@ -225,7 +226,7 @@ class Song(models.Model):
     artist = models.CharField(db_index=True, blank=True, default='', max_length=128)
     name = models.CharField(db_index=True, blank=True, default='' ,max_length=128)
     restricted = models.JSONField(default=list, blank=True)
-    
+
     class Meta:
         unique_together = ("artist", "name")
 
@@ -249,7 +250,7 @@ class Section(models.Model):
     duration = models.FloatField(default=0.0)  # sec
     filename = models.FileField(upload_to=audio_upload_path, max_length=255, validators=[audio_file_validator()])
     play_count = models.PositiveIntegerField(default=0)
-    code = models.PositiveIntegerField(default=random_code)    
+    code = models.PositiveIntegerField(default=random_code)
     tag = models.CharField(max_length=128, default='0', blank=True)
     group = models.CharField(max_length=128, default='0', blank=True)
 
@@ -269,7 +270,7 @@ class Section(models.Model):
             return self.song.artist
         else:
             return ''
-    
+
     def song_name(self):
         if self.song:
             return self.song.name
@@ -306,7 +307,7 @@ class Section(models.Model):
             'name': self.song.name,
             'play_count': self.play_count
         }
-       
+
     def export_song(self):
         return self.instance
 

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -314,15 +314,12 @@ class Section(models.Model):
     def export_admin_csv(self):
         """Export csv data for admin"""
         return [
-            self.id,
-            self.pk,
             self.song.artist,
             self.song.name,
             self.start_time,
             self.duration,
             self.filename,
             self.song.restricted,
-            self.play_count,
             self.tag,
             self.group,
         ]

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -108,8 +108,12 @@ class Playlist(models.Model):
             song = None
             if row['artist'] and row['name']:
                 song, created = Song.objects.get_or_create(artist=row['artist'], name=row['name'])
+
             if int(row['restrict_to_nl']) == 1:
                 song.restricted = [{"restricted": "nl"}]
+                song.save()
+            elif int(row['restrict_to_nl']) == 0:
+                song.restricted = []
                 song.save()
             section = Section(playlist=self,
                               start_time=float(row['start_time']),
@@ -319,7 +323,7 @@ class Section(models.Model):
             self.start_time,
             self.duration,
             self.filename,
-            self.song.restricted,
+            1 if self.song.restricted else 0,
             self.tag,
             self.group,
         ]

--- a/backend/section/templates/change_form.html
+++ b/backend/section/templates/change_form.html
@@ -20,6 +20,5 @@
 {% block after_field_sets %}
 <div class="custom-actions">
     <a href="{% url 'admin:section_playlist_export_csv' original.pk %}" class="button">Export to CSV</a>
-    <a href="{% url 'admin:section_playlist_export_json' original.pk %}" class="button">Export to JSON</a>
 </div>
 {% endblock %}

--- a/backend/section/templates/change_form.html
+++ b/backend/section/templates/change_form.html
@@ -1,0 +1,25 @@
+{% extends "admin/change_form.html" %}
+{% load i18n static %}
+
+{% block extrahead %}
+{{ block.super }}
+<style>
+    .custom-actions {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: center;
+        margin: 1rem 0;
+        gap: 1rem;
+    }
+
+</style>
+{% endblock %}
+
+
+{% block after_field_sets %}
+<div class="custom-actions">
+    <a href="{% url 'admin:section_playlist_export_csv' original.pk %}" class="button">Export to CSV</a>
+    <a href="{% url 'admin:section_playlist_export_json' original.pk %}" class="button">Export to JSON</a>
+</div>
+{% endblock %}

--- a/backend/section/tests.py
+++ b/backend/section/tests.py
@@ -7,6 +7,7 @@ from section.admin import PlaylistAdmin
 from section.models import Playlist, Section, Song
 from section.forms import PlaylistAdminForm
 
+
 class PlaylistModelTest(TestCase):
 
     @classmethod
@@ -132,6 +133,7 @@ class TestAdminEditSection(TestCase):
         self.assertEqual(edit_section.song.restricted, [])
         self.assertEqual(response.status_code, 302)
 
+
 class PlaylistAdminTest(TestCase):
     def setUp(self):
         self.playlist = Playlist.objects.create(name="Test Playlist")
@@ -149,6 +151,7 @@ class PlaylistAdminTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
+
 
 class PlaylistAdminFormTest(TestCase):
 
@@ -179,7 +182,6 @@ class PlaylistAdminFormTest(TestCase):
         playlist = form.save()
 
         self.assertEqual(playlist.csv.strip(), self.csv_content.decode('utf-8').strip())
-
 
     def test_should_not_process_csv(self):
         uploaded_file = SimpleUploadedFile('test.csv', self.csv_content, content_type='text/csv')

--- a/backend/section/tests.py
+++ b/backend/section/tests.py
@@ -146,13 +146,6 @@ class PlaylistAdminTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'text/csv')
 
-    def test_export_json(self):
-        url = reverse('admin:section_playlist_export_json', args=[self.playlist.pk])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['Content-Type'], 'application/json')
-
-
 class PlaylistAdminFormTest(TestCase):
 
     def setUp(self):

--- a/backend/section/tests.py
+++ b/backend/section/tests.py
@@ -146,6 +146,7 @@ class PlaylistAdminTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'text/csv')
 
+
 class PlaylistAdminFormTest(TestCase):
 
     def setUp(self):

--- a/backend/section/urls.py
+++ b/backend/section/urls.py
@@ -5,7 +5,7 @@ from .views import get_section
 app_name = 'section'
 
 urlpatterns = [
-# Section
+    # Section
     path('<int:section_id>/<int:code>/',
         get_section, name='section'),
 ]

--- a/backend/section/views.py
+++ b/backend/section/views.py
@@ -35,7 +35,7 @@ def get_section(request, section_id, code):
         # The range/seeking of audio files in Chrome
         if not settings.DEBUG:
             return redirect(settings.MEDIA_URL + str(section.filename))
-        
+
         # Option 2: stream file through Django
         # Advantage: keeps url secure, correct play_count value
         # Disadvantage: potential high server load


### PR DESCRIPTION
This pull request adds the ability to upload CSV files and export playlists to CSV and JSON formats in the PlaylistAdmin section.

Resolves #591