### PR TITLE
Added: Add FloatingActionButton and UserFeedback components

### DIFF
--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -25,10 +25,20 @@ class Base(object):
     def feedback_info(self):
         feedback_body = render_to_string('feedback/user_feedback.html', {'email': self.contact_email})
         return {
+            # Header above the feedback form
             'header': _("Do you have any remarks or questions?"),
+
+            # Button text
             'button': _("Submit"),
+
+            # Body of the feedback form, can be HTML. Shown under the button
             'contact_body': feedback_body,
-            'thank_you': _("We appreciate your feedback!")
+
+            # Thank you message after submitting feedback
+            'thank_you': _("We appreciate your feedback!"),
+
+            # Show a floating button on the right side of the screen to open the feedback form
+            'show_float_button': False,
         }
 
     def calculate_score(self, result, data):
@@ -112,7 +122,7 @@ class Base(object):
                 feedback_form=Form([question], is_skippable=question.is_skippable))
         except StopIteration:
             return None
-    
+
     def get_questionnaire(self, session, randomize=False, cutoff_index=None):
         ''' Get a list of questions to be asked in succession '''
 
@@ -127,7 +137,7 @@ class Base(object):
                 feedback_form=Form([question], is_skippable=question.is_skippable)
             ))
         return trials
-    
+
     def social_media_info(self, experiment, score):
         current_url =  "{}/{}".format(settings.RELOAD_PARTICIPANT_TARGET,
             experiment.slug

--- a/backend/experiment/rules/gold_msi.py
+++ b/backend/experiment/rules/gold_msi.py
@@ -43,5 +43,4 @@ class GoldMSI(Base):
 
     def feedback_info(self):
         info = super().feedback_info()
-        info['show_float_button'] = True
         return info

--- a/backend/experiment/rules/gold_msi.py
+++ b/backend/experiment/rules/gold_msi.py
@@ -40,3 +40,8 @@ class GoldMSI(Base):
             return questions
         else:
             return final_action_with_optional_button(session, '', request_session)
+
+    def feedback_info(self):
+        info = super().feedback_info()
+        info['show_float_button'] = True
+        return info

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,7 +83,6 @@ services:
           - REACT_APP_SENTRY_DSN=${REACT_APP_SENTRY_DSN}
         ports:
           - 3000:3000
-          - 6006:6006
         command: sh -c "yarn scss && yarn start"
 volumes:
     db_data:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "react-scripts": "5.0.0",
     "react-select": "^5.4.0",
     "react-transition-group": "^4.4.5",
-    "sass": "^1.50"
+    "sass": "^1.69.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/Experiment/Experiment.js
+++ b/frontend/src/components/Experiment/Experiment.js
@@ -224,6 +224,16 @@ const Experiment = ({ match, location }) => {
                         className={className}
                     >
                         {render(state.view)}
+
+                        {experiment?.feedback_info?.show_float_button && (
+                            <FloatingActionButton>
+                                <UserFeedback
+                                    experimentSlug={experiment.slug}
+                                    participant={participant}
+                                    feedbackInfo={experiment.feedback_info}
+                                    inline={false} />
+                            </FloatingActionButton>
+                        )}
                     </DefaultPage>
                 ) : (
                     <div className="loader-container">
@@ -231,11 +241,7 @@ const Experiment = ({ match, location }) => {
                     </div>
                 )}
 
-                {experiment?.feedback_info?.show_float_button && (
-                    <FloatingActionButton>
-                        <UserFeedback experimentSlug={experiment.slug} participant={participant} feedbackInfo={experiment.feedback_info} />
-                    </FloatingActionButton>
-                )}
+
             </CSSTransition>
         </TransitionGroup>
     );

--- a/frontend/src/components/Experiment/Experiment.js
+++ b/frontend/src/components/Experiment/Experiment.js
@@ -16,6 +16,8 @@ import Trial from "../Trial/Trial";
 import useResultHandler from "../../hooks/useResultHandler";
 import Info from "../Info/Info";
 import classNames from "classnames";
+import FloatingActionButton from "components/FloatingActionButton/FloatingActionButton";
+import UserFeedback from "components/UserFeedback/UserFeedback";
 
 // Experiment handles the main experiment flow:
 // - Loads the experiment and participant
@@ -55,7 +57,7 @@ const Experiment = ({ match, location }) => {
         [loadState]
     );
 
-    const updateActions = useCallback( (currentActions) => {
+    const updateActions = useCallback((currentActions) => {
         let newActions = currentActions;
         const newState = newActions.shift();
         loadState(newState);
@@ -213,9 +215,9 @@ const Experiment = ({ match, location }) => {
                         title={state.title}
                         logoClickConfirm={
                             ["FINAL", "ERROR", "TOONTJEHOGER"].includes(key) ||
-                            // Info pages at end of experiment
-                            (key === "INFO" &&
-                                (!state.next_round || !state.next_round.length))
+                                // Info pages at end of experiment
+                                (key === "INFO" &&
+                                    (!state.next_round || !state.next_round.length))
                                 ? null
                                 : "Are you sure you want to stop this experiment?"
                         }
@@ -227,6 +229,12 @@ const Experiment = ({ match, location }) => {
                     <div className="loader-container">
                         <Loading />
                     </div>
+                )}
+
+                {experiment?.feedback_info?.show_float_button && (
+                    <FloatingActionButton>
+                        <UserFeedback experimentSlug={experiment.slug} participant={participant} feedbackInfo={experiment.feedback_info} />
+                    </FloatingActionButton>
                 )}
             </CSSTransition>
         </TransitionGroup>

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.js
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.js
@@ -21,27 +21,39 @@ const FloatingActionButton = ({
     }
 
     return (<>
-        <div className={
-            classNames("floating-action-button",
-                getPositionClassNames(position),
-                expanded && 'floating-action-button--expanded',
-                className
-            )}>
+        <div
+            data-testid="floating-action-button"
+            className={
+                classNames("floating-action-button",
+                    getPositionClassNames(position),
+                    expanded && 'floating-action-button--expanded',
+                    className
+                )}
+        >
             <button
+                data-testid="floating-action-button__toggle-button"
                 className='floating-action-button__toggle-button'
                 onClick={() => setExpanded(!expanded)}
             >
-                {expanded ? <i className={`floating-action-button__icon fa fa-times`}></i> : <i className={`floating-action-button__icon fa ${icon}`}></i>}
+                <i
+                    data-testid="floating-action-button__icon"
+                    className={`floating-action-button__icon fa ${expanded ? 'fa-times' : icon}`}
+                />
             </button>
-            <div className='floating-action-button__content'>
+            <div
+                data-testid="floating-action-button__content"
+                className='floating-action-button__content'
+            >
                 {children}
             </div>
         </div>
-        <div className={
-            classNames(
-                'floating-action-button__overlay',
-                expanded && 'floating-action-button__overlay--expanded'
-            )}
+        <div
+            data-testid="floating-action-button__overlay"
+            className={
+                classNames(
+                    'floating-action-button__overlay',
+                    expanded && 'floating-action-button__overlay--expanded'
+                )}
             onClick={() => setExpanded(false)}
             aria-hidden={expanded ? 'false' : 'true'}
             role="presentation"

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.js
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.js
@@ -6,6 +6,7 @@ const FloatingActionButton = ({
     children,
     icon = 'fa-comment',
     position = 'center-right',
+    className,
 }) => {
 
     const [expanded, setExpanded] = React.useState(false);
@@ -23,7 +24,9 @@ const FloatingActionButton = ({
         <div className={
             classNames("floating-action-button",
                 getPositionClassNames(position),
-                expanded && 'floating-action-button--expanded')}>
+                expanded && 'floating-action-button--expanded',
+                className
+            )}>
             <button
                 className='floating-action-button__toggle-button'
                 onClick={() => setExpanded(!expanded)}

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.js
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.js
@@ -2,18 +2,29 @@
 import React from 'react';
 import classNames from 'util/classNames';
 
+/**
+ * The FloatingActionButton component is a reusable component that renders a floating action button with customizable position, icon, and content.
+ * @param {Object} props - The props object containing the following properties:
+ *   - children: The content to be rendered inside the floating action button.
+ *   - icon: The icon class name for the button. Default value is 'fa-comment'.
+ *   - position: The position of the button. Possible values are 'bottom-left', 'bottom-right', 'top-left', 'top-right', 'center-left', 'center-right'. Default value is 'center-right'.
+ *   - className: Additional CSS class names for the button.
+ * @returns {JSX.Element} The rendered FloatingActionButton component.
+ */
 const FloatingActionButton = ({
     children,
     icon = 'fa-comment',
-    position = 'center-right',
+    position = 'center-right', // 'bottom-left', 'bottom-right', 'top-left', 'top-right', 'center-left', 'center-right' (default)
     className,
 }) => {
 
     const [expanded, setExpanded] = React.useState(false);
 
     /**
-     * @param {string} position
-     * @returns {string}
+     * The getPositionClassNames function generates CSS class names based on the provided position string for a floating action button.
+     * Which is used to position the button and overlay.
+     * @param {string} position (e.g. 'bottom-left', 'center-right')
+     * @returns {string} (e.g. 'floating-action-button--bottom floating-action-button--left' or 'floating-action-button--center floating-action-button--right')
      */
     const getPositionClassNames = (position) => {
         const [vertical, horizontal] = position.split('-');

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.js
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.js
@@ -1,0 +1,41 @@
+
+import React from 'react';
+import classNames from 'util/classNames';
+
+const FloatingActionButton = ({
+    children,
+    icon = 'fa-comment',
+    position = 'center-right',
+}) => {
+
+    const [expanded, setExpanded] = React.useState(false);
+
+    /**
+     * @param {string} position
+     * @returns {string}
+     */
+    const getPositionClassNames = (position) => {
+        const [vertical, horizontal] = position.split('-');
+        return `floating-action-button--${vertical} ${horizontal ? `floating-action-button--${horizontal}` : ''}`;
+    }
+
+    return (
+        <div className={
+            classNames("floating-action-button",
+                getPositionClassNames(position),
+                expanded && 'floating-action-button--expanded')}>
+            <button
+                className='floating-action-button__toggle-button'
+                onClick={() => setExpanded(!expanded)}
+            >
+                {expanded ? <i className={`floating-action-button__icon fa fa-times`}></i> : <i className={`floating-action-button__icon fa ${icon}`}></i>}
+            </button>
+            <div className='floating-action-button__content'>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default FloatingActionButton;
+

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.js
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.js
@@ -19,7 +19,7 @@ const FloatingActionButton = ({
         return `floating-action-button--${vertical} ${horizontal ? `floating-action-button--${horizontal}` : ''}`;
     }
 
-    return (
+    return (<>
         <div className={
             classNames("floating-action-button",
                 getPositionClassNames(position),
@@ -34,6 +34,17 @@ const FloatingActionButton = ({
                 {children}
             </div>
         </div>
+        <div className={
+            classNames(
+                'floating-action-button__overlay',
+                expanded && 'floating-action-button__overlay--expanded'
+            )}
+            onClick={() => setExpanded(false)}
+            aria-hidden={expanded ? 'false' : 'true'}
+            role="presentation"
+        >
+        </div>
+    </>
     );
 };
 

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
@@ -57,7 +57,7 @@
     }
 
     &__toggle-button {
-        background: $gray;
+        background: $gray-200;
         border: none;
         padding: .5rem;
         border-top-left-radius: 4px;
@@ -67,11 +67,11 @@
     &__icon {
         width: 24px;
         height: 24px;
-        color: #fff;
+        color: $black;
     }
 
     &__content {
-        background: $gray;
+        background: $gray-200;
         border: none;
         padding: .5rem;
         border-top-right-radius: 4px;

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
@@ -5,14 +5,12 @@
 
     display: flex;
     flex-direction: row;
-
     position: fixed;
     z-index: 100;
     cursor: pointer;
     transition-property: transform, left, right, top, bottom, filter;
     transition-duration: 0.2s;
     transition-timing-function: ease-in-out;
-
     filter: drop-shadow(0, 0, 0, rgba(0, 0, 0, 0));
 
     &--expanded {
@@ -92,6 +90,24 @@
             border-bottom-left-radius: 4px;
             border-top-right-radius: 0px;
             border-bottom-right-radius: 0px;
+        }
+    }
+
+    &__overlay {
+        position: fixed;
+        z-index: 99;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0,0,0,.2);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity .2s ease-in-out;
+
+        &--expanded {
+            opacity: 1;
+            pointer-events: all;
         }
     }
 }

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
@@ -18,11 +18,12 @@
     }
 
     &--left {
+        flex-direction: row-reverse;
         right: auto;
-        left: 0px;
+        left: -200px;
 
         &#{$self}--expanded {
-            left: 200px;
+            left: 0px;
         }
     }
 
@@ -58,8 +59,20 @@
         background: $gray;
         border: none;
         padding: .5rem;
-        border-top-left-radius: 4px;
-        border-bottom-left-radius: 4px;
+
+        #{$self}--left & {
+            border-top-left-radius: 0px;
+            border-bottom-left-radius: 0px;
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+        }
+
+        #{$self}--right & {
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
+            border-top-right-radius: 0px;
+            border-bottom-right-radius: 0px;
+        }
     }
 
     &__icon {
@@ -89,6 +102,16 @@
             border-top-left-radius: 4px;
             border-bottom-left-radius: 4px;
             border-top-right-radius: 0px;
+            border-bottom-right-radius: 0px;
+        }
+
+        #{$self}--top & {
+            border-top-left-radius: 0px;
+            border-top-right-radius: 0px;
+        }
+
+        #{$self}--bottom & {
+            border-bottom-left-radius: 0px;
             border-bottom-right-radius: 0px;
         }
     }

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
@@ -55,7 +55,7 @@
     }
 
     &__toggle-button {
-        background: $gray-200;
+        background: $gray;
         border: none;
         padding: .5rem;
         border-top-left-radius: 4px;
@@ -69,7 +69,7 @@
     }
 
     &__content {
-        background: $gray-200;
+        background: $gray;
         border: none;
         padding: .5rem;
         border-top-right-radius: 4px;

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.scss
@@ -1,0 +1,97 @@
+@import "../../scss/variables.scss";
+
+.floating-action-button {
+    $self: &;
+
+    display: flex;
+    flex-direction: row;
+
+    position: fixed;
+    z-index: 100;
+    cursor: pointer;
+    transition-property: transform, left, right, top, bottom, filter;
+    transition-duration: 0.2s;
+    transition-timing-function: ease-in-out;
+
+    filter: drop-shadow(0, 0, 0, rgba(0, 0, 0, 0));
+
+    &--expanded {
+        filter: drop-shadow(0px 2px 2px rgba(0, 0, 0, 0.2));
+    }
+
+    &--left {
+        right: auto;
+        left: 0px;
+
+        &#{$self}--expanded {
+            left: 200px;
+        }
+    }
+
+    &--right {
+        left: auto;
+        right: -200px;
+
+        &#{$self}--expanded {
+            right: 0px;
+        }
+    }
+
+    &--top {
+        align-items: flex-start;
+        bottom: auto;
+        top: 0px;
+    }
+
+    &--bottom {
+        align-items: flex-end;
+        top: auto;
+        bottom: 0px;
+    }
+
+    // vertically centered
+    &--center {
+        align-items: center;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+
+    &__toggle-button {
+        background: $gray;
+        border: none;
+        padding: .5rem;
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+    }
+
+    &__icon {
+        width: 24px;
+        height: 24px;
+        color: #fff;
+    }
+
+    &__content {
+        background: $gray;
+        border: none;
+        padding: .5rem;
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        width: 200px;
+        min-height: 100px;
+        max-height: 100vh;
+
+        #{$self}--left & {
+            border-top-left-radius: 0px;
+            border-bottom-left-radius: 0px;
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+        }
+
+        #{$self}--right & {
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
+            border-top-right-radius: 0px;
+            border-bottom-right-radius: 0px;
+        }
+    }
+}

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.test.js
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import FloatingActionButton from './FloatingActionButton';
+
+describe('FloatingActionButton', () => {
+    it('renders the button with the initial icon', () => {
+        render(<FloatingActionButton icon="fa-comment" />);
+        const icon = screen.getByTestId('floating-action-button__icon');
+        expect(icon).toBeInTheDocument();
+        expect(icon).toHaveClass('fa-comment');
+    });
+
+    it('toggles the content on click', () => {
+        const { getByTestId } = render(<FloatingActionButton icon="fa-comment"><div>Test Content</div></FloatingActionButton>);
+
+        const toggleButton = getByTestId('floating-action-button__toggle-button');
+        fireEvent.click(toggleButton);
+
+        const content = getByTestId('floating-action-button');
+        expect(content).toHaveClass('floating-action-button--expanded');
+
+        fireEvent.click(toggleButton);
+        expect(content).not.toHaveClass('floating-action-button--expanded');
+    });
+
+    it('displays the correct icon when expanded', () => {
+        const { getByTestId } = render(<FloatingActionButton icon="fa-comment" />);
+
+        const toggleButton = getByTestId('floating-action-button__toggle-button');
+        fireEvent.click(toggleButton);
+
+        const icon = getByTestId('floating-action-button__icon');
+        expect(icon).toBeInTheDocument();
+        expect(icon).toHaveClass('fa-times');
+    });
+
+    it('closes the expanded content when the overlay is clicked', () => {
+        const { getByTestId } = render(<FloatingActionButton icon="fa-comment"><div>Test Content</div></FloatingActionButton>);
+
+        const toggleButton = getByTestId('floating-action-button__toggle-button');
+        fireEvent.click(toggleButton);
+
+        const overlay = getByTestId('floating-action-button__overlay');
+        fireEvent.click(overlay);
+
+        const content = getByTestId('floating-action-button__content');
+        expect(content).not.toHaveClass('floating-action-button--expanded');
+    });
+
+    it('initially renders in a collapsed state', () => {
+        render(<FloatingActionButton icon="fa-comment" />);
+        expect(screen.getByTestId('floating-action-button')).not.toHaveClass('floating-action-button--expanded');
+    });
+
+    it('correctly applies position classes', () => {
+        render(<FloatingActionButton position="bottom-left" />);
+        expect(screen.getByTestId('floating-action-button')).toHaveClass('floating-action-button--bottom');
+        expect(screen.getByTestId('floating-action-button')).toHaveClass('floating-action-button--left');
+    });
+
+    it('applies custom class name', () => {
+        render(<FloatingActionButton className="custom-class" />);
+        expect(screen.getByTestId('floating-action-button')).toHaveClass('custom-class');
+    });
+
+    it('updates aria-hidden attribute of overlay correctly', () => {
+        render(<FloatingActionButton />);
+        const overlay = screen.getByTestId('floating-action-button__overlay');
+        expect(overlay).toHaveAttribute('aria-hidden', 'true');
+        fireEvent.click(screen.getByTestId('floating-action-button__toggle-button'));
+        expect(overlay).toHaveAttribute('aria-hidden', 'false');
+    });
+});

--- a/frontend/src/components/UserFeedback/UserFeedback.js
+++ b/frontend/src/components/UserFeedback/UserFeedback.js
@@ -3,8 +3,9 @@ import React, { useState} from 'react';
 import { postFeedback } from '../../API';
 import Button from '../Button/Button';
 import HTML from '../HTML/HTML';
+import classNames from 'util/classNames';
 
-const UserFeedback = ({experimentSlug, participant, feedbackInfo}) => {
+const UserFeedback = ({experimentSlug, participant, feedbackInfo, inline = true}) => {
     const [value, setValue] = useState('');
     const [showForm, setShowForm] = useState(true);
 
@@ -22,13 +23,15 @@ const UserFeedback = ({experimentSlug, participant, feedbackInfo}) => {
     const handleChange = (event) => {
         setValue(event.target.value);
     }
-    
+
+    const orientationClassNames = inline ? '' : 'aha__user-feedback--vertical'
+
     return (
-        <div className="aha__user-feedback">
+        <div className={classNames("aha__user-feedback", orientationClassNames)}>
         {showForm === true ? (
             <div className='user-feedback__wrapper'>
                 <div className='user-feedback__header text-center'>{feedbackInfo.header}</div>
-                <div className="user-feedback__form d-flex justify-content-center">
+                <div className="user-feedback__form">
                     <textarea
                         className="user-feedback__input"
                         type="text"
@@ -37,7 +40,7 @@ const UserFeedback = ({experimentSlug, participant, feedbackInfo}) => {
                     ></textarea>
                     <Button
                         title={feedbackInfo.button}
-                        className={"btn-primary anim anim-fade-in anim-speed-500"}
+                        className={"user-feedback__button btn-primary anim anim-fade-in anim-speed-500"}
                         onClick={giveFeedback}
                     />
                 </div>

--- a/frontend/src/components/UserFeedback/UserFeedback.scss
+++ b/frontend/src/components/UserFeedback/UserFeedback.scss
@@ -1,19 +1,52 @@
+@import '../../scss/variables.scss';
+
 .aha__user-feedback {
     * {
         margin-top: .2rem;
     }
+}
 
-    button {
-        border-top-left-radius: 0%;
-        border-bottom-left-radius: 0%;
+.user-feedback__form {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 0;
+
+    .aha__user-feedback--vertical & {
+        display: block;
     }
 }
 
+
 .user-feedback__input {
-    width: 50vw;
     border: 1px solid #ccc;
+    border-right: none;
     border-radius: 4px;
     border-top-right-radius: 0%;
     border-bottom-right-radius: 0%;
-    border-right: none;
+    width: 50vw;
+
+    .aha__user-feedback--vertical & {
+        height: 5rem;
+        width: 100%;
+        align-items: center;
+        justify-content: center;
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-right: 1px solid #ccc;
+    }
+}
+
+
+.user-feedback__button {
+    border-top-left-radius: 0%;
+    border-bottom-left-radius: 0%;
+
+    .aha__user-feedback--vertical & {
+        margin-top: .5rem;
+        border-radius: 4px;
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+        width: 100%;
+    }
 }

--- a/frontend/src/components/UserFeedback/UserFeedback.scss
+++ b/frontend/src/components/UserFeedback/UserFeedback.scss
@@ -2,8 +2,18 @@
     * {
         margin-top: .2rem;
     }
+
+    button {
+        border-top-left-radius: 0%;
+        border-bottom-left-radius: 0%;
+    }
 }
 
 .user-feedback__input {
     width: 50vw;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    border-top-right-radius: 0%;
+    border-bottom-right-radius: 0%;
+    border-right: none;
 }

--- a/frontend/src/components/UserFeedback/UserFeedback.test.js
+++ b/frontend/src/components/UserFeedback/UserFeedback.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import UserFeedback from './UserFeedback';
+import { postFeedback } from '../../API';
+
+// Mock the API call
+jest.mock('../../API', () => ({
+  postFeedback: jest.fn(),
+}));
+
+describe('UserFeedback', () => {
+  const mockExperimentSlug = 'test-slug';
+  const mockParticipant = { id: 1 };
+  const mockFeedbackInfo = {
+    header: 'Your Feedback',
+    button: 'Submit',
+    contact_body: 'Contact us at test@example.com',
+    thank_you: 'Thank you for your feedback!'
+  };
+
+  it('renders the feedback form', () => {
+    const { getByText, getByRole } = render(
+      <UserFeedback
+        experimentSlug={mockExperimentSlug}
+        participant={mockParticipant}
+        feedbackInfo={mockFeedbackInfo}
+      />
+    );
+
+    expect(getByText(mockFeedbackInfo.header)).toBeInTheDocument();
+    expect(getByRole('textbox')).toBeInTheDocument();
+    expect(getByText(mockFeedbackInfo.button)).toBeInTheDocument();
+  });
+
+  it('allows input to be entered', () => {
+    const { getByRole } = render(
+      <UserFeedback
+        experimentSlug={mockExperimentSlug}
+        participant={mockParticipant}
+        feedbackInfo={mockFeedbackInfo}
+      />
+    );
+
+    const input = getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Great experience!' } });
+
+    expect(input.value).toBe('Great experience!');
+  });
+
+  it('submits feedback and shows thank you message', async () => {
+    postFeedback.mockResolvedValueOnce({}); // Mocking resolved promise
+
+    const { getByText, getByRole, queryByText } = render(
+      <UserFeedback
+        experimentSlug={mockExperimentSlug}
+        participant={mockParticipant}
+        feedbackInfo={mockFeedbackInfo}
+      />
+    );
+
+    fireEvent.change(getByRole('textbox'), { target: { value: 'Great experience!' } });
+    fireEvent.click(getByText(mockFeedbackInfo.button));
+
+    await waitFor(() => {
+      expect(postFeedback).toHaveBeenCalledWith({
+        experimentSlug: mockExperimentSlug,
+        feedback: 'Great experience!',
+        participant: mockParticipant
+      });
+      expect(queryByText(mockFeedbackInfo.header)).not.toBeInTheDocument();
+      expect(getByText(mockFeedbackInfo.thank_you)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/components.scss
+++ b/frontend/src/components/components.scss
@@ -21,6 +21,7 @@
 @import "./Experiment/Experiment";
 @import "./Explainer/Explainer";
 @import "./Final/Final";
+@import "./FloatingActionButton/FloatingActionButton";
 @import "./HTML/HTML";
 @import "./Info/Info";
 @import "./Listen/Listen";

--- a/frontend/src/scss/variables.scss
+++ b/frontend/src/scss/variables.scss
@@ -8,6 +8,7 @@ $blue: #0cc7f1;
 $green: #00b612;
 $indigo: #2b2bee;
 $gray: #bdbebf;
+$gray-200: #e9ecef;
 $gray-900: #212529;
 $black: $gray-900;
 

--- a/frontend/src/scss/variables.scss
+++ b/frontend/src/scss/variables.scss
@@ -22,3 +22,10 @@ $facebook-blue: #4267b2;
 $twitter-blue: #1da1f2;
 
 $fa-font-path: "../public/vendor/font-awesome/webfonts";
+
+// breakpoints
+$breakpoint-xs: 0;
+$breakpoint-sm: 576px;
+$breakpoint-md: 768px;
+$breakpoint-lg: 992px;
+$breakpoint-xl: 1200px;

--- a/frontend/src/stories/Final.stories.js
+++ b/frontend/src/stories/Final.stories.js
@@ -1,0 +1,66 @@
+import {
+    BrowserRouter as Router,
+} from "react-router-dom";
+
+import Final from '../components/Final/Final';
+
+export default {
+    title: 'Final',
+    component: Final,
+    parameters: {
+        layout: 'fullscreen',
+    },
+};
+
+export const Default = {
+    args: {
+        score: 100,
+        rank: {
+            text: 'Rank',
+            class: 'rank',
+        },
+        final_text: '<p>Final text</p>',
+        points: 'points',
+        button: {
+            text: 'Button',
+            link: 'https://www.google.com',
+        },
+        logo: {
+            image: 'https://via.placeholder.com/150',
+            link: 'https://www.google.com',
+        },
+        social: {
+            apps: ['facebook', 'whatsapp', 'twitter', 'weibo', 'share', 'clipboard'],
+            url: 'https://www.google.com',
+            message: 'Message',
+            hashtags: ['hashtag'],
+            text: 'Text',
+        },
+        show_profile_link: true,
+        action_texts: {
+            all_experiments: 'All experiments',
+            profile: 'Profile',
+        },
+        show_participant_link: true,
+        participant_id_only: false,
+        feedback_info: {
+            header: 'Feedback',
+            button: 'Submit',
+            thank_you: 'Thank you for your feedback!',
+            contact_body: '<p>Please contact us at <a href="mailto:info@example.com">info@example.com</a> if you have any questions.</p>',
+        },
+        experiment: {
+            slug: 'test',
+        },
+        participant: 'test',
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Router>
+                    <Story />
+                </Router>
+            </div>
+        ),
+    ],
+};

--- a/frontend/src/stories/FloatingActionButton.stories.js
+++ b/frontend/src/stories/FloatingActionButton.stories.js
@@ -35,3 +35,99 @@ export const Default = {
         ),
     ],
 };
+
+export const TopLeft = {
+    args: {
+        position: 'top-left',
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const TopRight = {
+    args: {
+        position: 'top-right',
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const BottomLeft = {
+    args: {
+        position: 'bottom-left',
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const BottomRight = {
+    args: {
+        position: 'bottom-right',
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const CenterLeft = {
+    args: {
+        position: 'center-left',
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const CenterRight = {
+    args: {
+        position: 'center-right',
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/frontend/src/stories/FloatingActionButton.stories.js
+++ b/frontend/src/stories/FloatingActionButton.stories.js
@@ -1,0 +1,37 @@
+import UserFeedback from 'components/UserFeedback/UserFeedback';
+import FloatingActionButton from '../components/FloatingActionButton/FloatingActionButton';
+
+export default {
+    title: 'FloatingActionButton',
+    component: FloatingActionButton,
+    parameters: {
+        layout: 'fullscreen',
+    },
+};
+
+const userFeedbackProps = {
+    experimentSlug: 'test',
+    participant: 'test',
+    feedbackInfo: {
+        header: 'Feedback',
+        button: 'Submit',
+        thank_you: 'Thank you for your feedback!',
+        contact_body: '<p>Please contact us at <a href="mailto:info@example.com">info@example.com</a> if you have any questions.</p>'
+    },
+    inline: false
+}
+
+export const Default = {
+    args: {
+        children: (
+            <UserFeedback {...userFeedbackProps} />
+        ),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#aaa', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/frontend/src/stories/UserFeedback.stories.js
+++ b/frontend/src/stories/UserFeedback.stories.js
@@ -17,7 +17,29 @@ export const Default = {
             button: 'Submit',
             thank_you: 'Thank you for your feedback!',
             contact_body: '<p>Please contact us at <a href="mailto:info@example.com">info@example.com</a> if you have any questions.</p>'
-        }
+        },
+        inline: true
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#fff', padding: '3rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Vertical = {
+    args: {
+        experimentSlug: 'test',
+        participant: 'test',
+        feedbackInfo: {
+            header: 'Feedback',
+            button: 'Submit',
+            thank_you: 'Thank you for your feedback!',
+            contact_body: '<p>Please contact us at <a href="mailto:info@example.com">info@example.com</a> if you have any questions.</p>'
+        },
+        inline: false
     },
     decorators: [
         (Story) => (

--- a/frontend/src/stories/UserFeedback.stories.js
+++ b/frontend/src/stories/UserFeedback.stories.js
@@ -1,0 +1,29 @@
+import UserFeedback from '../components/UserFeedback/UserFeedback';
+
+export default {
+    title: 'UserFeedback',
+    component: UserFeedback,
+    parameters: {
+        layout: 'fullscreen',
+    },
+};
+
+export const Default = {
+    args: {
+        experimentSlug: 'test',
+        participant: 'test',
+        feedbackInfo: {
+            header: 'Feedback',
+            button: 'Submit',
+            thank_you: 'Thank you for your feedback!',
+            contact_body: '<p>Please contact us at <a href="mailto:info@example.com">info@example.com</a> if you have any questions.</p>'
+        }
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#fff', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7395,7 +7395,7 @@ __metadata:
     react-scripts: "npm:5.0.0"
     react-select: "npm:^5.4.0"
     react-transition-group: "npm:^4.4.5"
-    sass: "npm:^1.50"
+    sass: "npm:^1.69.5"
     storybook: "npm:7.6.6"
     webpack: "npm:5.89.0"
   languageName: unknown
@@ -17160,16 +17160,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.50":
-  version: 1.66.1
-  resolution: "sass@npm:1.66.1"
+"sass@npm:^1.69.5":
+  version: 1.69.5
+  resolution: "sass@npm:1.69.5"
   dependencies:
     chokidar: "npm:>=3.0.0 <4.0.0"
     immutable: "npm:^4.0.0"
     source-map-js: "npm:>=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 2fd9510088c8754010479132b9708b2c7178fe158bba1cb84aba4f22d333919d5e9561b5aa33fee3e635ae2d33e3835d6aad132705200d66e5773ce50842c8a1
+  checksum: a9003a9482f2e467fc412cfe58ba4fa14fb78bef7e1283ce5d64a065f8a31114ec3bbf5d4e724f94eb8512c32c768a6f91f228c7f16a26a300bbf4db293b5608
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request adds the FloatingActionButton and UserFeedback components to the project. It also includes various style updates and unit tests.

At the experiment's `feedback_info` you can supply a parameter to turn it on or off for a given experiment by setting `show_float_button` to `True`.

For example:

```py
def feedback_info(self):
        info = super().feedback_info()
        info['show_float_button'] = True
        return info
```

It currently looks like this:

https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/1e199b58-207f-4740-b16b-77559a4b8435

## Flow
- User sees floating feedback button in the center right on it and clicks it
- Floating Action Button opens with an animation
- User enters feedback in text input
- User clicks submit
- If successful, a "Thank you..." message is shown
- User can close the Floating Action Button again by clicking the "X" close icon button, or by clicking somewhere else in the screen

## Questions for the reviewer(s)
* Should we enable or disable it by default for all experiments?
* Should it look _exactly_ like the existing feedback button on the UvA site in the issue?
* If not, is there anything else you would like to change to the appearance or the behavior of the components? 

Resolves #264