### PR TITLE
CI: Add Flake8 for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Lint Backend
-        continue-on-error: true
+        continue-on-error: false
         run: sudo docker-compose --env-file .env-github-actions run server bash -c "flake8"
 
   frontend-test:

--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,0 +1,54 @@
+[flake8]
+# Flake8 Configuration File
+
+# High Priority: Security and Correctness
+# These issues are critical and should be addressed first.
+extend-ignore =
+    E711, # Comparison to None should be 'if cond is None:'
+    E713, # Test for membership should be 'not in'
+    E722, # Do not use bare 'except'
+    F722, # Syntax error identified by pyflakes
+    F821, # Undefined name
+    E266, # Too many leading '#' for block comment
+
+# Medium Priority: Code Maintainability and Readability
+# Improving these can greatly enhance code readability and maintainability.
+    E101, # Indentation contains mixed spaces and tabs
+    E501, # Line too long
+    E303, # Too many blank lines
+    F401, # Unused import
+    F403, # 'from module import *' used; unable to detect undefined names
+    F405, # Name may be undefined, or defined from star imports
+    F811, # Redefinition of unused name from line N
+    F841, # Local variable name is assigned to but never used
+    E302, # Expected 2 blank lines, found 1
+    E305, # Expected 2 blank lines after class or function definition, found 1
+    E402, # Module level import not at top of file
+
+# Low Priority: Style Guide Adherence
+# These are mostly about whitespace and indentation, which can be adjusted later.
+    E201, # Whitespace after '('
+    E202, # Whitespace before ')'
+    E203, # Whitespace before ':'
+    E222, # Multiple spaces after operator
+    E225, # Missing whitespace around operator
+    E231, # Missing whitespace after ','
+    E251, # Unexpected spaces around keyword / parameter equals
+    E262, # Inline comment should start with '# '
+    E122, # Continuation line missing indentation or outdented
+    E124, # Closing bracket does not match visual indentation
+    E125, # Continuation line with same indent as next logical line
+    E127, # Continuation line over-indented for visual indent
+    E128, # Continuation line under-indented for visual indent
+    E131, # Continuation line unaligned for hanging indent
+    E261, # At least two spaces before inline comment
+    W191, # Indentation contains tabs
+    W291, # Trailing whitespace
+    W292, # No newline at end of file
+    W293, # Blank line contains whitespace
+    W391, # Blank line at end of file
+    W503, # Line break occurred before a binary operator
+
+# General Configuration
+max-line-length = 120
+exclude = .venv, .git, __pycache__, build, dist

--- a/backend/requirements.in/dev.txt
+++ b/backend/requirements.in/dev.txt
@@ -17,3 +17,6 @@ requests
 
 # Add pip-tools so we can use pip-compile in our develop environment
 pip-tools
+
+# Flake8 for linting
+flake8

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -40,6 +40,8 @@ django-debug-toolbar==3.2.2
     # via -r requirements.in/dev.txt
 django-inline-actions==2.4.0
     # via -r requirements.in/base.txt
+flake8==4.0.1
+    # via -r requirements.in/dev.txt
 genbadge[coverage]==1.1.1
     # via -r requirements.in/base.txt
 idna==3.3
@@ -53,7 +55,9 @@ isort==5.9.3
 lazy-object-proxy==1.6.0
     # via astroid
 mccabe==0.6.1
-    # via pylint
+    # via
+    #   flake8
+    #   pylint
 numpy==1.22.0
     # via pandas
 packaging==23.2
@@ -69,7 +73,11 @@ platformdirs==2.4.0
 psycopg2==2.9.1
     # via -r requirements.in/base.txt
 pycodestyle==2.8.0
-    # via autopep8
+    # via
+    #   autopep8
+    #   flake8
+pyflakes==2.4.0
+    # via flake8
 pylint==2.11.1
     # via
     #   -r requirements.in/dev.txt

--- a/scripts/lint-back
+++ b/scripts/lint-back
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose run --rm server bash -c "flake8"


### PR DESCRIPTION
This pull request adds Flake8 for linting the backend code. The `flake8` was already being run, but it turned out the `flake8` python wasn't even installed yet.

The flake8 linting job in the pipeline has now been configured to fail on linting errors. However, I've added a `.flake8` configuration to ignore all the issues we currently have. We can gradually un-ignore these issues (starting with the most important ones) and improve the quality of our codebase. My plan is to start with one of the issues that are rated as high priority in the `.flake8` file after this PR is merged.

The PR includes the following commits:

- chore(deps): Add Flake8 for linting

- config: Add .flake8 configuration file with flake8 rules

- ci: Update Lint Backend step to continue-on-error: false

- config: Add linting script for backend code (`scripts/lint-back`)