### PR TITLE
Fixed(CI): Remove unnecessary condition in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     name: Generate Frontend Coverage Badge
     needs: frontend-test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || 1 == 1 # TODO: Remove last condition
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v3
       - name: Generate Frontend Coverage Report (XML) and Badge


### PR DESCRIPTION
This pull request removes an unnecessary condition in the CI workflow that caused the frontend coverage job to run for every commit in a PR.