### PR TITLE
Fixed: Fix prepare_result function calls and add type hints

### DIFF
--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -20,13 +20,13 @@ class Trial(BaseAction):  # pylint: disable=too-few-public-methods
 
     def __init__(
             self,
-            playback=None,
-            html: str= None,
+            playback = None,
+            html: str = None,
             feedback_form: Form = None,
             title='',
-            config=None,
-            result_id=None,
-            style=None
+            config = None,
+            result_id = None,
+            style = None
             ):
         '''
         - playback: Playback object (may be None)

--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 
 from .base_action import BaseAction
+from experiment.actions.form import Form
 
 
 class Trial(BaseAction):  # pylint: disable=too-few-public-methods
@@ -17,7 +18,16 @@ class Trial(BaseAction):  # pylint: disable=too-few-public-methods
 
     ID = 'TRIAL_VIEW'
 
-    def __init__(self, playback=None, html=None, feedback_form=None, title='', config=None, result_id=None, style=None):
+    def __init__(
+            self,
+            playback=None,
+            html: str= None,
+            feedback_form: Form = None,
+            title='',
+            config=None,
+            result_id=None,
+            style=None
+            ):
         '''
         - playback: Playback object (may be None)
         - html: HTML object (may be None)

--- a/backend/experiment/rules/listening_conditions.py
+++ b/backend/experiment/rules/listening_conditions.py
@@ -18,7 +18,7 @@ class ListeningConditions(Base):
         feedback_form = None
         if round_number == 1:
             key = 'quiet_room'
-            result_pk = prepare_result(session, expected_response=key)
+            result_pk = prepare_result(key, session, expected_response=key)
             feedback_form = Form([
                 ChoiceQuestion(
                     key=key,
@@ -35,7 +35,7 @@ class ListeningConditions(Base):
                 )])
         elif round_number == 2:
             key = 'internet_connection'
-            result_pk = prepare_result(session, expected_response=key)
+            result_pk = prepare_result(key, session, expected_response=key)
             feedback_form = Form([ChoiceQuestion(
                 key='internet_connection',
                 question=_(
@@ -50,7 +50,7 @@ class ListeningConditions(Base):
             )])
         elif round_number == 3:
             key = 'headphones'
-            result_pk = prepare_result(session, expected_response=key)
+            result_pk = prepare_result(key, session, expected_response=key)
             feedback_form = Form([
                 ChoiceQuestion(
                     key=key,
@@ -67,7 +67,7 @@ class ListeningConditions(Base):
             ])
         elif round_number == 4:
             key = 'notifications_off'
-            result_pk = prepare_result(session, expected_response=key)
+            result_pk = prepare_result(key, session, expected_response=key)
             feedback_form = Form([
                 ChoiceQuestion(
                     key=key,

--- a/backend/experiment/rules/listening_conditions.py
+++ b/backend/experiment/rules/listening_conditions.py
@@ -96,7 +96,9 @@ class ListeningConditions(Base):
                     session, message, request_session)
             ]
             return actions
-        view = Trial(playback, feedback_form)
+
+        view = Trial(playback, feedback_form=feedback_form)
+
         return [view]
 
     def first_round(self, experiment):

--- a/backend/experiment/rules/tests/test_listening_conditions.py
+++ b/backend/experiment/rules/tests/test_listening_conditions.py
@@ -1,0 +1,77 @@
+from django.test import TestCase
+from section.models import Section, Song, Playlist as PlaylistModel
+from participant.models import Participant
+from session.models import Session
+from experiment.models import Experiment
+from experiment.rules.listening_conditions import ListeningConditions
+from experiment.actions import Consent, Explainer, Final, Playback, Playlist, StartSession, Trial, Form
+from experiment.actions.form import Form
+from experiment.actions.playback import Playback
+
+class ListeningConditionsTest(TestCase):
+
+    def setUp(self):
+        playlist = PlaylistModel.objects.create(
+            name='test'
+        )
+        song = Song.objects.create(
+            artist="Cheese Shop",
+            name="Gouda"
+        )
+        Section.objects.create(
+            playlist=playlist,
+            song=song,
+            filename="not/to_be_found.mp3",
+            tag=0
+        )
+        self.experiment = Experiment.objects.create(
+            name='test',
+            slug='TEST',
+        )
+        participant = Participant.objects.create()
+        self.session = Session.objects.create(
+            experiment=Experiment.objects.first(),
+            participant=participant,
+            playlist=playlist
+        )
+
+    def test_first_round(self):
+        listening_conditions = ListeningConditions()
+        actions = listening_conditions.first_round(self.experiment)
+
+        self.assertIsInstance(actions[0], Consent)
+        self.assertIsInstance(actions[1], Explainer)
+        self.assertIsInstance(actions[2], Playlist)
+        self.assertIsInstance(actions[3], StartSession)
+
+    def test_next_round_first_round(self):
+        listening_conditions = ListeningConditions()
+        listening_conditions.first_round(self.experiment)
+        actions = listening_conditions.next_round(self.session)
+
+        self.assertIsInstance(actions[0], Trial)
+
+        self.assertIsInstance(actions[0].feedback_form, Form)
+        self.assertEqual(len(actions[0].feedback_form.form), 1)
+        self.assertEqual(actions[0].feedback_form.form[0].key, 'quiet_room')
+
+
+    def test_next_round_final_round(self):
+        listening_conditions = ListeningConditions()
+        listening_conditions.first_round(self.experiment)
+        listening_conditions.next_round(self.session)
+        listening_conditions.next_round(self.session)
+        listening_conditions.next_round(self.session)
+        listening_conditions.next_round(self.session)
+        actions = listening_conditions.next_round(self.session)
+
+        self.assertIsInstance(actions[0], Trial)
+        self.assertIsInstance(actions[0].playback, Playback)
+        self.assertIsNone(actions[0].feedback_form)  # Assuming no feedback form for the final round
+        self.assertIsInstance(actions[1], Final)
+
+
+    def test_next_round_does_not_throw_error(self):
+        listening_conditions = ListeningConditions()
+        listening_conditions.next_round(self.session)
+

--- a/backend/experiment/rules/tests/test_listening_conditions.py
+++ b/backend/experiment/rules/tests/test_listening_conditions.py
@@ -8,6 +8,7 @@ from experiment.actions import Consent, Explainer, Final, Playback, Playlist, St
 from experiment.actions.form import Form
 from experiment.actions.playback import Playback
 
+
 class ListeningConditionsTest(TestCase):
 
     def setUp(self):
@@ -55,7 +56,6 @@ class ListeningConditionsTest(TestCase):
         self.assertEqual(len(actions[0].feedback_form.form), 1)
         self.assertEqual(actions[0].feedback_form.form[0].key, 'quiet_room')
 
-
     def test_next_round_final_round(self):
         listening_conditions = ListeningConditions()
         listening_conditions.first_round(self.experiment)
@@ -69,7 +69,6 @@ class ListeningConditionsTest(TestCase):
         self.assertIsInstance(actions[0].playback, Playback)
         self.assertIsNone(actions[0].feedback_form)  # Assuming no feedback form for the final round
         self.assertIsInstance(actions[1], Final)
-
 
     def test_next_round_does_not_throw_error(self):
         listening_conditions = ListeningConditions()

--- a/backend/result/utils.py
+++ b/backend/result/utils.py
@@ -1,3 +1,4 @@
+from session.models import Session
 from .models import Result
 
 from experiment.questions.profile_scoring_rules import PROFILE_SCORING_RULES
@@ -18,7 +19,7 @@ def get_result(session, data):
 
 
 def handle_results(data, session):
-    """ 
+    """
     if the given_result is an array of results, retrieve and save results for all of them
     else, handle results at top level
     """
@@ -42,7 +43,7 @@ def prepare_profile_result(question_key, participant, **kwargs):
     - question_key: the key of the question in the questionnaire dictionaries
     - participant: the participant on which the Result is going to be registered
     possible kwargs:
-        - expected_response: optionally, provide the correct answer, used for scoring  
+        - expected_response: optionally, provide the correct answer, used for scoring
         - comment: optionally, provide a comment to be saved in the database
         - scoring_rule: optionally, provide a scoring rule
     '''
@@ -56,13 +57,13 @@ def prepare_profile_result(question_key, participant, **kwargs):
     return result
 
 
-def prepare_result(question_key, session, **kwargs):
+def prepare_result(question_key: str, session: Session, **kwargs) -> int:
     ''' Create a Result object, and provide its id to be serialized
     - question_key: the key of the question in the questionnaire dictionaries
     - session: the session on which the Result is going to be registered
     possible kwargs:
         - section: optionally, provide a section to which the Result is going to be tied
-        - expected_response: optionally, provide the correct answer, used for scoring  
+        - expected_response: optionally, provide the correct answer, used for scoring
         - comment: optionally, provide a comment to be saved in the database, e.g. "training phase"
         - scoring_rule: optionally, provide a scoring rule
     '''
@@ -76,7 +77,7 @@ def prepare_result(question_key, session, **kwargs):
 
 def score_result(data, session):
     """
-    Create a result for given session, based on the result data 
+    Create a result for given session, based on the result data
     (form element or top level data)
     parameters:
     session: a Session object
@@ -90,7 +91,7 @@ def score_result(data, session):
     result.save_json_data(data)
     result.given_response = data.get('value')
     # Calculate score: by default, apply a scoring rule
-    # Can be overridden by defining calculate_score in the rules file    
+    # Can be overridden by defining calculate_score in the rules file
     if result.session:
         score = session.experiment_rules().calculate_score(result, data)
         # refresh session data in case anything was changed within calculate_score function


### PR DESCRIPTION
This pull request fixes the prepare_result function calls in listening_conditions.py by adding the missing key parameter. It also fixes the instantiation of the `Trial` class in the `next_round` method in the `listening_conditions` experiment. Furthermore, it adds type hints to the prepare_result function and the Trial class constructor. Additionally, it includes test cases for the ListeningConditions class.

Resolved #698