### PR TITLE
Hotfix(mpref): Fix preferred songs without section bug

### DIFF
--- a/backend/experiment/rules/musical_preferences.py
+++ b/backend/experiment/rules/musical_preferences.py
@@ -147,7 +147,7 @@ class MusicalPreferences(Base):
                              title=_("Audio check"))
         n_songs = next_round_number - self.round_increment
         if n_songs == self.preference_offset + 1:
-            like_results = session.result_set.filter(question_key='like_song', section_id__isnull=False)
+            like_results = session.result_set.filter(question_key='like_song')
             feedback = Trial(
                 html=HTML(body=render_to_string('html/musical_preferences/feedback.html', {
                     'unlocked': _("Love unlocked"),
@@ -157,7 +157,7 @@ class MusicalPreferences(Base):
             )
             actions = [feedback]
         elif n_songs == self.knowledge_offset + 1:
-            like_results = session.result_set.filter(question_key='like_song', section_id__isnull=False)
+            like_results = session.result_set.filter(question_key='like_song')
             known_songs = session.result_set.filter(
                 question_key='know_song', score=2).count()
             feedback = Trial(
@@ -170,7 +170,7 @@ class MusicalPreferences(Base):
             )
             actions = [feedback]
         elif n_songs == session.experiment.rounds + 1:
-            like_results = session.result_set.filter(question_key='like_song', section_id__isnull=False)
+            like_results = session.result_set.filter(question_key='like_song')
             known_songs = session.result_set.filter(
                 question_key='know_song', score=2).count()
             all_results = Result.objects.filter(

--- a/backend/experiment/rules/musical_preferences.py
+++ b/backend/experiment/rules/musical_preferences.py
@@ -147,7 +147,7 @@ class MusicalPreferences(Base):
                              title=_("Audio check"))
         n_songs = next_round_number - self.round_increment
         if n_songs == self.preference_offset + 1:
-            like_results = session.result_set.filter(question_key='like_song')
+            like_results = session.result_set.filter(question_key='like_song', section_id__isnull=False)
             feedback = Trial(
                 html=HTML(body=render_to_string('html/musical_preferences/feedback.html', {
                     'unlocked': _("Love unlocked"),
@@ -157,7 +157,7 @@ class MusicalPreferences(Base):
             )
             actions = [feedback]
         elif n_songs == self.knowledge_offset + 1:
-            like_results = session.result_set.filter(question_key='like_song')
+            like_results = session.result_set.filter(question_key='like_song', section_id__isnull=False)
             known_songs = session.result_set.filter(
                 question_key='know_song', score=2).count()
             feedback = Trial(
@@ -170,11 +170,12 @@ class MusicalPreferences(Base):
             )
             actions = [feedback]
         elif n_songs == session.experiment.rounds + 1:
-            like_results = session.result_set.filter(question_key='like_song')
+            like_results = session.result_set.filter(question_key='like_song', section_id__isnull=False)
             known_songs = session.result_set.filter(
                 question_key='know_song', score=2).count()
             all_results = Result.objects.filter(
-                question_key='like_song'
+                question_key='like_song',
+                section_id__isnull=False
             )
             top_participant = self.get_preferred_songs(like_results, 3)
             top_all = self.get_preferred_songs(all_results, 3)

--- a/backend/experiment/rules/tests/test_musical_preferences.py
+++ b/backend/experiment/rules/tests/test_musical_preferences.py
@@ -45,3 +45,30 @@ class MusicalPreferencesTest(TestCase):
         assert preferred_sections[1]['name'] == 'MehSong'
         assert preferred_sections[2]['artist'] == 'MehArtist'
         assert 'AwfulArtist' not in [p['artist'] for p in preferred_sections]
+
+    def test_preferred_songs_results_without_section(self):
+        # Create 3 results with a section
+        for index, section in enumerate(list(self.playlist.section_set.all())):
+            if index < 3:
+                Result.objects.create(
+                    question_key='like_song',
+                    score=5-index,
+                    section=section,
+                    session=self.session
+                )
+        # Create 10 results without a section
+        for i in range(10):
+            Result.objects.create(
+                question_key='like_song',
+                score=5-i,
+                section=None,
+                session=self.session
+            )
+        mp = MusicalPreferences()
+
+        # Go to the last round (top_all = ... caused the error)
+        for i in range(self.session.experiment.rounds + 1):
+            self.session.increment_round()
+        
+        # get_preferred_songs() called by top_all = ... in the final round should not raise an error
+        mp.next_round(self.session)

--- a/backend/experiment/rules/tests/test_musical_preferences.py
+++ b/backend/experiment/rules/tests/test_musical_preferences.py
@@ -56,13 +56,19 @@ class MusicalPreferencesTest(TestCase):
                     section=section,
                     session=self.session
                 )
-        # Create 10 results without a section
+
+        other_session = Session.objects.create(
+            experiment=self.experiment,
+            participant=self.participant,
+            playlist=self.playlist
+        )
+
         for i in range(10):
             Result.objects.create(
                 question_key='like_song',
                 score=5-i,
                 section=None,
-                session=self.session
+                session=other_session
             )
         mp = MusicalPreferences()
 


### PR DESCRIPTION
This pull request fixes a bug in the `MusicalPreferences` class where an error was raised when retrieving preferred songs without a section. The bug was caused by a filter condition that included results without a section. This PR updates the filter condition to exclude results without a section, ensuring that the error is no longer raised.

Resolves #685