### PR TITLE
Fix(mpref): Fix preferred songs without section bug (#708)

### DIFF
--- a/backend/experiment/rules/musical_preferences.py
+++ b/backend/experiment/rules/musical_preferences.py
@@ -173,7 +173,8 @@ class MusicalPreferences(Base):
             known_songs = session.result_set.filter(
                 question_key='know_song', score=2).count()
             all_results = Result.objects.filter(
-                question_key='like_song'
+                question_key='like_song',
+                section_id__isnull=False
             )
             top_participant = self.get_preferred_songs(like_results, 3)
             top_all = self.get_preferred_songs(all_results, 3)

--- a/backend/experiment/rules/tests/test_musical_preferences.py
+++ b/backend/experiment/rules/tests/test_musical_preferences.py
@@ -46,3 +46,36 @@ class MusicalPreferencesTest(TestCase):
         assert preferred_sections[1]['name'] == 'MehSong'
         assert preferred_sections[2]['artist'] == 'MehArtist'
         assert 'AwfulArtist' not in [p['artist'] for p in preferred_sections]
+
+    def test_preferred_songs_results_without_section(self):
+        # Create 3 results with a section
+        for index, section in enumerate(list(self.playlist.section_set.all())):
+            if index < 3:
+                Result.objects.create(
+                    question_key='like_song',
+                    score=5-index,
+                    section=section,
+                    session=self.session
+                )
+
+        other_session = Session.objects.create(
+            experiment=self.experiment,
+            participant=self.participant,
+            playlist=self.playlist
+        )
+
+        for i in range(10):
+            Result.objects.create(
+                question_key='like_song',
+                score=5-i,
+                section=None,
+                session=other_session
+            )
+        mp = MusicalPreferences()
+
+        # Go to the last round (top_all = ... caused the error)
+        for i in range(self.session.experiment.rounds + 1):
+            self.session.increment_round()
+        
+        # get_preferred_songs() called by top_all = ... in the final round should not raise an error
+        mp.next_round(self.session)


### PR DESCRIPTION
This PR is solely to keep `develop` up to date with the hotfix that had been merged to `main` earlier today.

* fix(muspref): Only fetch results with existing sections

* test(mpref): Add test case for preferred songs without section

* refactor: Remove unnecessary filters from the session's result set queries

* test: Don't create the sectionless results connected to the current session

(cherry picked from commit d502f9bd0994d9b2c4a756a2edaa298cf5a93a68)