### PR TITLE
fix react warning about passing {checked} prop

### DIFF
--- a/frontend/src/components/Question/_ButtonArray.js
+++ b/frontend/src/components/Question/_ButtonArray.js
@@ -52,7 +52,7 @@ const ToggleButton = ({ label, value, index, name, disabled, onChange, checked }
                 checked={checked}
                 aria-checked={checked}
                 disabled={disabled}
-                onClick={() => {
+                onChange={() => {
                     onChange(value);
                 }}
                 onKeyPress={() => {

--- a/frontend/src/components/Question/_ButtonArray.js
+++ b/frontend/src/components/Question/_ButtonArray.js
@@ -52,9 +52,7 @@ const ToggleButton = ({ label, value, index, name, disabled, onChange, checked }
                 checked={checked}
                 aria-checked={checked}
                 disabled={disabled}
-                onChange={() => {
-                    onChange(value);
-                }}
+                onChange={() => onChange(value)}}
                 onKeyPress={() => {
                     onChange(value);
                 }}


### PR DESCRIPTION
React warns about passing the {checked} prop in the ButtonArray without a onChange method. This is rectified in this PR.