### PR TITLE
Fixed: Fix broken TuneTwins card front on develop

### DIFF
--- a/frontend/src/components/PlayButton/PlayCard.js
+++ b/frontend/src/components/PlayButton/PlayCard.js
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 
 import Histogram from "../Histogram/Histogram";
-import { MATCHINGPAIRS } from "components/Playback/Playback";
+import { VISUALMATCHINGPAIRS } from "components/Playback/Playback";
 import { API_ROOT } from "config";
 
 const PlayCard = ({ onClick, registerUserClicks, playing, section, view }) => {
@@ -33,7 +33,11 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view }) => {
             role="button"
         >
             {section.turned ?
-                view === MATCHINGPAIRS ?
+                view === VISUALMATCHINGPAIRS ?
+                <div className="front front--visual">
+                        <img src={getImgSrc(section.url)} alt={section.name} />
+                    </div>
+                    :
                     <Histogram
                         className="front"
                         running={playing}
@@ -42,9 +46,6 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view }) => {
                         backgroundColor="purple"
                         borderRadius=".5rem"
                     />
-                    : <div className="front front--visual">
-                        <img src={getImgSrc(section.url)} alt={section.name} />
-                    </div>
                 :
                 <div className={classNames("back", { seen: section.seen })}>
                 </div>

--- a/frontend/src/components/PlayButton/PlayCard.js
+++ b/frontend/src/components/PlayButton/PlayCard.js
@@ -34,12 +34,14 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view }) => {
         >
             {section.turned ?
                 view === VISUALMATCHINGPAIRS ?
-                <div className="front front--visual">
+                    <div
+                        data-testid="front"
+                        className="front front--visual"
+                    >
                         <img src={getImgSrc(section.url)} alt={section.name} />
                     </div>
                     :
                     <Histogram
-                        className="front"
                         running={playing}
                         bars={5}
                         marginBottom={0}
@@ -47,7 +49,10 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view }) => {
                         borderRadius=".5rem"
                     />
                 :
-                <div className={classNames("back", { seen: section.seen })}>
+                <div
+                    data-testid="back"
+                    className={classNames("back", { seen: section.seen })}
+                >
                 </div>
             }
         </div>

--- a/frontend/src/components/PlayButton/PlayCard.test.js
+++ b/frontend/src/components/PlayButton/PlayCard.test.js
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import PlayCard from "./PlayCard"; // Adjust the path as necessary
+
+describe("PlayCard Component Tests", () => {
+    const mockOnClick = jest.fn();
+    const mockRegisterUserClicks = jest.fn();
+
+    const sectionProps = {
+        turned: false,
+        noevents: false,
+        inactive: false,
+        memory: false,
+        lucky: false,
+        nomatch: false,
+        seen: false,
+        url: "test.jpg",
+        name: "Test"
+    };
+
+    it("should render without crashing", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={sectionProps} />);
+    });
+
+    it("should call onClick and registerUserClicks when clicked", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={sectionProps} />);
+        fireEvent.click(screen.getByTestId("play-card"));
+        expect(mockOnClick).toHaveBeenCalled();
+        expect(mockRegisterUserClicks).toHaveBeenCalled();
+    });
+
+    it("should display the back of the card by default", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={sectionProps} />);
+        expect(screen.getByTestId("play-card").querySelector(".back")).toBeInTheDocument();
+    });
+
+    it("should display the front of the card when turned", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, turned: true }} />);
+        expect(screen.getByTestId("play-card").querySelector(".aha__histogram")).toBeInTheDocument();
+        expect(screen.getByTestId("play-card").querySelector(".front")).not.toBeInTheDocument();
+    });
+
+    it("should display image for visual matching pairs view", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, turned: true }} view="VISUALMATCHINGPAIRS" />);
+        expect(screen.getByAltText("Test")).toBeInTheDocument();
+    });
+
+    it("should display histogram for non-visual matching pairs view", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, turned: true }} view="MATCHINGPAIRS" />);
+        expect(screen.getByTestId("play-card").querySelector(".aha__histogram")).toHaveClass("aha__histogram");
+    });
+
+    it("should display a disabled card when inactive", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, inactive: true }} />);
+        expect(screen.getByTestId("play-card")).toHaveClass("disabled");
+    });
+
+    it("should display a card with no events when noevents", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, noevents: true }} />);
+        expect(screen.getByTestId("play-card")).toHaveClass("noevents");
+    });
+
+    it("should display a card with memory when memory", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, memory: true }} />);
+        expect(screen.getByTestId("play-card")).toHaveClass("memory");
+    });
+
+    it("should display a card with lucky when lucky", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, lucky: true }} />);
+        expect(screen.getByTestId("play-card")).toHaveClass("lucky");
+    });
+
+    it("should display a card with nomatch when nomatch", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, nomatch: true }} />);
+        expect(screen.getByTestId("play-card")).toHaveClass("nomatch");
+    });
+
+    it("should display a card with seen when seen", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} section={{ ...sectionProps, seen: true }} />);
+        expect(screen.getByTestId("play-card").querySelector(".back")).toHaveClass("seen");
+    });
+
+    it("should display a card with a histogram when turned and playing", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} playing section={{ ...sectionProps, turned: true }} />);
+        expect(screen.getByTestId("play-card").querySelector(".aha__histogram")).toBeInTheDocument();
+    });
+
+    it("should display a card with a histogram when turned and not playing", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} playing={false} section={{ ...sectionProps, turned: true }} />);
+        expect(screen.getByTestId("play-card").querySelector(".aha__histogram")).toBeInTheDocument();
+    });
+
+    it("should display a card without a histogram when not turned and playing", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} playing section={sectionProps} />);
+        expect(screen.getByTestId("play-card").querySelector(".aha__histogram")).not.toBeInTheDocument();
+    });
+
+    it("should display a card without a histogram when not turned and not playing", () => {
+        render(<PlayCard onClick={mockOnClick} registerUserClicks={mockRegisterUserClicks} playing={false} section={sectionProps} />);
+        expect(screen.getByTestId("play-card").querySelector(".aha__histogram")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/Playback/Playback.js
+++ b/frontend/src/components/Playback/Playback.js
@@ -150,18 +150,19 @@ const Playback = ({
 
     const render = (view) => {
         const attrs = {
-            sections,
-            showAnimation: playbackArgs.show_animation,
-            setView,
             autoAdvance,
-            responseTime,
-            startedPlaying,
-            playerIndex,
             finishedPlaying: onFinishedPlaying,
-            playSection,
             lastPlayerIndex,
+            playSection,
+            playerIndex,
+            responseTime,
+            sections,
             setPlayerIndex,
-            submitResult
+            setView,
+            showAnimation: playbackArgs.show_animation,
+            startedPlaying,
+            submitResult,
+            view,
         };
 
         switch (state.view) {

--- a/frontend/src/stories/PlayCard.stories.js
+++ b/frontend/src/stories/PlayCard.stories.js
@@ -1,0 +1,210 @@
+
+import PlayCard from '../components/PlayButton/PlayCard';
+import catImage from './assets/images/cat-01.webp';
+
+console.log(catImage);
+
+export default {
+  title: 'PlayCard',
+  component: PlayCard,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export const Default = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1"
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Turned = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "turned": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Seen = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "seen": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Memory = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "memory": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Lucky = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "lucky": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const NoEvents = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "noevents": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Inactive = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "inactive": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Playing = {
+    args: {
+        onClick: () => void 0,
+        registerUserClicks: () => void 0,
+        playing: true,
+        section: {
+            "id": 32,
+            "url": "/section/32/78165/",
+            "group": "\t1",
+            "turned": true
+        },
+        view: "MATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ display: 'flex', width: '100%', minHeight: '128px', height: '100%', backgroundColor: '#ddd', padding: '1rem'}}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const VisualMatchingPairs = {
+    args: {
+        onClick: () => alert("Clicked!"),
+        registerUserClicks: () => alert('Registered'),
+        playing: false,
+        section: {
+            "id": 32,
+            "url": `http://localhost:6006/${catImage}`,
+            "group": "\t1",
+            "turned": true
+        },
+        view: "VISUALMATCHINGPAIRS"
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: '100%', height: '100%', backgroundColor: '#ddd', padding: '1rem' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};


### PR DESCRIPTION
This pull request fixes the issue with the TuneTwins card front on the develop branch. The MatchingPairs component was not displaying the cards correctly, and a click on a card was not bringing up the histogram animation. The issue was not resolved by recompiling the code. This pull request includes the following changes:

- Render PlayCard correctly and show image only for Visual Matching Pairs view

- Refactor PlayCard component to improve code readability and add data-testid attributes

- Add tests for PlayCard component

- Add PlayCard stories

Resolves #715