### PR TITLE
fix: use section_from_unused_song rather than random selection

### DIFF
--- a/backend/experiment/rules/musical_preferences.py
+++ b/backend/experiment/rules/musical_preferences.py
@@ -195,7 +195,7 @@ class MusicalPreferences(Base):
                 top_all
             )]
 
-        section = session.playlist.get_section()
+        section = session.section_from_unused_song()
         like_key = 'like_song'
         likert = LikertQuestionIcon(
             question=_('2. How much do you like this song?'),


### PR DESCRIPTION
This should close #684 - the section selection was random, rather than restricted to sections which hadn't yet been played.