### PR TITLE
fix: refer to session.id from finalizeSession

### DIFF
--- a/frontend/src/API.js
+++ b/frontend/src/API.js
@@ -131,7 +131,7 @@ export const getNextRound = async ({ session }) => {
 export const finalizeSession = async ({ session, participant }) => {
     try {
         const response = await axios.post(
-            API_BASE_URL + URLS.session.finalize(session.current.id),
+            API_BASE_URL + URLS.session.finalize(session.id),
             qs.stringify({
                 csrfmiddlewaretoken: participant.csrf_token,
             })


### PR DESCRIPTION
It turns out that there was still a call to `session.current` in the `API.finalizeSession` function. Not caught by a test, unfortunately. What would be a good way to catch these kind of problems? The `Final` component calls this function, but mocks it. Obviously, TypeScript would warn if the function is called with the wrong types of arguments, so perhaps we can indeed introduce it gradually.