### PR TITLE
Added: Add a Django management command to create new experiments

### DIFF
--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -29,6 +29,8 @@ class Command(BaseCommand):
             if overwrite.lower() != 'y':
                 self.stdout.write(self.style.WARNING(f"File {filename} was not created"))
                 return
+            else:
+                self.stdout.write(self.style.WARNING(f"File {filename} will be overwritten"))
 
         # Create the file by copying ./experiment/management/commands/templates/experiment.py
         with open(filename, 'w') as f:

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -9,6 +9,16 @@ class Command(BaseCommand):
         # Ask for the experiment name
         experiment_name = input("What is the name of your experiment? (ex. Musical Preferences): ")
 
+        # Create the experiment rule class
+        self.create_experiment_rule_class(experiment_name)
+
+        # Add the new experiment to ./experiment/rules/__init__.py
+        self.register_experiment_rule(experiment_name, './experiment/rules/__init__.py')
+
+        # Create a basic test file for the experiment
+        self.create_test_file(experiment_name)
+
+    def create_experiment_rule_class(self, experiment_name):
         # Get the experiment name in different cases
         experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
 
@@ -40,9 +50,6 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
 
-        # Add the new experiment to ./experiment/rules/__init__.py
-        self.register_experiment_rule(experiment_name, './experiment/rules/__init__.py')
-
     def register_experiment_rule(self, experiment_name, file_path):
 
         # Get the experiment name in different cases
@@ -68,6 +75,40 @@ class Command(BaseCommand):
         # Write the modified lines back to the file
         with open(file_path, 'w') as file:
             file.writelines(lines)
+
+        self.stdout.write(self.style.SUCCESS(f"Registered {experiment_name} in {file_path}"))
+
+    def create_test_file(self, experiment_name):
+        # Get the experiment name in different cases
+        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+
+        # Create a new file for the experiment class
+        filename = f"./experiment/rules/tests/test_{experiment_name_snake_case}.py"
+
+        # Check if the file already exists
+        if os.path.isfile(filename):
+            # Warn the user that the file already exists and ask if they want to overwrite it
+            self.stdout.write(self.style.WARNING(f"File {filename} already exists"))
+            overwrite = input(f"Do you want to overwrite it? (y/n): ")
+
+            # If the user does not want to overwrite the file, exit the command
+            if overwrite.lower() != 'y':
+                self.stdout.write(self.style.WARNING(f"File {filename} was not created"))
+                return
+            else:
+                self.stdout.write(self.style.WARNING(f"File {filename} will be overwritten"))
+
+        # Create the file by copying ./experiment/management/commands/templates/experiment.py
+        with open(filename, 'w') as f:
+            with open('./experiment/management/commands/templates/test_experiment.py', 'r') as template:
+                f.write(template.read()
+                    .replace('NewExperiment', experiment_name_pascal_case)
+                    .replace('new_experiment', experiment_name_snake_case)
+                    .replace('NEW_EXPERIMENT', experiment_name_snake_case_upper)
+                    .replace('New Experiment', experiment_name.title())
+                )
+
+        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
 
     def get_experiment_name_cases(self, experiment_name):
         # Convert experiment name to snake_case and lowercase every word and replace spaces with underscores

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -28,16 +28,8 @@ class Command(BaseCommand):
 
         # Check if the file already exists
         if os.path.isfile(filename):
-            # Warn the user that the file already exists and ask if they want to overwrite it
-            self.stdout.write(self.style.WARNING(f"File {filename} already exists"))
-            overwrite = input("Do you want to overwrite it? (y/n): ")
-
-            # If the user does not want to overwrite the file, exit the command
-            if overwrite.lower() != 'y':
-                self.stdout.write(self.style.WARNING(f"File {filename} was not created"))
-                return
-            else:
-                self.stdout.write(self.style.WARNING(f"File {filename} will be overwritten"))
+            self.stdout.write(self.style.ERROR(f"File {filename} already exists. Exiting without creating file."))
+            return
 
         # Create the file by copying ./experiment/management/commands/templates/experiment.py
         with open(filename, 'w') as f:
@@ -88,16 +80,8 @@ class Command(BaseCommand):
 
         # Check if the file already exists
         if os.path.isfile(filename):
-            # Warn the user that the file already exists and ask if they want to overwrite it
-            self.stdout.write(self.style.WARNING(f"File {filename} already exists"))
-            overwrite = input("Do you want to overwrite it? (y/n): ")
-
-            # If the user does not want to overwrite the file, exit the command
-            if overwrite.lower() != 'y':
-                self.stdout.write(self.style.WARNING(f"File {filename} was not created"))
-                return
-            else:
-                self.stdout.write(self.style.WARNING(f"File {filename} will be overwritten"))
+            self.stdout.write(self.style.ERROR(f"File {filename} already exists. Exiting without creating file."))
+            return
 
         # Create the file by copying ./experiment/management/commands/templates/experiment.py
         with open(filename, 'w') as f:

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -11,7 +11,10 @@ class Command(BaseCommand):
         experiment_name = input("What is the name of your experiment? (ex. Musical Preferences): ")
 
         # Create the experiment rule class
-        self.create_experiment_rule_class(experiment_name)
+        success = self.create_experiment_rule_class(experiment_name)
+
+        if not success:
+            return
 
         # Add the new experiment to ./experiment/rules/__init__.py
         self.register_experiment_rule(experiment_name, './experiment/rules/__init__.py')
@@ -28,7 +31,7 @@ class Command(BaseCommand):
 
         # Check if the file already exists
         if os.path.isfile(filename):
-            self.stdout.write(self.style.ERROR(f"File {filename} already exists. Exiting without creating file."))
+            self.stdout.write(self.style.ERROR(f"Experiment {experiment_name} already exists. Exiting without creating file(s)."))
             return
 
         # Create the file by copying ./experiment/management/commands/templates/experiment.py
@@ -42,6 +45,8 @@ class Command(BaseCommand):
                 )
 
         self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
+
+        return True
 
     def register_experiment_rule(self, experiment_name, file_path):
 

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -2,6 +2,7 @@ import os.path
 
 from django.core.management.base import BaseCommand
 
+
 class Command(BaseCommand):
     help = 'Creates a new experiment rules class'
 
@@ -29,7 +30,7 @@ class Command(BaseCommand):
         if os.path.isfile(filename):
             # Warn the user that the file already exists and ask if they want to overwrite it
             self.stdout.write(self.style.WARNING(f"File {filename} already exists"))
-            overwrite = input(f"Do you want to overwrite it? (y/n): ")
+            overwrite = input("Do you want to overwrite it? (y/n): ")
 
             # If the user does not want to overwrite the file, exit the command
             if overwrite.lower() != 'y':
@@ -89,7 +90,7 @@ class Command(BaseCommand):
         if os.path.isfile(filename):
             # Warn the user that the file already exists and ask if they want to overwrite it
             self.stdout.write(self.style.WARNING(f"File {filename} already exists"))
-            overwrite = input(f"Do you want to overwrite it? (y/n): ")
+            overwrite = input("Do you want to overwrite it? (y/n): ")
 
             # If the user does not want to overwrite the file, exit the command
             if overwrite.lower() != 'y':

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -1,0 +1,50 @@
+import os.path
+
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    help = 'Creates a new experiment rules class'
+
+    def handle(self, *args, **options):
+        # Ask for the experiment name
+        experiment_name = input("What is the name of your experiment? (ex. Musical Preferences): ")
+
+        # Convert experiment name to snake_case and lowercase every word and replace spaces with underscores
+        experiment_name_snake_case = experiment_name.lower().replace(' ', '_')
+        experiment_name_snake_case_upper = experiment_name_snake_case.upper()
+
+        # Convert experiment name to PascalCase and capitalize every word and remove spaces
+        experiment_name_pascal_case = experiment_name.title().replace(' ', '')
+
+        # Create a new file for the experiment class
+        filename = f"./experiment/rules/{experiment_name_snake_case}.py"
+
+        # Check if the file already exists
+        if os.path.isfile(filename):
+            # Warn the user that the file already exists and ask if they want to overwrite it
+            self.stdout.write(self.style.WARNING(f"File {filename} already exists"))
+            overwrite = input(f"Do you want to overwrite it? (y/n): ")
+
+            # If the user does not want to overwrite the file, exit the command
+            if overwrite.lower() != 'y':
+                self.stdout.write(self.style.WARNING(f"File {filename} was not created"))
+                return
+
+        # Create the file by copying ./experiment/management/commands/templates/experiment.py
+        with open(filename, 'w') as f:
+            with open('./experiment/management/commands/templates/experiment.py', 'r') as template:
+                f.write(template.read()
+                    .replace('NewExperiment', experiment_name_pascal_case)
+                    .replace('new_experiment', experiment_name_snake_case)
+                    .replace('NEW_EXPERIMENT', experiment_name_snake_case_upper)
+                    .replace('New Experiment', experiment_name.title())
+                )
+
+        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
+
+        # Example of modifying an existing file by adding a line of text
+        # existing_file = 'existing_file.py'  # Specify the correct path to the file you want to modify
+        # with open(existing_file, 'a') as f:
+        #     f.write(f"# Added experiment: {experiment_name}\n")
+
+        # self.stdout.write(self.style.SUCCESS(f"Updated {existing_file}"))

--- a/backend/experiment/management/commands/templates/experiment.py
+++ b/backend/experiment/management/commands/templates/experiment.py
@@ -8,6 +8,7 @@ from .section.models import Playlist
 from .experiment.questions.demographics import EXTRA_DEMOGRAPHICS
 from .experiment.questions.utils import question_by_key
 
+
 class NewExperiment(Base):
     ID = 'NEW_EXPERIMENT'
     contact_email = 'info@example.com'

--- a/backend/experiment/management/commands/templates/experiment.py
+++ b/backend/experiment/management/commands/templates/experiment.py
@@ -1,0 +1,68 @@
+from typing import Final
+from django.utils.translation import gettext_lazy as _
+from django.template.loader import render_to_string
+
+from .experiment.rules import Base
+from .experiment.actions import Consent, Explainer, Final, Playlist, Step
+from .section.models import Playlist
+from .experiment.questions.demographics import EXTRA_DEMOGRAPHICS
+from .experiment.questions.utils import question_by_key
+
+class NewExperiment(Base):
+    ID = 'NEW_EXPERIMENT'
+    contact_email = 'info@example.com'
+
+    def __init__(self):
+        super().__init__(self.ID)
+        
+        # Add your questions here
+        self.questions = [
+            question_by_key('dgf_gender_identity'),
+            question_by_key('dgf_generation'),
+            question_by_key('dgf_musical_experience', EXTRA_DEMOGRAPHICS),
+            question_by_key('dgf_country_of_origin'),
+            question_by_key('dgf_education', drop_choices=['isced-2', 'isced-5'])
+        ]
+
+    def first_round(self, experiment):
+        
+        # 1. Informed consent
+        rendered = render_to_string('consent/consent_new_experiment.html')
+        consent = Consent(rendered, title=_(
+            'Informed consent'), confirm=_('I agree'), deny=_('Stop'))
+        
+        # 2. Choose playlist.
+        playlist = Playlist(experiment.playlists.all())
+
+        # 3. Explainer
+        explainer = Explainer(
+            instruction='',
+            steps=[
+                Step(description=_('New Experiment is ...')),
+                Step(description=_('Next page of explanation')),
+                Step(description=_('Another page of explanation')),
+            ],
+            step_numbers=True
+        )
+        
+        return [
+            consent,
+            playlist,
+            explainer
+        ]
+    
+    def next_round(self, session):
+        actions = self.get_questionnaire(session)
+
+        if actions:
+            return actions
+        
+        return [Final()]
+    
+    def feedback_info(self):
+        info = super().feedback_info()
+        info['header'] = _("Any remarks or questions (optional):")
+        info['thank_you'] = _("Thank you for your feedback!")
+        
+        return info
+    

--- a/backend/experiment/management/commands/templates/test_experiment.py
+++ b/backend/experiment/management/commands/templates/test_experiment.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from experiment.models import Experiment
+from participant.models import Participant
+from section.models import Playlist
+from session.models import Session
+
+class NewExperimentTest(TestCase):
+
+    @classmethod
+    def setUpTestData(self):
+        self.participant = Participant.objects.create()
+        self.playlist = Playlist.objects.create(name='NewExperiment')
+        self.experiment = Experiment.objects.create(name='NewExperiment', rounds=5)
+        self.session = Session.objects.create(
+            experiment=self.experiment,
+            participant=self.participant,
+            playlist=self.playlist
+        )
+
+    def test_initializes_correctly(self):
+        assert self.experiment.name == 'NewExperiment'

--- a/backend/experiment/management/commands/templates/test_experiment.py
+++ b/backend/experiment/management/commands/templates/test_experiment.py
@@ -5,6 +5,7 @@ from participant.models import Participant
 from section.models import Playlist
 from session.models import Session
 
+
 class NewExperimentTest(TestCase):
 
     @classmethod

--- a/backend/experiment/rules/__init__.py
+++ b/backend/experiment/rules/__init__.py
@@ -1,15 +1,14 @@
+from .anisochrony import Anisochrony
 from .beat_alignment import BeatAlignment
+from .categorization import Categorization
 from .duration_discrimination import DurationDiscrimination
 from .duration_discrimination_tone import DurationDiscriminationTone
-from .anisochrony import Anisochrony
-from .categorization import Categorization
 from .eurovision_2020 import Eurovision2020
 from .gold_msi import GoldMSI
 from .h_bat import HBat
 from .h_bat_bfit import HBatBFIT
 from .hbat_bst import BST
 from .hooked import Hooked
-from .tele_tunes import HookedTeleTunes
 from .huang_2022 import Huang2022
 from .kuiper_2020 import Kuiper2020
 from .listening_conditions import ListeningConditions
@@ -21,14 +20,15 @@ from .rhythm_experiment_series import RhythmExperimentSeries
 from .rhythm_experiment_series_mri import RhythmExperimentSeriesMRI
 from .rhythm_experiment_series_unpaid import RhythmExperimentSeriesUnpaid
 from .speech2song import Speech2Song
+from .tele_tunes import HookedTeleTunes
 from .thats_my_song import ThatsMySong
-from .toontjehoger_home import ToontjeHogerHome
 from .toontjehoger_1_mozart import ToontjeHoger1Mozart
 from .toontjehoger_2_preverbal import ToontjeHoger2Preverbal
 from .toontjehoger_3_plink import ToontjeHoger3Plink
 from .toontjehoger_4_absolute import ToontjeHoger4Absolute
 from .toontjehoger_5_tempo import ToontjeHoger5Tempo
 from .toontjehoger_6_relative import ToontjeHoger6Relative
+from .toontjehoger_home import ToontjeHogerHome
 from .visual_matching_pairs import VisualMatchingPairsGame
 
 # Rules available to this application
@@ -36,16 +36,21 @@ from .visual_matching_pairs import VisualMatchingPairsGame
 # so they can be referred to by the admin
 
 EXPERIMENT_RULES = {
+    Anisochrony.ID: Anisochrony,
     BeatAlignment.ID: BeatAlignment,
-    Speech2Song.ID: Speech2Song,
+    BST.ID: BST,
+    Categorization.ID: Categorization,
     DurationDiscrimination.ID: DurationDiscrimination,
     DurationDiscriminationTone.ID: DurationDiscriminationTone,
-    Anisochrony.ID: Anisochrony,
+    Eurovision2020.ID: Eurovision2020,
+    GoldMSI.ID: GoldMSI,
     HBat.ID: HBat,
     HBatBFIT.ID: HBatBFIT,
-    BST.ID: BST,
     Hooked.ID: Hooked,
     HookedTeleTunes.ID: HookedTeleTunes,
+    Huang2022.ID: Huang2022,
+    Kuiper2020.ID: Kuiper2020,
+    ListeningConditions.ID: ListeningConditions,
     MatchingPairsGame.ID: MatchingPairsGame,
     MatchingPairsICMPC.ID: MatchingPairsICMPC,
     MusicalPreferences.ID: MusicalPreferences,
@@ -53,19 +58,14 @@ EXPERIMENT_RULES = {
     RhythmExperimentSeries.ID: RhythmExperimentSeries,
     RhythmExperimentSeriesMRI.ID: RhythmExperimentSeriesMRI,
     RhythmExperimentSeriesUnpaid.ID: RhythmExperimentSeriesUnpaid,
-    GoldMSI.ID: GoldMSI,
-    ListeningConditions.ID: ListeningConditions,
-    Huang2022.ID: Huang2022,
-    Categorization.ID: Categorization,
-    ToontjeHogerHome.ID: ToontjeHogerHome,
+    Speech2Song.ID: Speech2Song,
+    ThatsMySong.ID: ThatsMySong,
     ToontjeHoger1Mozart.ID: ToontjeHoger1Mozart,
     ToontjeHoger2Preverbal.ID: ToontjeHoger2Preverbal,
     ToontjeHoger3Plink.ID: ToontjeHoger3Plink,
     ToontjeHoger4Absolute.ID: ToontjeHoger4Absolute,
     ToontjeHoger5Tempo.ID: ToontjeHoger5Tempo,
     ToontjeHoger6Relative.ID: ToontjeHoger6Relative,
-    Eurovision2020.ID: Eurovision2020,
-    Kuiper2020.ID: Kuiper2020,
-    ThatsMySong.ID: ThatsMySong,
+    ToontjeHogerHome.ID: ToontjeHogerHome,
     VisualMatchingPairsGame.ID: VisualMatchingPairsGame
 }

--- a/scripts/manage
+++ b/scripts/manage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This script executes Django management commands through Docker.
+docker-compose run --rm server python manage.py $@


### PR DESCRIPTION
This PR adds a Django management command that allows a developer to create new experiments.

* It first asks the user for the experiment name
* Based on that name it will create a new file with the experiment name in snake case (e.g. `experiment/rules/snake_case.py`) based on a template in `experiment/management/commands/templates/experiment.py`
* It will register the experiment to `experiment/rules/__init__.py` (this might have to be removed later, see also #732 )
* Lastly, it will add a basic unit test in `experiment/rules/tests/test_snake_case.py`, based on the template in `experiment/management/commands/templates/test_experiment.py`

Additionally, this pull request adds a script that allows executing Django management commands through Docker, making it easier to execute this specific command.

## Demonstration


https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/860d6aed-c3bd-48cb-b60c-b640ce71ceb5

