### PR TITLE
Fixed(MatchingPairs): Remove margin-bottom in Histogram.scss

### DIFF
--- a/frontend/src/components/Histogram/Histogram.scss
+++ b/frontend/src/components/Histogram/Histogram.scss
@@ -2,7 +2,6 @@
     display: flex;
     aspect-ratio: 1/1;
     transform: scaleY(-1);
-    margin-bottom: 5px;
     margin-top: -10px;
 
     div {


### PR DESCRIPTION
This pull request removes the margin-bottom property in the Histogram.scss file which was causing unwanted spacing in the histogram component. 

Resolves #747 