### PR TITLE
Fix/session creation

### DIFF
--- a/backend/session/tests/test_views.py
+++ b/backend/session/tests/test_views.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+
+from experiment.models import Experiment
+from participant.models import Participant
+from section.models import Playlist
+from session.models import Session
+
+
+class SessionViewsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.participant = Participant.objects.create(unique_hash=42)
+        cls.playlist1 = Playlist.objects.create(name='First Playlist')
+        cls.playlist2 = Playlist.objects.create(name='Second Playlist')
+        cls.experiment = Experiment.objects.create(
+            name='TestViews',
+            slug='testviews'
+        )
+        cls.experiment.playlists.add(
+            cls.playlist1, cls.playlist2
+        )
+
+    def setUp(self):
+        session = self.client.session
+        session['participant_id'] = self.participant.id
+        session.save()
+
+    def test_create_with_playlist(self):
+        request = {
+            "experiment_id": self.experiment.id,
+            "playlist_id": self.playlist2.id
+        }
+        self.client.post('/session/create/', request)
+        new_session = Session.objects.get(
+            experiment=self.experiment, participant=self.participant)
+        assert new_session
+        assert new_session.playlist == self.playlist2
+
+    def test_create_without_playlist(self):
+        request = {
+            "experiment_id": self.experiment.id
+        }
+        self.client.post('/session/create/', request)
+        new_session = Session.objects.get(
+            experiment=self.experiment, participant=self.participant)
+        assert new_session
+        assert new_session.playlist == self.playlist1

--- a/backend/session/urls.py
+++ b/backend/session/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .views import create_session, continue_session, next_round, finalize_session, register_playlist
+from .views import create_session, continue_session, next_round, finalize_session
+
 
 app_name='session'
 
@@ -7,9 +8,7 @@ urlpatterns = [
     path('create/',
         create_session, name='session_create'),
     path('<int:session_id>/next_round/',
-        next_round, name='session_next_round'),
-    path('<int:session_id>/register_playlist/',
-         register_playlist, name='register_playlist'),
+         next_round, name='session_next_round'),
     path('continue/<int:session_id>', 
         continue_session, name='continue_session'),
     path('<int:session_id>/finalize/', finalize_session)

--- a/backend/session/views.py
+++ b/backend/session/views.py
@@ -31,7 +31,14 @@ def create_session(request):
     # Create new session
     session = Session(experiment=experiment, participant=participant)
 
-    if experiment.playlists.count() >= 1:
+    if request.POST.get("playlist_id"):
+        try:
+            playlist = Playlist.objects.get(
+                pk=request.POST.get("playlist_id"), experiment__id=session.experiment.id)
+            session.playlist = playlist
+        except:
+            raise Http404("Playlist does not exist")
+    elif experiment.playlists.count() >= 1:
         # register first playlist
         session.playlist = experiment.playlists.first()
 
@@ -39,25 +46,6 @@ def create_session(request):
     session.save()
 
     return JsonResponse({'session': {'id': session.id}})
-
-
-@require_POST
-def register_playlist(request, session_id):
-    # load playlist from request
-    playlist_id = request.POST.get("playlist_id")
-    if not playlist_id:
-        return HttpResponseBadRequest("playlist_id not defined")
-    participant = get_participant(request)
-    session = get_object_or_404(Session,
-                                pk=session_id, participant__id=participant.id)
-    try:
-        playlist = Playlist.objects.get(
-            pk=playlist_id, experiment__id=session.experiment.id)
-        session.playlist = playlist
-        session.save()
-        return JsonResponse({'success': True})
-    except Playlist.DoesNotExist:
-        raise Http404("Playlist does not exist")
 
 
 def continue_session(request, session_id):

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,7 @@
     "@storybook/react-webpack5": "7.6.6",
     "@storybook/testing-library": "0.2.2",
     "@testing-library/jest-dom": "^6.1.5",
-    "@testing-library/react": "^14.1.2",
+    "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.1",
     "babel-plugin-named-exports-order": "0.0.2",
     "coverage-badges-cli": "^1.2.5",

--- a/frontend/src/API.js
+++ b/frontend/src/API.js
@@ -70,16 +70,17 @@ export const createConsent = async ({ experiment, participant }) => {
 };
 
 // Create a new session for given experiment
-export const createSession = async ( {experiment, participant} ) => {
+export const createSession = async ( {experiment, participant, playlist} ) => {
     try {
         const response = await axios.post(
             API_BASE_URL + URLS.session.create,
             qs.stringify({
                 experiment_id: experiment.id,
+                playlist_id: playlist.current,
                 csrfmiddlewaretoken: participant.csrf_token,
             })
         );
-        return response.data;
+        return response.data.session;
     } catch (err) {
         console.error(err);
         return null;

--- a/frontend/src/components/Experiment/Experiment.test.js
+++ b/frontend/src/components/Experiment/Experiment.test.js
@@ -4,21 +4,7 @@ import { render, screen } from '@testing-library/react';
 
 import Experiment from './Experiment';
 
-jest.mock("../../util/stores", () => ({
-    useSessionStore: (fn) => {
-        const methods = {
-            setSession: jest.fn(),
-            session: 1
-        } 
-        return fn(methods);
-    },
-    useParticipantStore: () => {
-        return {participant: 1}
-    },
-    useErrorStore: () => {
-        return {setError: jest.fn()}
-    }
-}));
+jest.mock("../../util/stores");
 
 jest.mock("../../API", () => ({
     useExperiment: () => {return [{id: 24, slug: 'test', name: 'Test', next_round: [

--- a/frontend/src/components/Experiment/Experiment.test.js
+++ b/frontend/src/components/Experiment/Experiment.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom/cjs/react-router-dom';
+import { render, screen } from '@testing-library/react';
+
+import Experiment from './Experiment';
+
+jest.mock("../../util/stores", () => ({
+    useSessionStore: (fn) => {
+        const methods = {
+            setSession: jest.fn(),
+            session: 1
+        } 
+        return fn(methods);
+    },
+    useParticipantStore: () => {
+        return {participant: 1}
+    },
+    useErrorStore: () => {
+        return {setError: jest.fn()}
+    }
+}));
+
+jest.mock("../../API", () => ({
+    useExperiment: () => {return [{id: 24, slug: 'test', name: 'Test', next_round: [
+        {view: 'EXPLAINER'}
+    ]}, false]},
+    createSession: () => Promise.resolve({data: {session: 1}})
+}));
+
+describe('Experiment Component', () => {
+
+    it('renders with given props', () => {
+
+        render(
+            <MemoryRouter>
+                <Experiment match={ {params: {slug: 'test'}} }/>
+            </MemoryRouter>
+        );
+        expect(screen.getByTestId('experiment-wrapper').toBeInTheDocument());
+    })
+
+
+
+});

--- a/frontend/src/components/Explainer/Explainer.js
+++ b/frontend/src/components/Explainer/Explainer.js
@@ -3,17 +3,17 @@ import Button from "../Button/Button";
 
 // Explainer is an experiment view that shows a list of steps
 // If the button has not been clicked, onNext will be called automatically after the timer expires (in milliseconds). If timer == null, onNext will only be called after the button is clicked.
-const Explainer = ({ instruction, button_label, steps = [], onNext, timer }) => {
+const Explainer = ({ instruction, button_label, steps = [], timer = null, onNext }) => {
 
     useEffect( () => {
         if (timer != null) {
             const id = setTimeout(onNext, timer);
             return () => {clearTimeout(id)}; // if button has been clicked, clear timeout
         }
-    })
+    }, [onNext, timer])
 
     return (
-        <div className="aha__explainer">
+        <div data-testid="explainer" className="aha__explainer">
             <h3 className="title">{instruction}</h3>
 
             <ul>

--- a/frontend/src/components/Explainer/Explainer.test.js
+++ b/frontend/src/components/Explainer/Explainer.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Explainer from './Explainer';
+
+describe('Explainer Component', () => {
+    const props = {
+        instruction: 'Some instruction',
+        button_label: 'Next',
+        steps: [],
+        onNext: jest.fn(),
+        timer: 1
+    }
+
+    it('renders with given props', () => {
+
+        render(
+            <Explainer {...props} />
+        );
+        expect(screen.getByTestId('explainer')).toBeInTheDocument();
+    })
+
+
+
+});

--- a/frontend/src/components/PlayButton/PlayCard.test.js
+++ b/frontend/src/components/PlayButton/PlayCard.test.js
@@ -2,6 +2,8 @@ import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import PlayCard from "./PlayCard"; // Adjust the path as necessary
 
+jest.mock("../../util/stores");
+
 describe("PlayCard Component Tests", () => {
     const mockOnClick = jest.fn();
     const mockRegisterUserClicks = jest.fn();

--- a/frontend/src/components/Playback/MatchingPairs.js
+++ b/frontend/src/components/Playback/MatchingPairs.js
@@ -16,7 +16,6 @@ const MatchingPairs = ({
     playSection,
     sections,
     playerIndex,
-    stopAudioAfter,
     showAnimation,
     finishedPlaying,
     scoreFeedbackDisplay = SCORE_FEEDBACK_DISPLAY.LARGE_TOP, // 'large-top' (default) | 'small-bottom-right' | 'hidden'
@@ -30,7 +29,6 @@ const MatchingPairs = ({
     const secondCard = useRef(-1);
     const [total, setTotal] = useState(100);
     const [message, setMessage] = useState('Pick a card');
-    const [turnFeedback, setTurnFeedback] = useState('');
     const [end, setEnd] = useState(false);
     const columnCount = sections.length > 6 ? 4 : 3;
 
@@ -140,7 +138,6 @@ const MatchingPairs = ({
         // remove third click event
         document.getElementById('root').removeEventListener('click', finishTurn);
         score.current = undefined;
-        setTurnFeedback('');
         // Turn all cards back and enable events
         sections.forEach(section => section.turned = false);
         sections.forEach(section => section.noevents = false);
@@ -172,8 +169,6 @@ const MatchingPairs = ({
                         registerUserClicks={registerUserClicks}
                         playing={playerIndex === index}
                         section={sections[index]}
-                        onFinish={showFeedback}
-                        stopAudioAfter={stopAudioAfter}
                         showAnimation={showAnimation}
                     />
                 )

--- a/frontend/src/components/Playback/MatchingPairs.test.js
+++ b/frontend/src/components/Playback/MatchingPairs.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import MatchingPairs, { SCORE_FEEDBACK_DISPLAY } from './MatchingPairs';
 
+jest.mock("../../util/stores");
+
 describe('MatchingPairs Component', () => {
 
     const baseProps = {

--- a/frontend/src/components/Playback/MatchingPairs.test.js
+++ b/frontend/src/components/Playback/MatchingPairs.test.js
@@ -2,10 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import MatchingPairs, { SCORE_FEEDBACK_DISPLAY } from './MatchingPairs';
 
-jest.mock("../PlayButton/PlayCard", () => (props) => (
-    <div data-testid="play-card" {...props} />
-));
-
 describe('MatchingPairs Component', () => {
 
     const baseProps = {
@@ -15,6 +11,7 @@ describe('MatchingPairs Component', () => {
         onFinish: jest.fn(),
         stopAudioAfter: 4.0,
         submitResult: jest.fn(),
+        showAnimation: false
     };
 
     it('displays three columns when sections length is less than or equal to 6', () => {
@@ -26,7 +23,7 @@ describe('MatchingPairs Component', () => {
     it('displays four columns when sections length is greater than 6', () => {
         const sections = new Array(7).fill({}).map((_, index) => ({ id: index }));
         const { container } = render(<MatchingPairs {...baseProps} sections={sections} />);
-        expect(container.querySelector('.playing-board--two-columns')).not.toBeInTheDocument();
+        expect(container.querySelector('.playing-board--three-columns')).not.toBeInTheDocument();
     });
 
     it('displays score feedback when scoreFeedbackDisplay is not HIDDEN', () => {

--- a/frontend/src/components/Playback/Playback.test.js
+++ b/frontend/src/components/Playback/Playback.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import Playback from './Playback';
+
+jest.mock("../../util/stores");
 
 describe('Playback', () => {
 

--- a/frontend/src/components/Playlist/Playlist.js
+++ b/frontend/src/components/Playlist/Playlist.js
@@ -43,7 +43,7 @@ const Playlist = ({ experiment, instruction, onNext }) => {
                 </ul>
             </div>
         );
-    };
+    } else { return null };
 };
 
 const PlaylistItem = ({ delay, playlist, onClick }) => (

--- a/frontend/src/components/Playlist/Playlist.js
+++ b/frontend/src/components/Playlist/Playlist.js
@@ -1,14 +1,8 @@
 import React, { useEffect } from "react";
 
-import { registerPlaylist } from "API";
-import { useErrorStore, useParticipantStore, useSessionStore } from "util/stores";
-
 // Playlist is an experiment view, that handles (auto)selection of a playlist
-const Playlist = ({ experiment, instruction, onNext }) => {
+const Playlist = ({ experiment, instruction, onNext, playlist }) => {
     const playlists = experiment.playlists;
-    const session = useSessionStore(state => state.session);
-    const participant = useParticipantStore(state => state.participant);
-    const setError = useErrorStore(state => state.setError);
 
     useEffect(() => {
         if (playlists.length < 2) {
@@ -23,19 +17,13 @@ const Playlist = ({ experiment, instruction, onNext }) => {
             <div className="aha__playlist">
                 <h3 data-testid="playlist-instruction" className="title">{instruction}</h3>
                 <ul>
-                    {playlists.map((playlist, index) => (
+                    {playlists.map((playlistItem, index) => (
                         <PlaylistItem
-                            key={playlist.id}
-                            playlist={playlist}
+                            key={playlistItem.id}
+                            playlist={playlistItem}
                             onClick={(playlistId) => {
-                                registerPlaylist(playlistId, participant, session).then(response => {
-                                    if (response) {
-                                        onNext();
-                                    }
-                                    else {
-                                        setError("Could not set playlist");
-                                    }
-                                });
+                                playlist.current = playlistId;
+                                onNext();
                             }}
                             delay={index * 250}
                         />

--- a/frontend/src/components/Playlist/Playlist.test.js
+++ b/frontend/src/components/Playlist/Playlist.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import Playlist from './Playlist';
 
@@ -10,31 +10,31 @@ jest.mock('../../API', () => ({
 }));
 
 describe('Playlist Component', () => {
+    const onNext = jest.fn();
+    const playlist = { current: 25 };
     const experimentProp = { slug: 'test-experiment', playlists: [{id: 42}, {id: 43}] };
     it('renders correctly with given props', () => {
         render(
-            <Playlist experiment={experimentProp} instruction="instruction" onNext={jest.fn()}/>
+            <Playlist experiment={experimentProp} instruction="instruction" onNext={onNext} playlist={playlist}/>
         )
         expect(screen.getByTestId('playlist-instruction')).toBeInTheDocument();
         const playlistItems = screen.getAllByTestId('playlist-item');
         expect(playlistItems.length === 2);
     });
 
-    it('calls registerPlaylist when playlist item is clicked', async () => {
-        const { registerPlaylist } = require('../../API');
+    it('calls registerPlaylist when playlist item is clicked', () => {
         render(
-            <Playlist experiment={experimentProp} instruction="instruction" onNext={jest.fn()}/>
+            <Playlist experiment={experimentProp} instruction="instruction" onNext={onNext} playlist={playlist}/>
         )
-        registerPlaylist.mockResolvedValueOnce({});
         fireEvent.click(screen.getAllByTestId('playlist-item')[0]);
-        await waitFor(() => expect(registerPlaylist).toHaveBeenCalled);
+        expect((onNext).toHaveBeenCalled);
     })
 
     it('does not render with less than 2 playlists', () => {
         const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         experimentProp.playlists = [{id: 42}]
         render(
-            <Playlist experiment={experimentProp} instruction="instruction" onNext={jest.fn()}/>
+            <Playlist experiment={experimentProp} instruction="instruction" onNext={onNext} playlist={playlist}/>
         )
         expect(consoleSpy).toHaveBeenCalled();
         expect(screen.queryByTestId('playlist-instruction')).not.toBeInTheDocument();

--- a/frontend/src/components/Playlist/Playlist.test.js
+++ b/frontend/src/components/Playlist/Playlist.test.js
@@ -3,17 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import Playlist from './Playlist';
 
-jest.mock("../../util/stores", () => ({
-    useSessionStore: () => {
-        return {session: 1}
-    },
-    useParticipantStore: () => {
-        return {participant: 1}
-    },
-    useErrorStore: () => {
-        return {setError: jest.fn()}
-    }
-}))
+jest.mock("../../util/stores");
 
 jest.mock('../../API', () => ({
     registerPlaylist: jest.fn(),

--- a/frontend/src/components/Trial/Trial.test.js
+++ b/frontend/src/components/Trial/Trial.test.js
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 
 import Trial from "./Trial";
 
+jest.mock("../../util/stores");
+
 const feedback_form = {
     form: [{
         key: 'test_question',

--- a/frontend/src/components/VisualMatchingPairs/VisualMatchingPairs.js
+++ b/frontend/src/components/VisualMatchingPairs/VisualMatchingPairs.js
@@ -153,8 +153,6 @@ const VisualMatchingPairs = (props) => {
             setMessage('');
         }
 
-        console.log('start time', startTime)
-
         const newResult = {
             selectedSection: currentCard.id,
             cardIndex: index,
@@ -202,7 +200,7 @@ const VisualMatchingPairs = (props) => {
     }, [gameState, setEnd]);
 
     const registerUserClicks = () => void 0;
-    const stopAudioAfter = () => void 0;
+
 
     const onPlayCardClick = (index) => {
         setPlayerIndex(-1);
@@ -247,10 +245,8 @@ const VisualMatchingPairs = (props) => {
                         key={index}
                         onClick={() => onPlayCardClick(index)}
                         playing={playerIndex === index}
-                        onFinish={showFeedback}
                         registerUserClicks={registerUserClicks}
                         section={section}
-                        stopAudioAfter={stopAudioAfter}
                         view={view}
                     />
                 )

--- a/frontend/src/components/VisualMatchingPairs/VisualMatchingPairs.test.js
+++ b/frontend/src/components/VisualMatchingPairs/VisualMatchingPairs.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import VisualMatchingPairs from './VisualMatchingPairs'; // Adjust the import path as necessary
 
+jest.mock("../../util/stores");
+
 // Mock data for sections
 const mockSections = [
     { id: 1, content: 'Card 1', url: '/cat-01.jpg', inactive: false, turned: false, noevents: false, seen: false, group: 1 },

--- a/frontend/src/util/__mocks__/stores.js
+++ b/frontend/src/util/__mocks__/stores.js
@@ -1,0 +1,15 @@
+module.exports = {
+    useSessionStore: (fn) => {
+        const methods = {
+            setSession: jest.fn(),
+            session: 1
+        } 
+        return fn(methods);
+    },
+    useParticipantStore: () => {
+        return {participant: 1}
+    },
+    useErrorStore: () => {
+        return {setError: jest.fn()}
+    }
+};

--- a/frontend/src/util/__mocks__/stores.js
+++ b/frontend/src/util/__mocks__/stores.js
@@ -2,7 +2,7 @@ module.exports = {
     useSessionStore: (fn) => {
         const methods = {
             setSession: jest.fn(),
-            session: 1
+            session: {id: 1}
         } 
         return fn(methods);
     },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6118,9 +6118,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^14.1.2":
-  version: 14.1.2
-  resolution: "@testing-library/react@npm:14.1.2"
+"@testing-library/react@npm:^14.2.1":
+  version: 14.2.1
+  resolution: "@testing-library/react@npm:14.2.1"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     "@testing-library/dom": "npm:^9.0.0"
@@ -6128,7 +6128,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: b5b0990d3aa0ea8b37c55804e0d5d584fc638a5c7d4df90da9a0fdb00bc981b27b6991468b2dc719982a5d0b0107a41596063ce51ad519eeab47b22bc04d6779
+  checksum: 83b35cf8bf5640f1b63b32223ebc75799dc1a8e034d819120b26838fba0b0ab10bdbe6ad07dd8ae8287365f2b0c52dc9892a6fa11bb24d3e63ad97dfb7f2f296
   languageName: node
   linkType: hard
 
@@ -7372,7 +7372,7 @@ __metadata:
     "@storybook/react-webpack5": "npm:7.6.6"
     "@storybook/testing-library": "npm:0.2.2"
     "@testing-library/jest-dom": "npm:^6.1.5"
-    "@testing-library/react": "npm:^14.1.2"
+    "@testing-library/react": "npm:^14.2.1"
     "@testing-library/user-event": "npm:^14.5.1"
     axios: "npm:>=1.6.0"
     babel-plugin-named-exports-order: "npm:0.0.2"


### PR DESCRIPTION
This branch undoes some of the changes to the playlist / session creation logic. It makes use of `useRef` to keep track of actions and playlists, as `useState` will pick up changes too slowly for the logic to work. Pending: unit test for  the `Experiment` component, which at the time of writing keeps going into an infinite `useEffect` loop between `Experiment` and the child component while testing.