### PR TITLE
add Trial to template

### DIFF
--- a/backend/experiment/management/commands/templates/experiment.py
+++ b/backend/experiment/management/commands/templates/experiment.py
@@ -27,7 +27,6 @@ class NewExperiment(Base):
                             'isced-2', 'isced-5'])
         ]
 
-
     def first_round(self, experiment):
         # 1. Informed consent (optional)
         rendered = render_to_string('consent/consent.html')

--- a/backend/experiment/management/commands/templates/experiment.py
+++ b/backend/experiment/management/commands/templates/experiment.py
@@ -2,46 +2,33 @@ from typing import Final
 from django.utils.translation import gettext_lazy as _
 from django.template.loader import render_to_string
 
-from .experiment.rules import Base
-from .experiment.actions import Consent, Explainer, Final, Playlist, Step
-from .section.models import Playlist
-from .experiment.questions.demographics import EXTRA_DEMOGRAPHICS
-from .experiment.questions.utils import question_by_key
+from experiment.actions import Consent, BooleanQuestion, Explainer, Final, Form, Playlist, Step, Trial
+from experiment.actions.playback import Autoplay
+from experiment.rules.base import Base
+from result.utils import prepare_result
+from section.models import Playlist
 
 
 class NewExperiment(Base):
     ID = 'NEW_EXPERIMENT'
     contact_email = 'info@example.com'
 
-    def __init__(self):
-        super().__init__(self.ID)
-        
-        # Add your questions here
-        self.questions = [
-            question_by_key('dgf_gender_identity'),
-            question_by_key('dgf_generation'),
-            question_by_key('dgf_musical_experience', EXTRA_DEMOGRAPHICS),
-            question_by_key('dgf_country_of_origin'),
-            question_by_key('dgf_education', drop_choices=['isced-2', 'isced-5'])
-        ]
-
     def first_round(self, experiment):
-        
         # 1. Informed consent
         rendered = render_to_string('consent/consent_new_experiment.html')
         consent = Consent(rendered, title=_(
             'Informed consent'), confirm=_('I agree'), deny=_('Stop'))
         
-        # 2. Choose playlist.
+        # 2. Choose playlist (only relevant if there are multiple playlists the participant can choose from)
         playlist = Playlist(experiment.playlists.all())
 
         # 3. Explainer
         explainer = Explainer(
-            instruction='',
+            instruction='Welcome to this new experiment',
             steps=[
-                Step(description=_('New Experiment is ...')),
-                Step(description=_('Next page of explanation')),
-                Step(description=_('Another page of explanation')),
+                Step(description=_('Please read the instructions carefully')),
+                Step(description=_('Next step of explanation')),
+                Step(description=_('Another step of explanation')),
             ],
             step_numbers=True
         )
@@ -53,17 +40,42 @@ class NewExperiment(Base):
         ]
     
     def next_round(self, session):
+        # ask any questions defined in the admin interface
         actions = self.get_questionnaire(session)
 
         if actions:
             return actions
-        
-        return [Final()]
-    
-    def feedback_info(self):
-        info = super().feedback_info()
-        info['header'] = _("Any remarks or questions (optional):")
-        info['thank_you'] = _("Thank you for your feedback!")
-        
-        return info
+        elif session.rounds_complete():
+            # we have as many results as rounds in this experiment
+            # finish session and show Final view
+            session.finish()
+            session.save()
+            return [Final()]
+        else:
+            return self.get_trial(session)
+
+    def get_trial(self, session):
+        # define a key, by which responses to this trial can be found in the database
+        key = 'test_trial'
+        # get a random section
+        section = session.section_from_any_song()
+        question = BooleanQuestion(
+            question=_(
+                "Do you like this song?"),
+            key=key,
+            result_id=prepare_result(key, session, section=section),
+            submits=True
+        )
+        form = Form([question])
+        playback = Autoplay([section])
+        view = Trial(
+            playback=playback,
+            feedback_form=form,
+            title=_('Test experiment'),
+            config={
+                'response_time': section.duration + .1,
+                'listen_first': True
+            }
+        )
+        return view
     

--- a/backend/experiment/management/commands/templates/experiment.py
+++ b/backend/experiment/management/commands/templates/experiment.py
@@ -4,6 +4,8 @@ from django.template.loader import render_to_string
 
 from experiment.actions import Consent, BooleanQuestion, Explainer, Final, Form, Playlist, Step, Trial
 from experiment.actions.playback import Autoplay
+from experiment.questions.demographics import EXTRA_DEMOGRAPHICS
+from experiment.questions.utils import question_by_key
 from experiment.rules.base import Base
 from result.utils import prepare_result
 from section.models import Playlist
@@ -12,6 +14,19 @@ from section.models import Playlist
 class NewExperiment(Base):
     ID = 'NEW_EXPERIMENT'
     contact_email = 'info@example.com'
+
+    def __init__(self):
+
+        # Add your questions here
+        self.questions = [
+            question_by_key('dgf_gender_identity'),
+            question_by_key('dgf_generation'),
+            question_by_key('dgf_musical_experience', EXTRA_DEMOGRAPHICS),
+            question_by_key('dgf_country_of_origin'),
+            question_by_key('dgf_education', drop_choices=[
+                            'isced-2', 'isced-5'])
+        ]
+
 
     def first_round(self, experiment):
         # 1. Informed consent
@@ -73,7 +88,7 @@ class NewExperiment(Base):
             feedback_form=form,
             title=_('Test experiment'),
             config={
-                'response_time': section.duration + .1,
+                'response_time': section.duration,
                 'listen_first': True
             }
         )


### PR DESCRIPTION
I was thinking along those lines for the template for `createexperiment`: add a `Trial` which demonstrates a typical setup. Still to be tested though, but just in general, @albertas-jn , do you think this could work? If you can already add documentation about the different methods in a typical rules file (i.e., first_round, next_round) to the wiki, that would certainly be helpful!

@drikusroor I removed the `feedback_info` method, since I figured we probably wouldn't *need* to override this - or is there a reason you did in the original template? I also got rid of the `questions` array in the `__init__`, because we can now select questions through the admin interface, and I'd rather that users choose that method over hard-coding them in the rules file.