### PR TITLE
Allow user to create experiment in db after creating experiment rule set

### DIFF
--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -28,12 +28,7 @@ class Command(BaseCommand):
         create_experiment = input("Do you want to create a new experiment with the same name? (yes/no): ")
 
         if create_experiment.lower() == 'yes' or create_experiment.lower() == 'y':
-            self.stdout.write(self.style.WARNING("Creating a new experiment..."))
-            Experiment.objects.create(
-                name=experiment_rules_set_name, 
-                rules=experiment_rules_set_name,
-                slug=experiment_rules_set_name.lower().replace(' ', '_')
-            )
+            self.create_test_in_db(experiment_rules_set_name)
 
     def create_experiment_rule_class(self, experiment_rules_set_name):
         # Get the experiment name in different cases
@@ -112,6 +107,15 @@ class Command(BaseCommand):
                 )
 
         self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_rules_set_name}"))
+
+    def create_test_in_db(self, experiment_rules_set_name):
+        self.stdout.write(self.style.WARNING("Creating a new experiment..."))
+        Experiment.objects.create(
+            name=experiment_rules_set_name, 
+            rules=experiment_rules_set_name,
+            slug=experiment_rules_set_name.lower().replace(' ', '_')
+        )
+        self.stdout.write(self.style.SUCCESS(f"Created experiment {experiment_rules_set_name}"))
 
     def get_experiment_rules_set_name_cases(self, experiment_rules_set_name):
         # Convert experiment name to snake_case and lowercase every word and replace spaces with underscores

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -35,7 +35,6 @@ class Command(BaseCommand):
                 slug=experiment_rules_set_name.lower().replace(' ', '_')
             )
 
-
     def create_experiment_rule_class(self, experiment_rules_set_name):
         # Get the experiment name in different cases
         experiment_rules_set_name_snake_case, experiment_rules_set_name_snake_case_upper, experiment_rules_set_name_pascal_case = self.get_experiment_rules_set_name_cases(experiment_rules_set_name)

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -12,6 +12,9 @@ class Command(BaseCommand):
         # Ask for the experiment name
         experiment_rules_set_name = input("What is the name of your experiment rule set? (ex. Musical Preferences): ")
 
+        (snake_case, snake_case_upper, pascal_case) = self.get_experiment_rules_set_name_cases(experiment_rules_set_name)
+        self.stdout.write(self.style.WARNING(f"Converting {experiment_rules_set_name} to {snake_case} (snake_case) and {pascal_case} (PascalCase) for file names and class names."))
+
         # Create the experiment rule class
         success = self.create_experiment_rule_class(experiment_rules_set_name)
 

--- a/backend/experiment/management/commands/createexperiment.py
+++ b/backend/experiment/management/commands/createexperiment.py
@@ -2,60 +2,74 @@ import os.path
 
 from django.core.management.base import BaseCommand
 
+from experiment.models import Experiment
+
 
 class Command(BaseCommand):
     help = 'Creates a new experiment rules class'
 
     def handle(self, *args, **options):
         # Ask for the experiment name
-        experiment_name = input("What is the name of your experiment? (ex. Musical Preferences): ")
+        experiment_rules_set_name = input("What is the name of your experiment rule set? (ex. Musical Preferences): ")
 
         # Create the experiment rule class
-        success = self.create_experiment_rule_class(experiment_name)
+        success = self.create_experiment_rule_class(experiment_rules_set_name)
 
         if not success:
             return
 
         # Add the new experiment to ./experiment/rules/__init__.py
-        self.register_experiment_rule(experiment_name, './experiment/rules/__init__.py')
+        self.register_experiment_rule(experiment_rules_set_name, './experiment/rules/__init__.py')
 
         # Create a basic test file for the experiment
-        self.create_test_file(experiment_name)
+        self.create_test_file(experiment_rules_set_name)
 
-    def create_experiment_rule_class(self, experiment_name):
+        # Ask if the user wants to create a new experiment with the same name (yes/no)
+        create_experiment = input("Do you want to create a new experiment with the same name? (yes/no): ")
+
+        if create_experiment.lower() == 'yes' or create_experiment.lower() == 'y':
+            self.stdout.write(self.style.WARNING("Creating a new experiment..."))
+            Experiment.objects.create(
+                name=experiment_rules_set_name, 
+                rules=experiment_rules_set_name,
+                slug=experiment_rules_set_name.lower().replace(' ', '_')
+            )
+
+
+    def create_experiment_rule_class(self, experiment_rules_set_name):
         # Get the experiment name in different cases
-        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+        experiment_rules_set_name_snake_case, experiment_rules_set_name_snake_case_upper, experiment_rules_set_name_pascal_case = self.get_experiment_rules_set_name_cases(experiment_rules_set_name)
 
         # Create a new file for the experiment class
-        filename = f"./experiment/rules/{experiment_name_snake_case}.py"
+        filename = f"./experiment/rules/{experiment_rules_set_name_snake_case}.py"
 
         # Check if the file already exists
         if os.path.isfile(filename):
-            self.stdout.write(self.style.ERROR(f"Experiment {experiment_name} already exists. Exiting without creating file(s)."))
+            self.stdout.write(self.style.ERROR(f"Experiment {experiment_rules_set_name} already exists. Exiting without creating file(s)."))
             return
 
         # Create the file by copying ./experiment/management/commands/templates/experiment.py
         with open(filename, 'w') as f:
             with open('./experiment/management/commands/templates/experiment.py', 'r') as template:
                 f.write(template.read()
-                    .replace('NewExperiment', experiment_name_pascal_case)
-                    .replace('new_experiment', experiment_name_snake_case)
-                    .replace('NEW_EXPERIMENT', experiment_name_snake_case_upper)
-                    .replace('New Experiment', experiment_name.title())
+                    .replace('NewExperiment', experiment_rules_set_name_pascal_case)
+                    .replace('new_experiment', experiment_rules_set_name_snake_case)
+                    .replace('NEW_EXPERIMENT', experiment_rules_set_name_snake_case_upper)
+                    .replace('New Experiment', experiment_rules_set_name.title())
                 )
 
-        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
+        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_rules_set_name}"))
 
         return True
 
-    def register_experiment_rule(self, experiment_name, file_path):
+    def register_experiment_rule(self, experiment_rules_set_name, file_path):
 
         # Get the experiment name in different cases
-        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+        experiment_rules_set_name_snake_case, experiment_rules_set_name_snake_case_upper, experiment_rules_set_name_pascal_case = self.get_experiment_rules_set_name_cases(experiment_rules_set_name)
 
         # New lines to add
-        new_import = f"from .{experiment_name_snake_case} import {experiment_name_pascal_case}\n"
-        new_dict_entry = f"    {experiment_name_pascal_case}.ID: {experiment_name_pascal_case},\n"
+        new_import = f"from .{experiment_rules_set_name_snake_case} import {experiment_rules_set_name_pascal_case}\n"
+        new_dict_entry = f"    {experiment_rules_set_name_pascal_case}.ID: {experiment_rules_set_name_pascal_case},\n"
 
         with open(file_path, 'r') as file:
             lines = file.readlines()
@@ -74,14 +88,14 @@ class Command(BaseCommand):
         with open(file_path, 'w') as file:
             file.writelines(lines)
 
-        self.stdout.write(self.style.SUCCESS(f"Registered {experiment_name} in {file_path}"))
+        self.stdout.write(self.style.SUCCESS(f"Registered {experiment_rules_set_name} in {file_path}"))
 
-    def create_test_file(self, experiment_name):
+    def create_test_file(self, experiment_rules_set_name):
         # Get the experiment name in different cases
-        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+        experiment_rules_set_name_snake_case, experiment_rules_set_name_snake_case_upper, experiment_rules_set_name_pascal_case = self.get_experiment_rules_set_name_cases(experiment_rules_set_name)
 
         # Create a new file for the experiment class
-        filename = f"./experiment/rules/tests/test_{experiment_name_snake_case}.py"
+        filename = f"./experiment/rules/tests/test_{experiment_rules_set_name_snake_case}.py"
 
         # Check if the file already exists
         if os.path.isfile(filename):
@@ -92,20 +106,20 @@ class Command(BaseCommand):
         with open(filename, 'w') as f:
             with open('./experiment/management/commands/templates/test_experiment.py', 'r') as template:
                 f.write(template.read()
-                    .replace('NewExperiment', experiment_name_pascal_case)
-                    .replace('new_experiment', experiment_name_snake_case)
-                    .replace('NEW_EXPERIMENT', experiment_name_snake_case_upper)
-                    .replace('New Experiment', experiment_name.title())
+                    .replace('NewExperiment', experiment_rules_set_name_pascal_case)
+                    .replace('new_experiment', experiment_rules_set_name_snake_case)
+                    .replace('NEW_EXPERIMENT', experiment_rules_set_name_snake_case_upper)
+                    .replace('New Experiment', experiment_rules_set_name.title())
                 )
 
-        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
+        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_rules_set_name}"))
 
-    def get_experiment_name_cases(self, experiment_name):
+    def get_experiment_rules_set_name_cases(self, experiment_rules_set_name):
         # Convert experiment name to snake_case and lowercase every word and replace spaces with underscores
-        experiment_name_snake_case = experiment_name.lower().replace(' ', '_')
-        experiment_name_snake_case_upper = experiment_name_snake_case.upper()
+        experiment_rules_set_name_snake_case = experiment_rules_set_name.lower().replace(' ', '_')
+        experiment_rules_set_name_snake_case_upper = experiment_rules_set_name_snake_case.upper()
 
         # Convert experiment name to PascalCase and capitalize every word and remove spaces
-        experiment_name_pascal_case = experiment_name.title().replace(' ', '')
+        experiment_rules_set_name_pascal_case = experiment_rules_set_name.title().replace(' ', '')
 
-        return experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case
+        return experiment_rules_set_name_snake_case, experiment_rules_set_name_snake_case_upper, experiment_rules_set_name_pascal_case


### PR DESCRIPTION
Per a suggestion by @hhoning 

This pull request adds a new feature that allows the user to create an experiment in the database after creating an experiment rule set, which you often want to do anyway.

## Screenshot

<img width="657" alt="image" src="https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/c07642b1-f031-4d03-a1d2-7059653caceb">
