### PR TITLE
Add a manage-podman script

### DIFF
--- a/scripts/manage-podman
+++ b/scripts/manage-podman
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This script executes Django management commands through Docker.
+podman-compose run --rm server python manage.py $@


### PR DESCRIPTION
Add ./scripts/manage-podman, a copy of ./scripts/manage that uses podman-compose instead of docker-compose.
This script can be used to run "manage" commands inside a container when using podman instead of docker.