### PR TITLE
Fixed: Fix input types for start time and duration fields in edit sections page

### DIFF
--- a/backend/experiment/templates/edit-sections.html
+++ b/backend/experiment/templates/edit-sections.html
@@ -64,11 +64,11 @@
                     value="{{ section.song.name}}" {% if not section.song %} placeholder="*" {% endif %}>
             </td>
             <td>
-                <input type="text" name="{{section.id}}_start_time" maxlength="128" required=""
+                <input type="number" name="{{section.id}}_start_time" maxlength="128" required=""
                     id="{{section.id}}_start_time" value="{{ section.start_time}}">
             </td>
             <td>
-                <input type="text" name="{{section.id}}_duration" maxlength="128" required=""
+                <input type="number" name="{{section.id}}_duration" maxlength="128" required=""
                     id="{{section.id}}_duration" value="{{ section.duration}}">
             </td>
             <td>

--- a/backend/experiment/templates/edit-sections.html
+++ b/backend/experiment/templates/edit-sections.html
@@ -45,7 +45,6 @@
             <th>Duration</th>
             <th>Group</th>
             <th>Tag</th>
-            <th>NL</th>
         </tr>        
         {% for section in sections %}
         <tr {% if not section.song %} class="song-padding" {% endif %}>


### PR DESCRIPTION
This pull request fixes the input types for the start time and duration fields in the playlist editing section. The input types have been updated from type=text to type=number to ensure that only numeric values can be entered.

Resolves #765

@Evert-R I have assigned you as reviewer as I believe you made this feature
@chfin I have assigned you as well as it might help with confirming the fix was successful after it has been deployed to acceptance