### PR TITLE
Fixed: Fix export_table method to export question_key and add unit tests

### DIFF
--- a/backend/experiment/forms.py
+++ b/backend/experiment/forms.py
@@ -13,7 +13,7 @@ SESSION_CHOICES = [('experiment_id', 'Experiment ID'),
                    ('participant_access_info', 'Participant access info'),
                    ('session_start', 'Session start time'),
                    ('session_end', 'Session end time'),
-                   ('final_score', 'Final score')
+                   ('final_score', 'Final score'),
                    ]
 
 # result_keys for Export CSV
@@ -22,7 +22,8 @@ RESULT_CHOICES = [('section_name', 'Section name'),
                   ('result_score', 'Result score'),
                   ('result_comment', 'Result comment'),
                   ('expected_response', 'Expected response'),
-                  ('given_response', 'Given response')
+                  ('given_response', 'Given response'),
+                  ('question_key', 'Question key'),
                   ]
 
 # export_options for Export CSV

--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -2,12 +2,11 @@ import copy
 
 from django.db import models
 from django.utils import timezone
+from django.contrib.postgres.fields import ArrayField
+from typing import List, Dict, Tuple, Any
 from experiment.rules import EXPERIMENT_RULES
 from experiment.standards.iso_languages import ISO_LANGUAGES
-
-from django.contrib.postgres.fields import ArrayField
 from .questions import QUESTIONS_CHOICES, get_default_question_keys
-from django import forms
 
 language_choices = [(key, ISO_LANGUAGES[key]) for key in ISO_LANGUAGES.keys()]
 language_choices[0] = ('', 'Unset')
@@ -94,7 +93,7 @@ class Experiment(models.Model):
         # export session objects
         return self.session_set.all()
 
-    def export_table(self, session_keys, result_keys, export_options):
+    def export_table(self, session_keys: List[str], result_keys: List[str], export_options: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[str]]:
         """Export filtered tabular data for admin
             session_keys : session fieldnames to be included
             result_keys : result fieldnames to be included

--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -152,8 +152,10 @@ class Experiment(models.Model):
                         'result_score': result.score,
                         'result_comment': result.comment,
                         'expected_response': result.expected_response,
-                        'given_response': result.given_response
+                        'given_response': result.given_response,
+                        'question_key': result.question_key,
                     }
+
                     result_data = {}
                     # Add counter for single row / wide format
                     if 'wide_format' in export_options:

--- a/backend/experiment/tests/test_admin_experiment.py
+++ b/backend/experiment/tests/test_admin_experiment.py
@@ -83,12 +83,13 @@ class TestAdminExperimentExport(TestCase):
             Result.objects.create(
                 session=Session.objects.first(),
                 expected_response = i,
-                given_response = i
+                given_response = i,
+                question_key = 'test_question_' + str(i),
             )
             Result.objects.create(
                 participant=cls.participant,
                 question_key= i,
-                given_response = i
+                given_response = i,
             )
             
     def setUp(self):
@@ -132,3 +133,18 @@ class TestAdminExperimentExport(TestCase):
         # test response from forced download
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['content-type'], 'application/x-zip-compressed')
+
+    def test_export_table_includes_question_key(self):
+        session_keys = ['session_start', 'session_end']
+        result_keys = ['question_key']
+        export_options = ['convert_result_json']  # Adjust based on your needs
+
+        # Call the method under test
+        rows, fieldnames = self.experiment.export_table(session_keys, result_keys, export_options)
+
+        # Assert that 'question_key' is in the fieldnames and check its value in rows
+        self.assertIn('question_key', fieldnames)
+        for i in range(len(rows)):
+            row = rows[i]
+            self.assertIn('question_key', row)
+            self.assertEqual(row['question_key'], 'test_question_' + str(i))


### PR DESCRIPTION
Resolves #670 (CSV export doesn't export the "question_key" of results)