### PR TITLE
Fix: Increase file size limit for uploads in nginx configuration

### DIFF
--- a/nginx/custom-nginx.conf
+++ b/nginx/custom-nginx.conf
@@ -9,6 +9,8 @@ server {
 
     # Proxy pass to the Django app
     location /server/ {
+        client_max_body_size 100M;
+
         proxy_pass http://server:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This pull request adds the `client_max_body_size` directive to the nginx configuration and sets it to `100mb`, allowing for larger file uploads.

@BeritJanssen did or do we have a file size limit configured already somewhere in Django?

Resolves #777