### PR TITLE
Fixed(Sentry): Fix conditional initialization of Sentry based on environment variable SENTRY_DSN

### DIFF
--- a/backend/aml/base_settings.py
+++ b/backend/aml/base_settings.py
@@ -11,8 +11,11 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+import logging
 from corsheaders.defaults import default_headers
 import sentry_sdk
+
+logger = logging.getLogger(__name__)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -165,16 +168,18 @@ LOCALE_PATHS = [os.path.join(BASE_DIR, 'locale')]
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
-# Sentry
-sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", ""),
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=0.2,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=0.2,
-)
+if os.getenv("SENTRY_DSN"):
+    sentry_sdk.init(
+        dsn=os.getenv("SENTRY_DSN", ""),
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=0.2,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=0.2,
+    )
+else:
+    logger.info("SENTRY_DSN is not defined. Skipping Sentry initialization.")
 
 SUBPATH = os.getenv('AML_SUBPATH', None)


### PR DESCRIPTION
This pull request fixes the conditional initialization of Sentry based on the environment variable SENTRY_DSN. Previously, Sentry was always initialized regardless of whether the SENTRY_DSN variable was defined. With this fix, Sentry will only be initialized if the SENTRY_DSN variable is defined.

Resolves #769