### PR TITLE
Refactored(command) Rename createexperiment command to createruleset

### DIFF
--- a/backend/experiment/management/commands/createruleset.py
+++ b/backend/experiment/management/commands/createruleset.py
@@ -8,54 +8,54 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # Ask for the experiment name
-        experiment_name = input("What is the name of your experiment? (ex. Musical Preferences): ")
+        ruleset_name = input("What is the name of your experiment ruleset? (ex. Musical Preferences): ")
 
         # Create the experiment rule class
-        success = self.create_experiment_rule_class(experiment_name)
+        success = self.create_experiment_rule_class(ruleset_name)
 
         if not success:
             return
 
         # Add the new experiment to ./experiment/rules/__init__.py
-        self.register_experiment_rule(experiment_name, './experiment/rules/__init__.py')
+        self.register_experiment_rule(ruleset_name, './experiment/rules/__init__.py')
 
         # Create a basic test file for the experiment
-        self.create_test_file(experiment_name)
+        self.create_test_file(ruleset_name)
 
-    def create_experiment_rule_class(self, experiment_name):
+    def create_experiment_rule_class(self, ruleset_name):
         # Get the experiment name in different cases
-        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+        ruleset_name_snake_case, ruleset_name_snake_case_upper, ruleset_name_pascal_case = self.get_ruleset_name_cases(ruleset_name)
 
-        # Create a new file for the experiment class
-        filename = f"./experiment/rules/{experiment_name_snake_case}.py"
+        # Create a new file for the experiment rules class
+        filename = f"./experiment/rules/{ruleset_name_snake_case}.py"
 
         # Check if the file already exists
         if os.path.isfile(filename):
-            self.stdout.write(self.style.ERROR(f"Experiment {experiment_name} already exists. Exiting without creating file(s)."))
+            self.stdout.write(self.style.ERROR(f"Experiment ruleset \"{ruleset_name}\" already exists. Exiting without creating file(s)."))
             return
 
         # Create the file by copying ./experiment/management/commands/templates/experiment.py
         with open(filename, 'w') as f:
             with open('./experiment/management/commands/templates/experiment.py', 'r') as template:
                 f.write(template.read()
-                    .replace('NewExperiment', experiment_name_pascal_case)
-                    .replace('new_experiment', experiment_name_snake_case)
-                    .replace('NEW_EXPERIMENT', experiment_name_snake_case_upper)
-                    .replace('New Experiment', experiment_name.title())
+                    .replace('NewExperimentRuleset', ruleset_name_pascal_case)
+                    .replace('new_experiment_ruleset', ruleset_name_snake_case)
+                    .replace('NEW_EXPERIMENT_RULESET', ruleset_name_snake_case_upper)
+                    .replace('New Experiment Ruleset', ruleset_name.title())
                 )
 
-        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
+        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment ruleset \"{ruleset_name}\""))
 
         return True
 
-    def register_experiment_rule(self, experiment_name, file_path):
+    def register_experiment_rule(self, ruleset_name, file_path):
 
         # Get the experiment name in different cases
-        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+        ruleset_name_snake_case, ruleset_name_snake_case_upper, ruleset_name_pascal_case = self.get_ruleset_name_cases(ruleset_name)
 
         # New lines to add
-        new_import = f"from .{experiment_name_snake_case} import {experiment_name_pascal_case}\n"
-        new_dict_entry = f"    {experiment_name_pascal_case}.ID: {experiment_name_pascal_case},\n"
+        new_import = f"from .{ruleset_name_snake_case} import {ruleset_name_pascal_case}\n"
+        new_dict_entry = f"    {ruleset_name_pascal_case}.ID: {ruleset_name_pascal_case},\n"
 
         with open(file_path, 'r') as file:
             lines = file.readlines()
@@ -74,14 +74,14 @@ class Command(BaseCommand):
         with open(file_path, 'w') as file:
             file.writelines(lines)
 
-        self.stdout.write(self.style.SUCCESS(f"Registered {experiment_name} in {file_path}"))
+        self.stdout.write(self.style.SUCCESS(f"Registered ruleset \"{ruleset_name}\" in {file_path}"))
 
-    def create_test_file(self, experiment_name):
+    def create_test_file(self, ruleset_name):
         # Get the experiment name in different cases
-        experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case = self.get_experiment_name_cases(experiment_name)
+        ruleset_name_snake_case, ruleset_name_snake_case_upper, ruleset_name_pascal_case = self.get_ruleset_name_cases(ruleset_name)
 
         # Create a new file for the experiment class
-        filename = f"./experiment/rules/tests/test_{experiment_name_snake_case}.py"
+        filename = f"./experiment/rules/tests/test_{ruleset_name_snake_case}.py"
 
         # Check if the file already exists
         if os.path.isfile(filename):
@@ -92,20 +92,20 @@ class Command(BaseCommand):
         with open(filename, 'w') as f:
             with open('./experiment/management/commands/templates/test_experiment.py', 'r') as template:
                 f.write(template.read()
-                    .replace('NewExperiment', experiment_name_pascal_case)
-                    .replace('new_experiment', experiment_name_snake_case)
-                    .replace('NEW_EXPERIMENT', experiment_name_snake_case_upper)
-                    .replace('New Experiment', experiment_name.title())
+                    .replace('NewExperimentRuleset', ruleset_name_pascal_case)
+                    .replace('new_experiment_ruleset', ruleset_name_snake_case)
+                    .replace('NEW_EXPERIMENT_RULESET', ruleset_name_snake_case_upper)
+                    .replace('New Experiment Ruleset', ruleset_name.title())
                 )
 
-        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {experiment_name}"))
+        self.stdout.write(self.style.SUCCESS(f"Created {filename} for experiment {ruleset_name}"))
 
-    def get_experiment_name_cases(self, experiment_name):
+    def get_ruleset_name_cases(self, ruleset_name):
         # Convert experiment name to snake_case and lowercase every word and replace spaces with underscores
-        experiment_name_snake_case = experiment_name.lower().replace(' ', '_')
-        experiment_name_snake_case_upper = experiment_name_snake_case.upper()
+        ruleset_name_snake_case = ruleset_name.lower().replace(' ', '_')
+        ruleset_name_snake_case_upper = ruleset_name_snake_case.upper()
 
         # Convert experiment name to PascalCase and capitalize every word and remove spaces
-        experiment_name_pascal_case = experiment_name.title().replace(' ', '')
+        ruleset_name_pascal_case = ruleset_name.title().replace(' ', '')
 
-        return experiment_name_snake_case, experiment_name_snake_case_upper, experiment_name_pascal_case
+        return ruleset_name_snake_case, ruleset_name_snake_case_upper, ruleset_name_pascal_case

--- a/backend/experiment/management/commands/templates/experiment.py
+++ b/backend/experiment/management/commands/templates/experiment.py
@@ -10,9 +10,9 @@ from experiment.rules.base import Base
 from result.utils import prepare_result
 
 
-class NewExperiment(Base):
+class NewExperimentRuleset(Base):
     ''' An experiment type that could be used to test musical preferences '''
-    ID = 'NEW_EXPERIMENT'
+    ID = 'NEW_EXPERIMENT_RULESET'
     contact_email = 'info@example.com'
 
     def __init__(self):
@@ -99,7 +99,6 @@ class NewExperiment(Base):
             title=_('Test experiment'),
             config={
                 'response_time': section.duration,
-                # listen_first: whether response buttons will be greyed out during `response_time`
                 'listen_first': True
             }
         )

--- a/backend/experiment/management/commands/templates/test_experiment.py
+++ b/backend/experiment/management/commands/templates/test_experiment.py
@@ -6,13 +6,13 @@ from section.models import Playlist
 from session.models import Session
 
 
-class NewExperimentTest(TestCase):
+class NewExperimentRulesetTest(TestCase):
 
     @classmethod
     def setUpTestData(self):
         self.participant = Participant.objects.create()
-        self.playlist = Playlist.objects.create(name='NewExperiment')
-        self.experiment = Experiment.objects.create(name='NewExperiment', rounds=5)
+        self.playlist = Playlist.objects.create(name='NewExperimentRuleset')
+        self.experiment = Experiment.objects.create(name='NewExperimentRuleset', rounds=5)
         self.session = Session.objects.create(
             experiment=self.experiment,
             participant=self.participant,
@@ -20,4 +20,4 @@ class NewExperimentTest(TestCase):
         )
 
     def test_initializes_correctly(self):
-        assert self.experiment.name == 'NewExperiment'
+        assert self.experiment.name == 'NewExperimentRuleset'


### PR DESCRIPTION
This PR is a follow up of #766 after we have decided to rename the `createexperiment` command to `createruleset` to better reflect its purpose. See also [this comment](https://github.com/Amsterdam-Music-Lab/MUSCLE/pull/766#issuecomment-1953974269)

The templates are renamed accordingly as well.