### PR TITLE
Config: Update port mapping in docker-compose file for podman

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -97,7 +97,7 @@ services:
       target: runner
     command: nginx -g 'daemon off;'
     ports:
-      - 3000:80
+      - 8080:80
     depends_on:
       - client-builder
       - server


### PR DESCRIPTION
This pull request updates the port mapping in the docker-compose file for podman. The entrypoint for the nginx container is changed to always be 8080, similar to the AML Blog setup.