### PR TITLE
Fixed: Refactor BaseAction class to handle missing style parameter

### DIFF
--- a/backend/experiment/actions/base_action.py
+++ b/backend/experiment/actions/base_action.py
@@ -3,14 +3,17 @@ from .frontend_style import FrontendStyle
 
 class BaseAction(object):
     ID = 'BASE'
+    style = None
 
-    def __init__(self, style = FrontendStyle()):
+    def __init__(self, style: FrontendStyle = None):
         self.style = style
         pass
 
     def action(self):
         action_dict = self.__dict__
         action_dict['view'] = self.ID
-        action_dict['style'] = self.style.to_dict()
+
+        if self.style is not None:
+            action_dict['style'] = self.style.to_dict()
 
         return action_dict


### PR DESCRIPTION
This pull request refactors the BaseAction class to handle the case when the style parameter is missing. Previously, the class assumed that the style parameter would always be provided, which could lead to errors if it was not. With this change, the class now checks if the style parameter is None and handles it accordingly.

Related to #696