### PR TITLE
Chore: Only generate code coverage badges on push to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       # Push coverage badge to separate branch (only for main and develop branches)
       - name: Push Backend Coverage Badge to separate branch
         continue-on-error: true
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/develop'
         run: |
           if git ls-remote --heads origin code-coverage-badges; then
             git fetch origin code-coverage-badges
@@ -69,7 +69,7 @@ jobs:
     name: Generate Frontend Coverage Badge
     needs: frontend-test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v3
       - name: Generate Frontend Coverage Report (XML) and Badge


### PR DESCRIPTION
This pull request updates the code to only generate code coverage badges when pushing to the develop branch. This change ensures that code coverage badges are not generated unnecessarily (on main branch) and reduces conflicting coverage percentages. The code coverage badges will now always reflect the `develop` branch.