### PR TITLE
CI: Add restart options to Docker services

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -21,10 +21,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: always
   ip2country:
     image: extrawurst/ip2country:latest
     ports:
       - 8854:5000
+    restart: always
+
   server:
     build:
       context: ./backend
@@ -57,6 +60,8 @@ services:
     ports:
       - 8000:8000
     command: bash -c "python manage.py migrate && python manage.py bootstrap && python manage.py collectstatic --noinput && gunicorn aml.wsgi:application --bind 0.0.0.0:8000"
+    restart: always
+
   client-builder:
     build:
       context: ./frontend
@@ -86,8 +91,9 @@ services:
       - REACT_APP_HTML_BODY_CLASS=${REACT_APP_HTML_BODY_CLASS}
       - REACT_APP_SENTRY_DSN=${REACT_APP_SENTRY_DSN}
       - REACT_APP_STRICT=${REACT_APP_STRICT}
+    restart: "no"
 
-  # This service is responsible for serving 
+  # This service is responsible for serving
   # 1. The built frontend from the client-builder service
   # 2. The static files from the server service (e.g., static files & uploads from the Django app)
   nginx-proxy:
@@ -105,4 +111,4 @@ services:
       - /home/github-runner/podman-volumes/server-static:/usr/share/nginx/html/django_static
       - /home/github-runner/podman-volumes/server-uploads:/usr/share/nginx/html/upload
       - ./nginx/custom-nginx.conf:/etc/nginx/conf.d/default.conf
-      
+    restart: always


### PR DESCRIPTION
This pull request adds the `restart` option to the Docker services in the `docker-compose.yml` file. The `restart` option ensures that the services automatically restart if they fail or if the Docker daemon restarts. This improves the reliability and availability of the application as the new test & acc environment's containers are currently down after a github runner update.