### PR TITLE
Fixed: Refactor import statement in test_experiment.py

### DIFF
--- a/backend/experiment/management/commands/templates/test_experiment.py
+++ b/backend/experiment/management/commands/templates/test_experiment.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from django.test import TestCase
 
 from experiment.models import Experiment
 from participant.models import Participant


### PR DESCRIPTION
This pull request refactors the import statement in the test_experiment.py file (aka the **ruleset unit test template**) from `from unittest import TestCase` to `from django.test import TestCase`. This change ensures that the correct TestCase class is imported and used for testing the Experiment model, and the `setupTestData` test method will be called automatically, just like in all other Django unit tests.

See also this similar problem: https://stackoverflow.com/questions/70835853/django-setuptestdata-doesnt-run