### PR TITLE
Fixed(CI): Fix podman workflow on PRs

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Prevent the podman workflow from always running (and thereby _deploying_ to ACC) on pull requests, which was still the case up to now.