### PR TITLE
CI: Update Podman workflow to include Sentry release action

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -64,14 +64,14 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      - uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: uva-aml
-        with:
-          environment: test
-          projects: muscle-frontend, muscle-backend
-          sourcemaps: './frontend/build/static/js'
+      # - uses: getsentry/action-release@v1
+      #   env:
+      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      #     SENTRY_ORG: uva-aml
+      #   with:
+      #     environment: test
+      #     projects: muscle-frontend, muscle-backend
+      #     sourcemaps: './frontend/build/static/js'
       - name: Notify Sentry of new release
         run: |
           curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -61,17 +61,18 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
       - name: Notify Sentry of new release
         run: |
-          curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
-          -H "Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -d '{
-            "version": "${{ github.sha }}",
-            "refs": [{
-              "repository": "Amsterdam-Music-Lab/MUSCLE",
-              "commit": "${{ github.sha }}"
-            }],
-            "projects": ["muscle-frontend", "muscle-backend"]
-          }'
+            curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
+            -H "Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+                "version": "${{ github.sha }}",
+                "refs": [{
+                    "repository": "Amsterdam-Music-Lab/MUSCLE",
+                    "commit": "${{ github.sha }}"
+                }],
+                "projects": ["muscle-frontend", "muscle-backend"],
+                "environment": "test"
+            }'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images
@@ -142,7 +143,8 @@ jobs:
               "repository": "Amsterdam-Music-Lab/MUSCLE",
               "commit": "${{ github.sha }}"
             }],
-            "projects": ["muscle-frontend", "muscle-backend"]
+            "projects": ["muscle-frontend", "muscle-backend"],
+            "environment": "acceptance"
           }'
       - name: Prune old images
         run: podman image prune -a -f

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -80,7 +80,7 @@ jobs:
           -d '{
             "version": "${{ github.sha }}",
             "refs": [{
-              "repository": "uva-aml/muscle-frontend",
+              "repository": "Amsterdam-Music-Lab/MUSCLE",
               "commit": "${{ github.sha }}"
             }],
             "projects": ["muscle-frontend", "muscle-backend"]

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -16,7 +16,7 @@ jobs:
     name: Deploy to test environment
     environment: Test
     runs-on: tst
-    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop' || 1 == 1 # Temporarily always run during testing
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:
@@ -64,6 +64,14 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: uva-aml
+        with:
+          environment: test
+          projects: muscle-frontend, muscle-backend
+          sourcemaps: './frontend/build/static/js'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images
@@ -123,6 +131,16 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_URL: https://sentry.io/
+        with:
+          environment: acceptance
+          version: ${{ github.sha }}
+          projects: muscle-frontend, muscle-backend
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -46,9 +46,6 @@ jobs:
       DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
       DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
 
-      # Sentry Auth Token
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
       # Prevent podman services from exiting after startup
       RUNNER_TRACKING_ID: ""
 
@@ -67,27 +64,14 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      # - uses: getsentry/action-release@v1
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #     SENTRY_ORG: uva-aml
-      #   with:
-      #     environment: test
-      #     projects: muscle-frontend, muscle-backend
-      #     sourcemaps: './frontend/build/static/js'
-      - name: Notify Sentry of new release
-        run: |
-          # Install Sentry CLI
-          curl -sL https://sentry.io/get-cli/ | bash
-
-          # Create new Sentry release
-          export SENTRY_RELEASE=$(sentry-cli releases propose-version)
-          sentry-cli releases new -p aml-uva $SENTRY_RELEASE
-          sentry-cli releases set-commits --auto $SENTRY_RELEASE
-          sentry-cli releases finalize $SENTRY_RELEASE
-
-          # Create new deploy for this Sentry release
-          sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_DEPLOY_ENVIRONMENT
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: uva-aml
+        with:
+          environment: test
+          projects: muscle-frontend, muscle-backend
+          sourcemaps: './frontend/build/static/js'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images
@@ -150,13 +134,11 @@ jobs:
       - uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_URL: https://sentry.io/
+          SENTRY_ORG: uva-aml
         with:
           environment: acceptance
-          version: ${{ github.sha }}
           projects: muscle-frontend, muscle-backend
+          sourcemaps: './frontend/build/static/js'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -64,14 +64,14 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      # - uses: getsentry/action-release@v1
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #     SENTRY_ORG: uva-aml
-      #   with:
-      #     environment: test
-      #     projects: muscle-frontend, muscle-backend
-      #     sourcemaps: './frontend/build/static/js'
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: uva-aml
+        with:
+          environment: test
+          projects: muscle-frontend, muscle-backend
+          sourcemaps: './frontend/build/static/js'
       - name: Notify Sentry of new release
         run: |
           curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
@@ -81,7 +81,7 @@ jobs:
             "version": "${{ github.sha }}",
             "refs": [{
               "repository": "uva-aml/muscle-frontend",
-              "commit": ${{ github.sha }}
+              "commit": "${{ github.sha }}"
             }],
             "projects": ["muscle-frontend", "muscle-backend"]
           }'

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -46,6 +46,9 @@ jobs:
       DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
       DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
 
+      # Sentry Auth Token
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
       # Prevent podman services from exiting after startup
       RUNNER_TRACKING_ID: ""
 
@@ -64,14 +67,27 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      - uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: uva-aml
-        with:
-          environment: test
-          projects: muscle-frontend, muscle-backend
-          sourcemaps: './frontend/build/static/js'
+      # - uses: getsentry/action-release@v1
+      #   env:
+      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      #     SENTRY_ORG: uva-aml
+      #   with:
+      #     environment: test
+      #     projects: muscle-frontend, muscle-backend
+      #     sourcemaps: './frontend/build/static/js'
+      - name: Notify Sentry of new release
+        run: |
+          # Install Sentry CLI
+          curl -sL https://sentry.io/get-cli/ | bash
+
+          # Create new Sentry release
+          export SENTRY_RELEASE=$(sentry-cli releases propose-version)
+          sentry-cli releases new -p aml-uva $SENTRY_RELEASE
+          sentry-cli releases set-commits --auto $SENTRY_RELEASE
+          sentry-cli releases finalize $SENTRY_RELEASE
+
+          # Create new deploy for this Sentry release
+          sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_DEPLOY_ENVIRONMENT
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -64,14 +64,27 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      - uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: uva-aml
-        with:
-          environment: test
-          projects: muscle-frontend, muscle-backend
-          sourcemaps: './frontend/build/static/js'
+      # - uses: getsentry/action-release@v1
+      #   env:
+      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      #     SENTRY_ORG: uva-aml
+      #   with:
+      #     environment: test
+      #     projects: muscle-frontend, muscle-backend
+      #     sourcemaps: './frontend/build/static/js'
+      - name: Notify Sentry of new release
+        run: |
+          curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
+          -H "Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "version": "${{ github.sha }}",
+            "refs": [{
+              "repository": "uva-aml/muscle-frontend",
+              "commit": ${{ github.sha }}
+            }],
+            "projects": ["muscle-frontend", "muscle-backend"]
+          }'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images
@@ -131,14 +144,14 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      - uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: uva-aml
-        with:
-          environment: acceptance
-          projects: muscle-frontend, muscle-backend
-          sourcemaps: './frontend/build/static/js'
+      # - uses: getsentry/action-release@v1
+      #   env:
+      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      #     SENTRY_ORG: uva-aml
+      #   with:
+      #     environment: acceptance
+      #     projects: muscle-frontend, muscle-backend
+      #     sourcemaps: './frontend/build/static/js'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -16,7 +16,7 @@ jobs:
     name: Deploy to test environment
     environment: Test
     runs-on: tst
-    if: github.ref == 'refs/heads/develop' || 1 == 1 # Temporarily always run during testing
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/develop' || 1 == 1 # Temporarily always run during testing
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:
@@ -83,7 +83,7 @@ jobs:
     name: Deploy to acceptance environment
     environment: Acceptance
     runs-on: ACC
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/*' || 1 == 1 # Temporarily always run during testing
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/*'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -6,17 +6,12 @@ on:
       - develop
   workflow_dispatch:
 
-  # temporarily also for PRs
-  pull_request:
-      branches:
-      - develop
-
 jobs:
   deploy-test:
     name: Deploy to test environment
     environment: Test
     runs-on: tst
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/develop' || 1 == 1 # Temporarily always run during testing
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/develop'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:
@@ -64,14 +59,6 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      # - uses: getsentry/action-release@v1
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #     SENTRY_ORG: uva-aml
-      #   with:
-      #     environment: test
-      #     projects: muscle-frontend, muscle-backend
-      #     sourcemaps: './frontend/build/static/js'
       - name: Notify Sentry of new release
         run: |
           curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
@@ -144,14 +131,19 @@ jobs:
         run: podman-compose -f docker-compose-deploy.yml build
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
-      # - uses: getsentry/action-release@v1
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #     SENTRY_ORG: uva-aml
-      #   with:
-      #     environment: acceptance
-      #     projects: muscle-frontend, muscle-backend
-      #     sourcemaps: './frontend/build/static/js'
+      - name: Notify Sentry of new release
+        run: |
+          curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
+          -H "Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "version": "${{ github.sha }}",
+            "refs": [{
+              "repository": "Amsterdam-Music-Lab/MUSCLE",
+              "commit": "${{ github.sha }}"
+            }],
+            "projects": ["muscle-frontend", "muscle-backend"]
+          }'
       - name: Prune old images
         run: podman image prune -a -f
       - name: Check Podman images


### PR DESCRIPTION
This pull request updates the Podman workflow to include the Sentry release action. It let's Sentry know of the release and the version and also uploads sourcemaps. This will improve the monitoring and error tracking capabilities of the application.

Resolves #755 