### PR TITLE
Hotfix: Fix experiment URL participant_id query parameter handling

### DIFF
--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -24,8 +24,8 @@ const App = () => {
     const queryParams = window.location.search;
     
     useEffect(() => {
-        if (queryParams && !(new URLSearchParams(queryParams).has("participant_id"))) {
-            setError("Unknown URL parameter, use ?participant_id=");
+        const urlParams = new URLSearchParams(queryParams);
+        if (!urlParams.has("participant_id")) {
             return;
         }
         try {
@@ -34,7 +34,7 @@ const App = () => {
             });
         } catch (err) {
             console.error(err);
-            setError(err);
+            setError('Could not load participant');
         }
     }, [setError, queryParams, setParticipant])
 


### PR DESCRIPTION
This pull request fixes the handling of the participant_id query parameter in the experiment URL. Previously, only the participant_id parameter was allowed, but now other query parameters are also allowed.

Resolves #838 