### PR TITLE
Hotfix: Fix passing participantId only when it exists

### DIFF
--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -25,8 +25,10 @@ const App = () => {
     
     useEffect(() => {
         const urlParams = new URLSearchParams(queryParams);
-        if (!urlParams.has("participant_id")) {
-            return;
+        const participantId = urlParams.get('participant_id');
+        let queryParams = '';
+        if (participantId) {
+            queryParams = `?participant_id=${participantId}`;
         }
         try {
             axios.get(API_BASE_URL + API_URLS.participant.current + queryParams).then(response => {


### PR DESCRIPTION
This pull request fixes the issue where the participantId was being passed even when it didn't exist. Now, the participantId is only passed as a query parameter if it exists in the URL.