### PR TITLE
fix: move apt-get update to same layer as library installs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,6 @@
 FROM docker.io/python:3.8
 ENV PYTHONUNBUFFERED 1
-RUN apt-get -y update
-RUN apt-get install -y ffmpeg
-RUN apt-get install -y gettext
+RUN apt-get -y update && apt-get install -y ffmpeg gettext
 
 WORKDIR /server
 COPY requirements/prod.txt /server/

--- a/backend/DockerfileDevelop
+++ b/backend/DockerfileDevelop
@@ -1,7 +1,6 @@
 FROM docker.io/python:3.8 as base
 ENV PYTHONUNBUFFERED 1
-RUN apt-get -y update
-RUN apt-get install -y ffmpeg gettext
+RUN apt-get -y update && apt-get install -y ffmpeg gettext
 
 WORKDIR /server
 COPY requirements/dev.txt /server/


### PR DESCRIPTION
We just noticed that it may be problematic if the `apt-get update` call is cached separately from the library installs, as the install might try to pull an outdated version. This PR should fix that.