### PR TITLE
fix: select all sections which don't have tag 'Original'

### DIFF
--- a/backend/experiment/rules/matching_pairs_lite.py
+++ b/backend/experiment/rules/matching_pairs_lite.py
@@ -49,7 +49,7 @@ class MatchingPairsLite(MatchingPairsGame):
         originals = session.playlist.section_set.filter(
             group__in=selected_pairs, tag='Original')
         degradations = session.playlist.section_set.filter(
-            group__in=selected_pairs, tag='Degradation')
+            group__in=selected_pairs).exclude(tag='Original')
         if degradations:
             player_sections = list(originals) + list(degradations)
         else:


### PR DESCRIPTION
Fix problem with section selection in `matching_pairs_lite`.