### PR TITLE
Fixed: Remove incorrect import

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -153,7 +153,7 @@ class ModelFormFieldAsJSON(ModelMultipleChoiceField):
 class ExperimentSeriesForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(ModelForm, self).__init__(*args, **kwargs)
-        from . import Experiment
+        
         experiments = Experiment.objects.all().filter(experiment_series=None)
         self.fields['first_experiments'] = ModelFormFieldAsJSON(queryset=experiments, required=False)
         self.fields['random_experiments'] = ModelFormFieldAsJSON(queryset=experiments, required=False)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aml-experiments",
-    "version": "1.9.0",
+    "version": "1.9.3",
     "private": false,
     "description": "The MUSCLE platform is an application that provides an easy way to implement and run online listening experiments for music research.",
     "license": "MIT",


### PR DESCRIPTION
This import would cause the admin dashboard to throw an error, thereby making it impossible to update experiment series.