### PR TITLE
Added: Add useDisableRightClickOnTouchDevices hook

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,6 +80,7 @@
     "@storybook/react-vite": "^7.6.17",
     "@storybook/testing-library": "0.2.2",
     "@testing-library/react": "^14.1.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.5.1",
     "@vitest/coverage-v8": "^1.2.1",
     "axios-mock-adapter": "^1.22.0",

--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -15,6 +15,7 @@ import ExperimentCollection from "../ExperimentCollection/ExperimentCollection";
 import Profile from "../Profile/Profile";
 import Reload from "../Reload/Reload";
 import StoreProfile from "../StoreProfile/StoreProfile.js";
+import useDisableRightClickOnTouchDevices from "../../hooks/useDisableRightClickOnTouchDevices.js";
 
 
 // App is the root component of our application
@@ -23,6 +24,8 @@ const App = () => {
     const setError = useBoundStore(state => state.setError);
     const setParticipant = useBoundStore((state) => state.setParticipant);
     const queryParams = window.location.search;
+    
+    useDisableRightClickOnTouchDevices();
     
     useEffect(() => {
         const urlParams = new URLSearchParams(queryParams);

--- a/frontend/src/hooks/useDisableRightClickOnTouchDevices.js
+++ b/frontend/src/hooks/useDisableRightClickOnTouchDevices.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const useDisableRightClickOnTouchDevices = () => useEffect(() => {
+  const isTouchDevice = () => !!('ontouchstart' in window || !!(navigator.maxTouchPoints));
+
+  const handleContextMenu = (event) => {
+    if (isTouchDevice()) {
+      event.preventDefault();
+    }
+  };
+
+  document.addEventListener('contextmenu', handleContextMenu);
+
+  return () => {
+    document.removeEventListener('contextmenu', handleContextMenu);
+  };
+}, []);
+
+
+export default useDisableRightClickOnTouchDevices;

--- a/frontend/src/hooks/useDisableRightClickOnTouchDevices.test.js
+++ b/frontend/src/hooks/useDisableRightClickOnTouchDevices.test.js
@@ -1,0 +1,38 @@
+import { vi } from "vitest";
+import { renderHook } from "@testing-library/react-hooks";
+import { waitFor } from "@testing-library/react";
+import useDisableRightClickOnTouchDevices from "./useDisableRightClickOnTouchDevices";
+
+describe("useDisableRightClickOnTouchDevices", () => {
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("should prevent context menu on touch devices", async () => {
+    vi.stubGlobal("ontouchstart", true);
+
+    const mockEvent = new MouseEvent('contextmenu');
+    mockEvent.preventDefault = vi.fn();
+
+    const spy = vi.spyOn(mockEvent, 'preventDefault').mockImplementation(() => { });
+
+    renderHook(() => useDisableRightClickOnTouchDevices());
+
+    await waitFor(() => document.dispatchEvent(mockEvent));
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+  });
+
+  test("should not prevent context menu on non-touch devices", () => {
+    const mockEvent = new MouseEvent('contextmenu');
+    mockEvent.preventDefault = vi.fn();
+
+    const spy = vi.spyOn(mockEvent, 'preventDefault').mockImplementation(() => { console.log("Drikus!") });
+
+    renderHook(() => useDisableRightClickOnTouchDevices());
+
+    document.dispatchEvent(mockEvent);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5581,6 +5581,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react-hooks@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@testing-library/react-hooks@npm:8.0.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    react-error-boundary: "npm:^3.1.0"
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+    react-test-renderer: ^16.9.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-dom:
+      optional: true
+    react-test-renderer:
+      optional: true
+  checksum: 83bef2d4c437b84143213b5275ef00ef14e5bcd344f9ded12b162d253dc3c799138ead4428026b9c725e5a38dbebf611f2898aa43f3e43432bcaccbd7bf413e5
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:^14.1.2":
   version: 14.1.2
   resolution: "@testing-library/react@npm:14.1.2"
@@ -6562,6 +6584,7 @@ __metadata:
     "@storybook/react-vite": "npm:^7.6.17"
     "@storybook/testing-library": "npm:0.2.2"
     "@testing-library/react": "npm:^14.1.2"
+    "@testing-library/react-hooks": "npm:^8.0.1"
     "@testing-library/user-event": "npm:^14.5.1"
     "@types/react-router-dom": "npm:^5.3.3"
     "@vitejs/plugin-react": "npm:^4.2.1"
@@ -12254,6 +12277,17 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: f977ca61823e43de2381d53dd7aa8b4d79ff6a984c9afdc88dc44f9973b99de7fd382d2f0f91f2688e24bb987c0185bf45d0b004f22afaaab0f990a830253bfb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request adds the `@testing-library/react-hooks` dependency and includes a new hook called `useDisableRightClickOnTouchDevices`. The hook prevents the context menu from appearing on touch devices.

Resolves #857