### PR TITLE
Fixed: Fix experiment name link in admin dashboard

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -12,6 +12,8 @@ from django.shortcuts import render, redirect
 from django.forms import CheckboxSelectMultiple, ModelForm, ModelMultipleChoiceField
 from django.http import HttpResponse
 from inline_actions.admin import InlineActionsModelAdminMixin
+from django.urls import reverse
+from django.utils.html import format_html
 from experiment.models import Experiment, ExperimentSeries, Feedback
 from experiment.forms import ExperimentForm, ExportForm, TemplateForm, EXPORT_TEMPLATES
 from section.models import Section, Song
@@ -29,7 +31,7 @@ class FeedbackInline(admin.TabularInline):
 
 
 class ExperimentAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
-    list_display = ('image_preview', 'name', 'rules', 'rounds', 'playlist_count',
+    list_display = ('image_preview', 'experiment_link', 'rules', 'rounds', 'playlist_count',
                     'session_count', 'active')
     list_filter = ['active']
     search_fields = ['name']
@@ -146,6 +148,12 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
             img_src = obj.image.file.url
             return mark_safe(f'<img src="{img_src}" style="max-height: 50px;"/>')
         return ""
+    
+    def experiment_link(self, obj):
+        """Generate a link to the experiment's admin change page."""
+        url = reverse("admin:experiment_experiment_change", args=[obj.pk])
+        name = obj.name or obj.slug or "No name"
+        return format_html('<a href="{}">{}</a>', url, name)
 
 
 admin.site.register(Experiment, ExperimentAdmin)

--- a/backend/image/tests/test_admin.py
+++ b/backend/image/tests/test_admin.py
@@ -45,3 +45,12 @@ class ImageAdminTest(TestCase):
     def test_readonly_fields(self):
         expected_readonly_fields = ['created_at', 'updated_at']
         self.assertEqual(self.admin.readonly_fields, expected_readonly_fields)
+
+    def test_experiment_link(self):
+        experiment = Experiment.objects.create(name="Test Experiment")
+        request = self.factory.get('/')
+        link = self.admin.experiment_link(experiment)
+        expected_url = reverse("admin:experiment_experiment_change", args=[experiment.pk])
+        expected_name = "Test Experiment"
+        expected_link = format_html('<a href="{}">{}</a>', expected_url, expected_name)
+        self.assertEqual(link, expected_link)


### PR DESCRIPTION
This pull request fixes the issue where the experiment name was not clickable in the admin dashboard. It adds a new method `experiment_link` to generate a link to the experiment's admin change page and updates the `ExperimentAdmin` class to display the experiment name as a clickable link.