### PR TITLE
fix: use random seed before shuffle

### DIFF
--- a/backend/experiment/rules/matching_pairs.py
+++ b/backend/experiment/rules/matching_pairs.py
@@ -19,7 +19,7 @@ class MatchingPairsGame(Base):
     show_animation = True
     score_feedback_display = 'large-top'
     contact_email = 'aml.tunetwins@gmail.com'
-    randomize = True
+    random_seed = None
 
     def __init__(self):
         self.questions = [
@@ -94,16 +94,16 @@ class MatchingPairsGame(Base):
         pairs = json_data.get('pairs', [])
         if len(pairs) < self.num_pairs:
             pairs = list(session.playlist.section_set.order_by().distinct('group').values_list('group', flat=True))
-            if self.randomize:
-                random.shuffle(pairs)
+            random.seed(self.random_seed)
+            random.shuffle(pairs)
         selected_pairs = pairs[:self.num_pairs]
         session.save_json_data({'pairs': pairs[self.num_pairs:]})
         originals = session.playlist.section_set.filter(group__in=selected_pairs, tag='Original')  
         degradations = json_data.get('degradations')
         if not degradations:
             degradations = ['Original', '1stDegradation', '2ndDegradation']
-            if self.randomize:
-                random.shuffle(degradations)
+            random.seed(self.random_seed)
+            random.shuffle(degradations)
         degradation_type = degradations.pop()
         session.save_json_data({'degradations': degradations})
         if degradation_type == 'Original':
@@ -115,8 +115,8 @@ class MatchingPairsGame(Base):
 
     def get_matching_pairs_trial(self, session):
         player_sections = self.select_sections(session)
-        if self.randomize:
-            random.shuffle(player_sections)
+        random.seed(self.random_seed)
+        random.shuffle(player_sections)
 
         playback = MatchingPairs(
             sections=player_sections,

--- a/backend/experiment/rules/matching_pairs_fixed.py
+++ b/backend/experiment/rules/matching_pairs_fixed.py
@@ -7,4 +7,4 @@ from .matching_pairs_lite import MatchingPairsLite
 
 class MatchingPairsFixed(MatchingPairsLite):
     ID = 'MATCHING_PAIRS_FIXED'
-    randomize = False
+    random_seed = 'fixed'

--- a/backend/experiment/rules/matching_pairs_lite.py
+++ b/backend/experiment/rules/matching_pairs_lite.py
@@ -13,7 +13,6 @@ class MatchingPairsLite(MatchingPairsGame):
     show_animation = False
     score_feedback_display = 'small-bottom-right'
     contact_email = 'aml.tunetwins@gmail.com'
-    randomize = True
 
     def first_round(self, experiment):     
         # 2. Choose playlist.
@@ -35,8 +34,8 @@ class MatchingPairsLite(MatchingPairsGame):
     def select_sections(self, session):
         pairs = list(session.playlist.section_set.order_by().distinct(
             'group').values_list('group', flat=True))
-        if self.randomize:
-            random.shuffle(pairs)
+        random.seed(self.random_seed)
+        random.shuffle(pairs)
         selected_pairs = pairs[:self.num_pairs]
         originals = session.playlist.section_set.filter(
             group__in=selected_pairs, tag='Original')


### PR DESCRIPTION
Address problem for Congo-MatchingPairs that the board used for the practice sessions should be fixed, but not too predictable.