### PR TITLE
Fixed: Fix deterministic randomisation

### DIFF
--- a/backend/experiment/rules/matching_pairs_lite.py
+++ b/backend/experiment/rules/matching_pairs_lite.py
@@ -23,7 +23,7 @@ class MatchingPairsLite(MatchingPairsGame):
         return [
             playlist, info
         ]
-    
+
     def next_round(self, session):
         if session.rounds_passed() < 1:
             trial = self.get_matching_pairs_trial(session)
@@ -34,14 +34,20 @@ class MatchingPairsLite(MatchingPairsGame):
     def select_sections(self, session):
         pairs = list(session.playlist.section_set.order_by().distinct(
             'group').values_list('group', flat=True))
-        random.seed(self.random_seed)
-        random.shuffle(pairs)
         selected_pairs = pairs[:self.num_pairs]
         originals = session.playlist.section_set.filter(
-            group__in=selected_pairs, tag='Original')
+            group__in=selected_pairs, tag='Original'
+        )
         degradations = session.playlist.section_set.exclude(tag='Original').filter(
-            group__in=selected_pairs)
+            group__in=selected_pairs
+        )
         if degradations:
-            return list(originals) + list(degradations)
+            sections = list(originals) + list(degradations)
+            random.seed(self.random_seed)
+            random.shuffle(sections)
+            return sections
         else:
-            return list(originals) + list(originals)
+            sections = list(originals) * 2
+            random.seed(self.random_seed)
+            random.shuffle(sections)
+            return sections

--- a/backend/experiment/rules/test_matching_pairs_fixed.py
+++ b/backend/experiment/rules/test_matching_pairs_fixed.py
@@ -1,0 +1,172 @@
+from django.test import TestCase
+
+from experiment.models import Experiment
+from participant.models import Participant
+from section.models import Playlist, Section
+from session.models import Session
+from experiment.rules.matching_pairs_fixed import MatchingPairsFixed
+
+
+class MatchingPairsFixedTest(TestCase):
+    @classmethod
+    def setUpTestData(self):
+        self.experiment = Experiment.objects.create(
+            name='Test Experiment',
+            slug='test-experiment',
+            rules='matching_pairs_lite'
+        )
+        self.playlist = Playlist.objects.create(
+            name='Test Playlist'
+        )
+
+    def test_select_sections_original_degraded(self):
+
+        self.section1 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Original'
+        )
+        self.section2 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Degradation'
+        )
+        self.section3 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Original'
+        )
+        self.section4 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Degradation'
+        )
+        self.section5 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Original'
+        )
+        self.section6 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Degradation'
+        )
+        self.section7 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Original'
+        )
+        self.section8 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Degradation'
+        )
+        self.participant = Participant.objects.create(
+            unique_hash='testhash'
+        )
+        self.session = Session.objects.create(
+            experiment=self.experiment,
+            participant=self.participant,
+            playlist=self.playlist,
+        )
+
+        rule = MatchingPairsFixed()
+        sections = rule.select_sections(self.session)
+        deterministic_order = [6, 5, 1, 4, 7, 8, 2, 3]
+
+        self.assertEqual(len(sections), 8)
+        self.assertIn(self.section1, sections)
+        self.assertIn(self.section2, sections)
+        self.assertIn(self.section3, sections)
+        self.assertIn(self.section4, sections)
+        self.assertIn(self.section5, sections)
+        self.assertIn(self.section6, sections)
+        self.assertIn(self.section7, sections)
+        self.assertIn(self.section8, sections)
+        self.assertEqual(sections.count(self.section1), 1)
+        self.assertEqual(sections.count(self.section2), 1)
+        self.assertEqual(sections.count(self.section3), 1)
+        self.assertEqual(sections.count(self.section4), 1)
+        self.assertEqual(sections.count(self.section5), 1)
+        self.assertEqual(sections.count(self.section6), 1)
+        self.assertEqual(sections.count(self.section7), 1)
+        self.assertEqual(sections.count(self.section8), 1)
+
+        for i in range(8):
+            self.assertEqual(sections[i].pk, deterministic_order[i])
+
+    def test_select_sections_original_original(self):
+
+        self.section1 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Original'
+        )
+        self.section2 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Original'
+        )
+        self.section3 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Original'
+        )
+        self.section4 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Original'
+        )
+        self.section5 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Original'
+        )
+        self.section6 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 1',
+            tag='Original'
+        )
+        self.section7 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Original'
+        )
+        self.section8 = Section.objects.create(
+            playlist=self.playlist,
+            group='Group 2',
+            tag='Original'
+        )
+        self.participant = Participant.objects.create(
+            unique_hash='testhash'
+        )
+        self.session = Session.objects.create(
+            experiment=self.experiment,
+            participant=self.participant,
+            playlist=self.playlist,
+        )
+
+        rule = MatchingPairsFixed()
+        sections = rule.select_sections(self.session)
+        deterministic_order = [9, 10, 13, 12, 14, 13, 15, 11, 10, 14, 16, 15, 16, 11, 9, 12]
+
+        self.assertEqual(len(sections), 16)
+        self.assertIn(self.section1, sections)
+        self.assertIn(self.section2, sections)
+        self.assertIn(self.section3, sections)
+        self.assertIn(self.section4, sections)
+        self.assertIn(self.section5, sections)
+        self.assertIn(self.section6, sections)
+        self.assertIn(self.section7, sections)
+        self.assertIn(self.section8, sections)
+        self.assertEqual(sections.count(self.section1), 2)
+        self.assertEqual(sections.count(self.section2), 2)
+        self.assertEqual(sections.count(self.section3), 2)
+        self.assertEqual(sections.count(self.section4), 2)
+        self.assertEqual(sections.count(self.section5), 2)
+        self.assertEqual(sections.count(self.section6), 2)
+        self.assertEqual(sections.count(self.section7), 2)
+        self.assertEqual(sections.count(self.section8), 2)
+
+        for i in range(8):
+            self.assertEqual(sections[i].pk, deterministic_order[i])

--- a/backend/experiment/rules/test_matching_pairs_fixed.py
+++ b/backend/experiment/rules/test_matching_pairs_fixed.py
@@ -11,53 +11,61 @@ class MatchingPairsFixedTest(TestCase):
     @classmethod
     def setUpTestData(self):
         self.experiment = Experiment.objects.create(
-            name='Test Experiment',
-            slug='test-experiment',
+            name='Test Experiment Matching Pairs Fixed',
+            slug='test-experiment-matching-pairs-fixed',
             rules='matching_pairs_lite'
         )
         self.playlist = Playlist.objects.create(
-            name='Test Playlist'
+            name='Test Playlist for select_sections',
         )
 
     def test_select_sections_original_degraded(self):
 
         self.section1 = Section.objects.create(
             playlist=self.playlist,
+            code='1',
             group='Group 1',
             tag='Original'
         )
         self.section2 = Section.objects.create(
             playlist=self.playlist,
+            code='2',
             group='Group 1',
             tag='Degradation'
         )
         self.section3 = Section.objects.create(
             playlist=self.playlist,
+            code='3',
             group='Group 2',
             tag='Original'
         )
         self.section4 = Section.objects.create(
             playlist=self.playlist,
+            code='4',
             group='Group 2',
             tag='Degradation'
         )
         self.section5 = Section.objects.create(
             playlist=self.playlist,
+            code='5',
             group='Group 1',
             tag='Original'
         )
         self.section6 = Section.objects.create(
             playlist=self.playlist,
+            code='6',
             group='Group 1',
             tag='Degradation'
         )
         self.section7 = Section.objects.create(
             playlist=self.playlist,
+            code='7',
             group='Group 2',
             tag='Original'
         )
         self.section8 = Section.objects.create(
             playlist=self.playlist,
+            code='8',
             group='Group 2',
             tag='Degradation'
         )
@@ -92,48 +100,57 @@ class MatchingPairsFixedTest(TestCase):
         self.assertEqual(sections.count(self.section7), 1)
         self.assertEqual(sections.count(self.section8), 1)
 
-        for i in range(8):
-            self.assertEqual(sections[i].pk, deterministic_order[i])
+        for (index, section) in enumerate(sections):
+            code = section.code
+            self.assertEqual(code, deterministic_order[index])
 
     def test_select_sections_original_original(self):
 
         self.section1 = Section.objects.create(
             playlist=self.playlist,
+            code='1',
             group='Group 1',
             tag='Original'
         )
         self.section2 = Section.objects.create(
             playlist=self.playlist,
+            code='2',
             group='Group 1',
             tag='Original'
         )
         self.section3 = Section.objects.create(
             playlist=self.playlist,
+            code='3',
             group='Group 2',
             tag='Original'
         )
         self.section4 = Section.objects.create(
             playlist=self.playlist,
+            code='4',
             group='Group 2',
             tag='Original'
         )
         self.section5 = Section.objects.create(
             playlist=self.playlist,
+            code='5',
             group='Group 1',
             tag='Original'
         )
         self.section6 = Section.objects.create(
             playlist=self.playlist,
+            code='6',
             group='Group 1',
             tag='Original'
         )
         self.section7 = Section.objects.create(
             playlist=self.playlist,
+            code='7',
             group='Group 2',
             tag='Original'
         )
         self.section8 = Section.objects.create(
             playlist=self.playlist,
+            code='8',
             group='Group 2',
             tag='Original'
         )
@@ -148,7 +165,7 @@ class MatchingPairsFixedTest(TestCase):
 
         rule = MatchingPairsFixed()
         sections = rule.select_sections(self.session)
-        deterministic_order = [9, 10, 13, 12, 14, 13, 15, 11, 10, 14, 16, 15, 16, 11, 9, 12]
+        deterministic_order = [1, 2, 5, 4, 6, 5, 7, 3, 2, 6, 8, 7, 8, 3, 1, 4]
 
         self.assertEqual(len(sections), 16)
         self.assertIn(self.section1, sections)
@@ -168,5 +185,6 @@ class MatchingPairsFixedTest(TestCase):
         self.assertEqual(sections.count(self.section7), 2)
         self.assertEqual(sections.count(self.section8), 2)
 
-        for i in range(8):
-            self.assertEqual(sections[i].pk, deterministic_order[i])
+        for (index, section) in enumerate(sections):
+            code = section.code
+            self.assertEqual(code, deterministic_order[index])


### PR DESCRIPTION
This pull request fixes the deterministic randomisation method in the MatchingPairsFixed class. The random.shuffle() function is now called after combining the original and degraded sections, ensuring that the sections are shuffled correctly. Additionally, unit tests have been added to verify the correctness of the select_sections method.