### PR TITLE
Enhance(SameDiff): Handle undefined values, use play button with multiple plays allowed

### DIFF
--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -28,7 +28,7 @@ class Trial(BaseAction):  # pylint: disable=too-few-public-methods
             title='',
             config: dict = None,
             result_id: int = None,
-            style = FrontendStyle()
+            style: FrontendStyle = FrontendStyle()
             ):
         '''
         - playback: Playback object (may be None)

--- a/backend/experiment/rules/congosamediff.py
+++ b/backend/experiment/rules/congosamediff.py
@@ -117,10 +117,11 @@ class CongoSameDiff(Base):
         )
         form = Form([question])
         playback = PlayButton([section], play_once=False)
+        experiment_name = session.experiment.name if session.experiment else 'SameDiff Experiment'
         view = Trial(
             playback=playback,
             feedback_form=form,
-            title=_(session.experiment.name),
+            title=_(experiment_name),
             config={
                 'response_time': section.duration,
                 'listen_first': True

--- a/backend/experiment/rules/congosamediff.py
+++ b/backend/experiment/rules/congosamediff.py
@@ -95,9 +95,9 @@ class CongoSameDiff(Base):
         subset_count = subset.count()
 
         practice_label = 'PRACTICE' if is_practice else 'NORMAL'
-        section_name = section.song.name
-        section_tag = section.tag
-        section_group = section.group
+        section_name = section.song.name if section.song else 'No name'
+        section_tag = section.tag if section.tag else 'No tag'
+        section_group = section.group if section.group else 'No group'
 
         question = ChoiceQuestion(
             explainer=f'{practice_label} ({trial_index}/{subset_count}) | {section_name} | {section_tag} | {section_group}',

--- a/backend/experiment/rules/congosamediff.py
+++ b/backend/experiment/rules/congosamediff.py
@@ -5,7 +5,7 @@ from experiment.models import Experiment
 from section.models import Playlist as PlaylistModel
 from session.models import Session
 from experiment.actions import ChoiceQuestion, Explainer, Form, Playlist, Trial
-from experiment.actions.playback import Autoplay
+from experiment.actions.playback import PlayButton
 from .base import Base
 from result.utils import prepare_result
 
@@ -60,7 +60,8 @@ class CongoSameDiff(Base):
         # return a practice trial
         if next_round_number <= practice_trials_count:
             subset = session.playlist.section_set.filter(
-                tag__contains='practice')
+                tag__contains='practice'
+            )
             return self.get_next_trial(
                 session,
                 subset,
@@ -68,7 +69,8 @@ class CongoSameDiff(Base):
                 True
             )
         subset = session.playlist.section_set.exclude(
-            tag__contains='practice')
+            tag__contains='practice'
+        )
 
         # if the next_round_number is greater than the no. of practice trials,
         # return a non-practice trial
@@ -114,7 +116,7 @@ class CongoSameDiff(Base):
             submits=True
         )
         form = Form([question])
-        playback = Autoplay([section])
+        playback = PlayButton([section], play_once=False)
         view = Trial(
             playback=playback,
             feedback_form=form,

--- a/backend/experiment/rules/congosamediff.py
+++ b/backend/experiment/rules/congosamediff.py
@@ -61,14 +61,12 @@ class CongoSameDiff(Base):
         if next_round_number <= practice_trials_count:
             subset = session.playlist.section_set.filter(
                 tag__contains='practice')
-            
             return self.get_next_trial(
                 session,
                 subset,
                 next_round_number,
                 True
             )
-        
         subset = session.playlist.section_set.exclude(
             tag__contains='practice')
 
@@ -120,7 +118,7 @@ class CongoSameDiff(Base):
         view = Trial(
             playback=playback,
             feedback_form=form,
-            title=_('Test experiment'),
+            title=_(session.experiment.name),
             config={
                 'response_time': section.duration,
                 'listen_first': True

--- a/frontend/src/components/PlayButton/PlayButton.jsx
+++ b/frontend/src/components/PlayButton/PlayButton.jsx
@@ -1,24 +1,22 @@
 import React, { useState } from "react";
 import classNames from "classnames";
 
-const PlayButton = ({ playSection, isPlaying, className="" }) => {
-
-    const [clicked, setClicked] = useState(false);
+const PlayButton = ({ playSection, isPlaying, className = "", disabled }) => {
 
     return (
         <>
-        <div
-            className={classNames("aha__play-button btn-blue border-outside", "btn", {
-                stop: isPlaying, disabled: clicked && !isPlaying,
-            },className)}
-            onClick={ (playSection && !clicked) ? () => {setClicked(true); playSection(0);} : undefined}
-            tabIndex="0"
-            onKeyPress={(e) => {
-                playSection && playSection(0)
-            }}
-        >
-        </div>
-        <div className="playbutton-spacer"></div>
+            <div
+                className={classNames("aha__play-button btn-blue border-outside", "btn", {
+                    stop: isPlaying, disabled: disabled || isPlaying
+                }, className)}
+                onClick={playSection && !disabled ? () => playSection(0) : undefined}
+                tabIndex="0"
+                onKeyPress={(e) => {
+                    playSection && playSection(0)
+                }}
+            >
+            </div>
+            <div className="playbutton-spacer"></div>
         </>
     );
 };


### PR DESCRIPTION
This pull request fixes an issue where the section name, tag, or group could be missing in certain cases. It also adds typing for the FrontendStyle class and shows the experiment name in the app bar. Additionally, it refactors the PlayButton component to handle the disabled state and allow multiple playbacks if the argument `play_once = False` is present. Finally, it refactors the CongoSameDiff class to use the PlayButton component instead of Autoplay for playback while allowing playing the audio more than once.

## tl;dr

- experiment name, section tag, group, name are not required anymore
- use play button instead of autoplay and allow multiple playbacks
- show experiment name in the top bar