### PR TITLE
Fixed: Fix "unknown view" error and refactor fetch requests

### DIFF
--- a/frontend/src/components/Playback/Playback.jsx
+++ b/frontend/src/components/Playback/Playback.jsx
@@ -16,6 +16,7 @@ export const BUTTON = "BUTTON";
 export const MULTIPLAYER = "MULTIPLAYER";
 export const IMAGE = "IMAGE";
 export const MATCHINGPAIRS = "MATCHINGPAIRS";
+export const VISUALMATCHINGPAIRS = "VISUALMATCHINGPAIRS";
 export const PRELOAD = "PRELOAD";
 
 const Playback = ({
@@ -214,6 +215,7 @@ const Playback = ({
                     />
                 );
             case MATCHINGPAIRS:
+            case VISUALMATCHINGPAIRS:
                 return (
                     <MatchingPairs
                         {...attrs}

--- a/frontend/src/components/Playback/Playback.jsx
+++ b/frontend/src/components/Playback/Playback.jsx
@@ -16,7 +16,6 @@ export const BUTTON = "BUTTON";
 export const MULTIPLAYER = "MULTIPLAYER";
 export const IMAGE = "IMAGE";
 export const MATCHINGPAIRS = "MATCHINGPAIRS";
-export const VISUALMATCHINGPAIRS = "VISUALMATCHINGPAIRS";
 export const PRELOAD = "PRELOAD";
 
 const Playback = ({
@@ -215,7 +214,6 @@ const Playback = ({
                     />
                 );
             case MATCHINGPAIRS:
-            case VISUALMATCHINGPAIRS:
                 return (
                     <MatchingPairs
                         {...attrs}

--- a/frontend/src/components/Preload/Preload.jsx
+++ b/frontend/src/components/Preload/Preload.jsx
@@ -28,7 +28,7 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
         const preloadResources = async () => {
             if (playMethod === 'NOAUDIO') {
 
-                await Promise.all(sections.map((section) => fetch(MEDIA_ROOT + section.url, {mode: 'no-cors'})));
+                await Promise.all(sections.map((section) => fetch(MEDIA_ROOT + section.url)));
 
                 return onNext();
             }


### PR DESCRIPTION
> This pull request fixes the "unknown view" error by adding the VISUALMATCHINGPAIRS experiment type to the Playback component.

The visual matching pairs rules set still returned the view as `VISUALMATCHINGPAIRS`, causing an "unknown view" error. Either we do it like this (by keeping the rule set and adding the view to `Playback.jsx`) or we remove this rules set and go full monty on the matching pairs rules sets and use the `determine_play_method`, which is more automagically but might also give the user less control (what if the user uses an audio format that's not in the list?).

> It also refactors the fetch requests by removing the 'no-cors' mode.

As for the CORS errors, I'm not getting them 😅 Have you also experienced them on ACC or APP? Maybe we can compare our `.env` files. In the screenshot in the issue it seems like your `Access-Allow-Control-Origin` is set to `http://localhost:3000`, is that correct? My allowed hosts environment variable is set to only localhost (`AML_ALLOWED_HOSTS=localhost`) could you @BeritJanssen try and see what happens if you do that as well?

Related to #841 