### PR TITLE
Added: Show started session count in experiment collection tiles

### DIFF
--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -53,6 +53,7 @@ def serialize_experiment(experiment_object: Experiment, participant: Participant
     return {
         'slug': experiment_object.slug,
         'name': experiment_object.name,
+        'started_session_count': get_started_session_count(experiment_object, participant),
         'finished_session_count': get_finished_session_count(experiment_object, participant),
         'description': experiment_object.description,
         'image': experiment_object.image.file.url if experiment_object.image else '',
@@ -68,6 +69,13 @@ def get_upcoming_experiment(experiment_list, participant, repeat_allowed=True):
     if not repeat_allowed and minimum_session_count != 0:
         return None
     return serialize_experiment(experiment_list[finished_session_counts.index(minimum_session_count)].experiment, participant)
+
+
+def get_started_session_count(experiment, participant):
+    ''' Get the number of started sessions for this experiment and participant '''
+    count = Session.objects.filter(
+        experiment=experiment, participant=participant).count()
+    return count
 
 
 def get_finished_session_count(experiment, participant):

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -105,7 +105,6 @@ def get_experiment_collection(request, slug):
         **serialize_experiment_collection(collection),
         **serialized_group
     })
-)
 
 
 def get_associated_experiments(pk_list):

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-
 from django.http import Http404, JsonResponse
 from django.conf import settings
 from django.utils.translation import activate, gettext_lazy as _

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -105,6 +105,7 @@ def get_experiment_collection(request, slug):
         **serialize_experiment_collection(collection),
         **serialized_group
     })
+)
 
 
 def get_associated_experiments(pk_list):

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.scss
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.scss
@@ -240,11 +240,26 @@
                         padding: 0 15px 15px;
                         opacity: 0.8;
                     }
-                    .counter {
-                        color: white;
+
+                    .status-bar {
                         position: absolute;
-                        bottom: 1rem;
-                        right: 1rem;
+                        bottom: .25rem;
+                        right: .25rem;
+                        display: flex;
+                        justify-content: flex-end;
+                        align-items: center;
+                        column-gap: .25rem;
+                    }
+                    .counter {
+                        color: var(--white);
+                        background-color: rgba(0, 0, 0, 0.3);
+                        padding: 0.2rem 0.5rem;
+                        border-radius: 0.5rem;
+                        transition: background-color 0.3s ease-out;
+
+                        &:hover {
+                            background-color: rgba(0, 0, 0, 1);
+                        }
                     }
                 }
                 

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
 
 import ExperimentCollectionDashboard from './ExperimentCollectionDashboard';
+import Experiment from '@/types/Experiment';
 
 const getExperiment = (overrides = {}) => {
     return {
         slug: 'some_slug',
         name: 'Some Experiment',
-        finished_session_count: 0,
+        started_session_count: 2,
+        finished_session_count: 1,
         ...overrides
-    };
+    } as Experiment
 }
 
 const experiment1 = getExperiment({
@@ -36,8 +38,9 @@ describe('ExperimentCollectionDashboard', () => {
         await waitFor(() => {
             expect(screen.getByRole('menu')).toBeTruthy();
             const counters = screen.getAllByRole('status');
-            expect(counters).toHaveLength(2);
-            expect(counters[1].innerHTML).toBe('2');
+            expect(counters).toHaveLength(4);
+            expect(counters[0].innerHTML).toBe(experiment1.started_session_count.toString());
+            expect(counters[1].innerHTML).toBe(experiment1.finished_session_count.toString());
         })
     });
 })

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
@@ -39,7 +39,10 @@ export const ExperimentCollectionDashboard: React.FC<ExperimentCollectionDashboa
                             <Link to={"/" + exp.slug}>
                                 <ImageOrPlaceholder imagePath={exp.image} alt={exp.description} />
                                 <h3>{exp.name}</h3>
-                                <div role="status" className="counter">{exp.finished_session_count}</div>
+                                <div className="status-bar">
+                                    <span title={`Het "${exp.name}" experiment is ${exp.started_session_count} keer gestart`} role="status" className="counter">{exp.started_session_count}</span>
+                                    <span title={`Het "${exp.name}" experiment is ${exp.finished_session_count} keer voltooid`} role="status" className="counter">{exp.finished_session_count}</span>
+                                </div>
                             </Link>
                         </li>
                     ))}
@@ -55,6 +58,5 @@ const ImageOrPlaceholder = ({ imagePath, alt }: { imagePath: string, alt: string
 
     return imgSrc ? <img src={imgSrc} alt={alt} /> : <div className="placeholder" />;
 }
-
 
 export default ExperimentCollectionDashboard;

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
@@ -40,8 +40,8 @@ export const ExperimentCollectionDashboard: React.FC<ExperimentCollectionDashboa
                                 <ImageOrPlaceholder imagePath={exp.image} alt={exp.description} />
                                 <h3>{exp.name}</h3>
                                 <div className="status-bar">
-                                    <span title={`Het "${exp.name}" experiment is ${exp.started_session_count} keer gestart`} role="status" className="counter">{exp.started_session_count}</span>
-                                    <span title={`Het "${exp.name}" experiment is ${exp.finished_session_count} keer voltooid`} role="status" className="counter">{exp.finished_session_count}</span>
+                                    <span title={`Started ${exp.started_session_count} times`} role="status" className="counter">{exp.started_session_count}</span>
+                                    <span title={`Started ${exp.finished_session_count} times`} role="status" className="counter">{exp.finished_session_count}</span>
                                 </div>
                             </Link>
                         </li>

--- a/frontend/src/types/Experiment.ts
+++ b/frontend/src/types/Experiment.ts
@@ -4,5 +4,6 @@ export default interface Experiment {
     slug: string;
     description: string;
     image: string;
+    started_session_count?: number;
     finished_session_count?: number;
 }

--- a/frontend/src/types/Experiment.ts
+++ b/frontend/src/types/Experiment.ts
@@ -4,6 +4,6 @@ export default interface Experiment {
     slug: string;
     description: string;
     image: string;
-    started_session_count?: number;
-    finished_session_count?: number;
+    started_session_count: number;
+    finished_session_count: number;
 }


### PR DESCRIPTION
Fix routing issue by using Switch instead of BrowserRouter in ExperimentCollection.tsx

Add started_session_count property to Experiment interface in Experiment.ts

Update Experiment interface in Experiment.ts to remove optional session count properties

Update ExperimentCollectionDashboard to display started and finished session counts in Experiment links

Update tests for newly added started session counter badge

Resolves #912