### PR TITLE
Added: Pick a random variant per trial for the CongoSameDiff Experiment

### DIFF
--- a/backend/experiment/rules/congosamediff.py
+++ b/backend/experiment/rules/congosamediff.py
@@ -1,4 +1,6 @@
 
+import random
+import re
 from django.utils.translation import gettext_lazy as _
 from experiment.actions.final import Final
 from experiment.models import Experiment
@@ -29,14 +31,19 @@ class CongoSameDiff(Base):
         # All sections need to have a group value
         sections = experiment.playlists.first().section_set.all()
         for section in sections:
-            if not section.group:
-                file_name = section.song.name if section.song else 'No name'
-                raise ValueError(f'Section {file_name} should have a group value')
-            
+            file_name = section.song.name if section.song else 'No name'
+            # every section.group should consist of a number
+            regex_pattern = r'^\d+$'
+            if not section.group or not re.search(regex_pattern, section.group):
+                raise ValueError(f'Section {file_name} should have a group value containing only digits')
+            # the section song name should not be empty
+            if not section.song.name:
+                raise ValueError(f'Section {file_name} should have a name that will be used for the result key')
+
         # It also needs at least one section with the tag 'practice'
         if not sections.filter(tag__contains='practice').exists():
             raise ValueError('At least one section should have the tag "practice"')
-        
+
         # It should also contain at least one section without the tag 'practice'
         if not sections.exclude(tag__contains='practice').exists():
             raise ValueError('At least one section should not have the tag "practice"')
@@ -59,8 +66,8 @@ class CongoSameDiff(Base):
 
         next_round_number = session.get_current_round()
 
-        # total number of trials
-        total_trials_count = session.playlist.section_set.count() + 1  # +1 for the post-practice round
+        # practice trials + post-practice question + non-practice trials
+        total_trials_count = self.get_total_trials_count(session)
 
         practice_done = session.result_set.filter(
             question_key='practice_done',
@@ -97,7 +104,7 @@ class CongoSameDiff(Base):
             return self.get_next_trial(
                 session,
                 practice_trials_subset,
-                1,
+                1,  # first practice trial
                 True
             )
 
@@ -108,17 +115,26 @@ class CongoSameDiff(Base):
         if next_round_number == practice_trials_count + 1 and not practice_done:
             return self.get_practice_done_view(session)
 
-        # load the non-practice trials
-        real_trials_subset = session.playlist.section_set.exclude(
+        # group number of the trial to be played
+        group_number = next_round_number - practice_trials_count - 1
+
+        # load the non-practice trial variants for the group number
+        real_trial_variants = session.playlist.section_set.exclude(
             tag__contains='practice'
+        ).filter(
+            group=group_number
         )
+
+        # pick a variant from the variants randomly (#919)
+        variants_count = real_trial_variants.count()
+        random_variants_index = random.randint(0, variants_count - 1)
 
         # if the next_round_number is greater than the no. of practice trials,
         # return a non-practice trial
         return self.get_next_trial(
             session,
-            real_trials_subset,
-            next_round_number - practice_trials_count - 1,
+            real_trial_variants,
+            random_variants_index + 1,
             False
         )
 
@@ -165,7 +181,7 @@ class CongoSameDiff(Base):
         section_group = section.group if section.group else 'no_group'
 
         # define a key, by which responses to this trial can be found in the database
-        key = f'samediff_trial_{section_group}'
+        key = f'samediff_trial_{section_group}_{section_name}'
 
         question = ChoiceQuestion(
             explainer=f'{practice_label} ({trial_index}/{subset_count}) | {section_name} | {section_tag} | {section_group}',
@@ -207,3 +223,15 @@ class CongoSameDiff(Base):
             session=session,
             final_text=_('Thank you for participating!'),
         )
+
+    def get_total_trials_count(self, session: Session):
+        practice_trials_subset = session.playlist.section_set.filter(
+            tag__contains='practice'
+        )
+        practice_trials_count = practice_trials_subset.count()
+        total_exp_variants = session.playlist.section_set.exclude(
+            tag__contains='practice'
+        )
+        total_unique_exp_trials_count = total_exp_variants.values('group').distinct().count()
+        total_trials_count = practice_trials_count + total_unique_exp_trials_count + 1
+        return total_trials_count

--- a/backend/experiment/rules/congosamediff.py
+++ b/backend/experiment/rules/congosamediff.py
@@ -71,15 +71,13 @@ class CongoSameDiff(Base):
         if next_round_number > total_trials_count:
             return self.get_final_round(session)
 
-        # count of practice rounds (excluding the post-practice round)
-        practice_trials_count = session.playlist.section_set.filter(
-            tag__contains='practice'
-        ).count()
-
         # load the practice trials
         practice_trials_subset = session.playlist.section_set.filter(
             tag__contains='practice'
         )
+
+        # count of practice rounds (excluding the post-practice round)
+        practice_trials_count = practice_trials_subset.count()
 
         # if the user hasn't completed the practice trials
         # return the next practice trial

--- a/backend/experiment/rules/tests/test_congosamediff.py
+++ b/backend/experiment/rules/tests/test_congosamediff.py
@@ -175,6 +175,39 @@ class CongoSameDiffTest(TestCase):
         with self.assertRaisesRegex(ValueError, 'At least one section should not have the tag "practice"'):
             congo_same_diff.first_round(experiment)
 
+    def test_throw_combined_exceptions_if_multiple_errors(self):
+        congo_same_diff = CongoSameDiff()
+        experiment = Experiment(id=1, name='CongoSameDiff', slug='congosamediff_first_round', rounds=4)
+        experiment.save()
+        playlist = PlaylistModel.objects.create(name='CongoSameDiff')
+        Section.objects.create(
+            playlist=playlist,
+            start_time=0.0,
+            duration=20.0,
+            song=Song.objects.create(artist='no_group', name='no_group'),
+            tag='practice_contour',
+            group=''
+        )
+        Section.objects.create(
+            playlist=playlist,
+            start_time=0.0,
+            duration=20.0,
+            song=Song.objects.create(artist='group_not_int', name='group_not_int'),
+            tag='practice_contour',
+            group='not_int_42'
+        )
+        Section.objects.create(
+            playlist=playlist,
+            start_time=0.0,
+            duration=20.0,
+            song=Song.objects.create(artist='only_practice', name='only_practice'),
+            tag='practice_contour',
+            group='42'
+        )
+        experiment.playlists.set([playlist])
+        with self.assertRaisesRegex(ValueError, "The experiment playlist is not valid: \n- Section group_not_int should have a group value containing only digits\n- Section no_group should have a group value containing only digits\n- At least one section should not have the tag \"practice\""):
+            congo_same_diff.first_round(experiment)
+
     def test_get_total_trials_count(self):
         congo_same_diff = CongoSameDiff()
         total_trials_count = congo_same_diff.get_total_trials_count(self.session)


### PR DESCRIPTION
This PR adds the following things to the CongoSameDiff experiment rule set:

- Pick a random variant per trial based on the group number
- Improve validation logic, mention all errors when playlist is invalid instead of just the first one it encounters

## Data structure / CSV format

It requires the playlist to have the following format:

- Name: Will be used for the `result_key`, so it can be whatever you think is convenient.
- Group: Will be used as the trial number from which a random variant will be picked. If you have 3 variants that you want to use as the first experiment trial, you should have three stimuli in group 1.
- Tag: Will be used to mark a trial as a practice trial.

### Example data

| Name | Group  | Tag  | 
|---|---|---|
| Rhythm_Practice_Same  | 1  | practice  |
| Rhythm_Practice_Diff  | 2  | practice  |
| Rhythm_1_Same | 1  |   |
| Rhythm_1_Diff_100  | 1  |   |
| Rhythm_1_Diff_50  | 1  |   |
| Rhythm_2_Same | 2  |   |
| Rhythm_2_Diff_100  | 2  |   |
| Rhythm_2_Diff_50  | 2  |   |

## Possible conversion to factorial design

If we do decide to start using factorial design, we could then easily update this structure by using the variant number or letter in the `tag` column:

### Example of factorial design data structure

| Name | Group  | Tag  | 
|---|---|---|
| Rhythm_Practice_Same  | 1  | practice  |
| Rhythm_Practice_Diff  | 2  | practice  |
| Rhythm_1_Same | 1  | 1 |
| Rhythm_1_Diff_100  | 1  | 2 |
| Rhythm_1_Diff_50  | 1  | 2 |
| Rhythm_2_Same | 2  | 1 |
| Rhythm_2_Diff_100  | 2  | 2 |
| Rhythm_2_Diff_50  | 2  | 3 |



Resolves #919