### PR TITLE
Fixed: Fix word-wrap issue in edit-sections.html and add links to experiment and collection in admin overview

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -32,13 +32,18 @@ class FeedbackInline(admin.TabularInline):
 
 
 class ExperimentAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
-    list_display = ('image_preview', 'experiment_name_link', 'experiment_slug_link', 'rules', 'rounds', 'playlist_count',
+    list_display = ('image_preview', 'experiment_name_link',
+                    'experiment_slug_link', 'rules',
+                    'rounds', 'playlist_count',
                     'session_count', 'active')
     list_filter = ['active']
     search_fields = ['name']
     inline_actions = ['export', 'export_csv']
-    fields = ['name', 'description', 'image', 'slug', 'url', 'hashtag', 'theme_config',  'language', 'active', 'rules',
-              'rounds', 'bonus_points', 'playlists', 'consent', 'questions']
+    fields = ['name', 'description', 'image',
+              'slug', 'url', 'hashtag', 'theme_config', 
+              'language', 'active', 'rules',
+              'rounds', 'bonus_points', 'playlists',
+              'consent', 'questions']
     inlines = [FeedbackInline]
     form = ExperimentForm
 
@@ -158,7 +163,6 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
 
     def experiment_slug_link(self, obj):
         dev_mode = settings.DEBUG is True
-
         url = f"http://localhost:3000/{obj.slug}" if dev_mode else f"/{obj.slug}"
 
         return format_html(
@@ -189,12 +193,19 @@ class MarkdownPreviewTextInput(TextInput):
 
 
 class ExperimentSeriesAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
-    list_display = ('slug', 'name', 'description_excerpt', 'dashboard', 'groups')
+    list_display = ('name', 'slug_link', 'description_excerpt', 'dashboard', 'groups')
     fields = ['slug', 'name', 'description', 'first_experiments',
               'random_experiments', 'last_experiments', 'dashboard',
               'about_content']
     form = ExperimentSeriesForm
     inlines = [ExperimentSeriesGroupInline]
+
+    def slug_link(self, obj):
+        dev_mode = settings.DEBUG is True
+        url = f"http://localhost:3000/collection/{obj.slug}" if dev_mode else f"/collection/{obj.slug}"
+
+        return format_html(
+            f'<a href="{url}" target="_blank" rel="noopener noreferrer" title="Open {obj.slug} experiment group in new tab" >{obj.slug}&nbsp;<small>&#8599;</small></a>')
 
     def description_excerpt(self, obj):
 
@@ -206,6 +217,8 @@ class ExperimentSeriesAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
     def groups(self, obj):
         groups = ExperimentSeriesGroup.objects.filter(series=obj)
         return format_html(', '.join([f'<a href="/admin/experiment/experimentseriesgroup/{group.id}/change/">{group.name}</a>' for group in groups]))
+    
+    slug_link.short_description = "Slug"
 
 
 admin.site.register(ExperimentSeries, ExperimentSeriesAdmin)

--- a/backend/experiment/templates/edit-sections.html
+++ b/backend/experiment/templates/edit-sections.html
@@ -9,6 +9,7 @@
     }
     p.form-filename {
         max-width: 200px;
+        word-wrap: break-word;
     }
     .song-padding {
         height: 2rem;
@@ -52,7 +53,7 @@
                 <p>{{section.code}}</p>
             </td>
             <td>
-                <p class="form-filename">{{section.filename}}</p>
+                <p class="form-filename" title="{{section.filename}}">{{section.filename}}</p>
             </td>
             <td>
                 <input type="text" name="{{section.id}}_artist" maxlength="128" id="{{section.id}}_artist"

--- a/backend/experiment/tests/test_admin_experiment.py
+++ b/backend/experiment/tests/test_admin_experiment.py
@@ -168,7 +168,7 @@ class TestExperimentSeriesAdmin(TestCase):
     def test_experiment_series_admin_list_display(self):
         self.assertEqual(
             ExperimentSeriesAdmin.list_display,
-            ('slug', 'name', 'description_excerpt', 'dashboard', 'groups')
+            ('name', 'slug_link', 'description_excerpt', 'dashboard', 'groups')
         )
 
     def test_experiment_series_admin_description_excerpt(self):


### PR DESCRIPTION
## Filename display of Edit Sections page

This pull request fixes the word-wrap issue in the edit-sections.html file that would make the filename disappear behind the next column if it was too long. The word-wrap property is added to the .form-filename class to ensure that long filenames are properly displayed.

### Before

<img width="294" alt="image" src="https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/ec078f9e-422b-48c0-b444-b9d3473608df">

### After

<img width="293" alt="image" src="https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/00abbe56-e88f-4e04-b5d2-4d88045d9e3e">

## Experiment(Series) admin overview improvements

Additionally, this PR slightly refactors the admin overview of Experiment and ExperimentSeries by:
- Improving the column names, and by 
- Adding links to the actual experiment and experiment collection in the slug column that are opened in a new tab. Just a simple quality of life improvement that saves you the time and effort to retype the whole url/slug of the experiment when you want to test/use it. Based on whether we are in DEBUG mode, it prefixes the url with `http://localhost:3000`. On TST/ACC/APP this prefix won't be needed since the backend and the frontend run on the same domain and a simple `/collection/{slug}` or `/{slug}` should be enough.

## Screenshots

### ExperimentSeries admin overview

<img width="1077" alt="image" src="https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/c1507a60-9f57-4407-9503-ba20255fe0c9">

### Experiment admin overview

<img width="815" alt="image" src="https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/50718c73-e010-4569-850b-0adc11e89d6e">

