### PR TITLE
Fixed: Update RELOAD_PARTICIPANT_TARGET URL in production settings to avoid double slashes in social media share url

### DIFF
--- a/backend/aml/production_settings.py
+++ b/backend/aml/production_settings.py
@@ -64,6 +64,6 @@ LOGGING = {
     }
 }
 
-RELOAD_PARTICIPANT_TARGET = 'http://app.amsterdammusiclab.nl/'
+RELOAD_PARTICIPANT_TARGET = 'http://app.amsterdammusiclab.nl'
 
 TESTING = os.getenv('AML_TESTING', '') != 'False'

--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -146,9 +146,7 @@ class Base(object):
         return trials
 
     def social_media_info(self, experiment, score):
-        current_url =  "{}/{}".format(settings.RELOAD_PARTICIPANT_TARGET,
-            experiment.slug
-        )
+        current_url = f"{settings.RELOAD_PARTICIPANT_TARGET}/{experiment.slug}"
         return {
             'apps': ['facebook', 'twitter'],
             'message': _("I scored %(score)i points on %(url)s") % {

--- a/backend/experiment/rules/tests/test_base.py
+++ b/backend/experiment/rules/tests/test_base.py
@@ -24,27 +24,6 @@ class BaseTest(TestCase):
         self.assertEqual(social_media_info['apps'], ['facebook', 'twitter'])
         self.assertEqual(social_media_info['message'], 'I scored 100 points on https://app.amsterdammusiclab.nl/music-lab')
         self.assertEqual(social_media_info['url'], expected_url)
-        self.assertNotContains(social_media_info['url'], '//') # Check for double slashes
-        self.assertEqual(social_media_info['hashtags'], ['music-lab', 'amsterdammusiclab', 'citizenscience'])
-
-        from django.conf import settings
-        # Override settings with production values
-        # import production settings
-        import aml.production_settings
-        settings.configure(aml.production_settings)
-
-
-        experiment = Experiment.objects.create(
-            name='Music Lab',
-            slug='music-lab',
-        )
-        base = Base()
-        social_media_info = base.social_media_info(
-            experiment=experiment,
-            score=100,
-        )
-
-        self.assertEqual(social_media_info['apps'], ['facebook', 'twitter'])
-        self.assertEqual(social_media_info['message'], 'I scored 100 points on https://app.amsterdammusiclab.nl/music-lab')
-        self.assertEqual(social_media_info['url'], 'https://app.amsterdammusiclab.nl/music-lab')
+        # Check for double slashes
+        self.assertNotIn(social_media_info['url'], '//')
         self.assertEqual(social_media_info['hashtags'], ['music-lab', 'amsterdammusiclab', 'citizenscience'])

--- a/backend/experiment/rules/tests/test_base.py
+++ b/backend/experiment/rules/tests/test_base.py
@@ -1,0 +1,50 @@
+from django.test import TestCase
+from django.conf import settings
+from experiment.models import Experiment
+from ..base import Base
+
+
+class BaseTest(TestCase):
+
+    def test_social_media_info(self):
+        reload_participant_target = settings.RELOAD_PARTICIPANT_TARGET
+        slug = 'music-lab'
+        experiment = Experiment.objects.create(
+            name='Music Lab',
+            slug=slug,
+        )
+        base = Base()
+        social_media_info = base.social_media_info(
+            experiment=experiment,
+            score=100,
+        )
+
+        expected_url = f"{reload_participant_target}/{slug}"
+
+        self.assertEqual(social_media_info['apps'], ['facebook', 'twitter'])
+        self.assertEqual(social_media_info['message'], 'I scored 100 points on https://app.amsterdammusiclab.nl/music-lab')
+        self.assertEqual(social_media_info['url'], expected_url)
+        self.assertNotContains(social_media_info['url'], '//') # Check for double slashes
+        self.assertEqual(social_media_info['hashtags'], ['music-lab', 'amsterdammusiclab', 'citizenscience'])
+
+        from django.conf import settings
+        # Override settings with production values
+        # import production settings
+        import aml.production_settings
+        settings.configure(aml.production_settings)
+
+
+        experiment = Experiment.objects.create(
+            name='Music Lab',
+            slug='music-lab',
+        )
+        base = Base()
+        social_media_info = base.social_media_info(
+            experiment=experiment,
+            score=100,
+        )
+
+        self.assertEqual(social_media_info['apps'], ['facebook', 'twitter'])
+        self.assertEqual(social_media_info['message'], 'I scored 100 points on https://app.amsterdammusiclab.nl/music-lab')
+        self.assertEqual(social_media_info['url'], 'https://app.amsterdammusiclab.nl/music-lab')
+        self.assertEqual(social_media_info['hashtags'], ['music-lab', 'amsterdammusiclab', 'citizenscience'])


### PR DESCRIPTION
Update the RELOAD_PARTICIPANT_TARGET URL in the production settings to remove the trailing slash. This ensures consistency in the URL format.

- refactor: Make string formatting of social media share link url more readable
- Refactor the string formatting of the social media share link URL to improve readability. This change does not affect the functionality of the code.
- test: Add test for social media info in BaseTest

Resolves #950