### PR TITLE
Set first card status to seen

### DIFF
--- a/frontend/src/components/MatchingPairs/MatchingPairs.jsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.jsx
@@ -89,7 +89,7 @@ const MatchingPairs = ({
         if (turnedCards.length < 2) {
             if (turnedCards.length === 1) {
                 // This is the second card to be turned
-                currentCard.turned = true;
+                currentCard.turned = true;                
                 setSecondCard(currentCard);
                 // set no mouse events for all but current
                 sections.forEach(section => section.noevents = true);
@@ -110,6 +110,7 @@ const MatchingPairs = ({
                 // turn first card, disable events
                 currentCard.turned = true;
                 currentCard.noevents = true;
+                currentCard.seen = true;
                 // clear feedback text
                 setFeedbackText('');
             }


### PR DESCRIPTION
The first card is now set to seen on the first move of a turn.

- Score will now be `misremembered` when a first card with status `seen`  is used as the second card in a future turn.
- When 2 cards with a status `seen` are a match the score is `Good Job`. This was already the case, but didn't work properly because the first card in a turn was never set to `seen`  

Fixes #949 