### PR TITLE
fix: delete playlist action from first_round

### DIFF
--- a/backend/experiment/rules/thats_my_song.py
+++ b/backend/experiment/rules/thats_my_song.py
@@ -54,9 +54,8 @@ class ThatsMySong(Hooked):
     
     def first_round(self, experiment):
         actions = super().first_round(experiment)
-        # remove consent
-        del actions[1]
-        return actions
+        # skip Consent and Playlist action
+        return actions[:1]
 
     def next_round(self, session):	
         """Get action data for the next round"""


### PR DESCRIPTION
A fix for the problem we just noticed with That's My Song: it won't continue after the first explainer. Caused by an orphan `Playlist` view.