### PR TITLE
Set first_card seen after posting the result and fix double asignment…

### DIFF
--- a/frontend/src/components/MatchingPairs/MatchingPairs.jsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.jsx
@@ -77,7 +77,7 @@ const MatchingPairs = ({
             }
             setFeedbackClass(fbclass);
             turnedCards[0].matchClass = turnedCards[1].matchClass = fbclass;
-            turnedCards[1].seen = turnedCards[1].seen = true;
+            turnedCards[0].seen = turnedCards[1].seen = true;
             setInBetweenTurns(true);
             return;
         }
@@ -113,8 +113,7 @@ const MatchingPairs = ({
                 setFirstCard(currentCard);
                 // turn first card, disable events
                 currentCard.turned = true;
-                currentCard.noevents = true;
-                currentCard.seen = true;
+                currentCard.noevents = true;                
                 currentCard.boardposition = parseInt(index) + 1;
                 currentCard.timestamp = performance.now();
                 // reset response interval in case this card has a value from a previous turn


### PR DESCRIPTION
This PR fixes:

- Typo in (the original) assignment of .seen to the turnedcards. 
- Assignment of .seen to the first_card after the result instead of before. (this was a later bugfix for the first problem)