### PR TITLE
fix: do not call onNext() from within map

### DIFF
--- a/frontend/src/components/Preload/Preload.jsx
+++ b/frontend/src/components/Preload/Preload.jsx
@@ -34,13 +34,11 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
             }
 
             if (playMethod === 'BUFFER') {
-
                 // Use Web-audio and preload sections in buffers            
                 sections.map((section, index) => {
                     // skip Preload if the section has already been loaded in the previous action
                     if (webAudio.checkSectionLoaded(section)) {
-                        onNext();
-                        return undefined;
+                        return true;
                     }
                     // Clear buffers if this is the first section
                     if (index === 0) {
@@ -57,6 +55,7 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
                         }                                        
                     });
                 })
+            onNext();
             } else {
                 if (playMethod === 'EXTERNAL') {                    
                     webAudio.closeWebAudio();        


### PR DESCRIPTION
Close #1002 . The problem was caused by the `checkSectionLoaded` mechanism, which was introduced to prevent reloading files for consecutive views, such as in SongSync. The `onNext` call in the `.map` loop would cause the next view to be triggered before all files were loaded, as the `Originals` board contains duplicates of sections.

Moving the `onNext()` call to after the `.map` loop should fix this.