### PR TITLE
Clear buffers before preloading first section

### DIFF
--- a/frontend/src/components/Preload/Preload.jsx
+++ b/frontend/src/components/Preload/Preload.jsx
@@ -41,6 +41,11 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
                         }
                         return;
                     }
+                    
+                    // Clear buffers if this is the first section
+                    if (index === 0) {
+                        webAudio.clearBuffers();
+                    }
 
                     // Load sections in buffer                
                     return webAudio.loadBuffer(section.id, section.url, () => {                    
@@ -66,8 +71,6 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
         }
 
         preloadResources();
-        // on destroy, clean up buffers
-        return webAudio.clearBuffers();    
     }, [sections, playMethod, onNext]);
     
     return (


### PR DESCRIPTION
This PR fixes #1006 

The `webAudio.clearBuffers()` function was moved in #1003  to act as the cleanup function for the react hook it's in.
When preloading a section that was also used in the previous turn, the preloading of the section was skipped by `webAudio.checkSectionLoaded()` after which the buffers were cleared on cleanup and there was nothing to play, which caused the experiment to freeze.
Putting the `webAudio.clearBuffers()` back in place solved the problem.

As most experiments only use 1 section per round the `webAudio.clearBuffers()` was meant to prevent the loaded buffers from taking up to much memory:  Otherwise if there were 30 rounds with unique sections, all 30 buffers would remain in memory untill the experiment was finished, which could cause problems.

I made some further suggestions to improve performance in issue #1008 