### PR TITLE
Fixed: Fix fetch URL in loadBuffer function by not prefixing the url with MEDIA_ROOT

### DIFF
--- a/frontend/src/util/webAudio.js
+++ b/frontend/src/util/webAudio.js
@@ -74,7 +74,7 @@ export const changeGain = (level) => {
 
 // load sound data and store in buffers object
 export const loadBuffer = async (id, src, canPlay) => {
-    await fetch(MEDIA_ROOT + src, {})
+    await fetch(src, {})
         // Return the data as an ArrayBuffer
         .then(response => response.arrayBuffer())
         // Decode the audio data


### PR DESCRIPTION
Resolves #1012

This PR eliminates the double `/server/server` prefix that was caused by both the frontend and the backend adding a `/server` path to the urls that fetches the sections.

In this solution, I have removed it from the frontend part as the section url received from the backend already contains the `/server` path configured through the `AML_SUBPATH` environment variable. The backend uses a reverse url function that automatically adds that path already. See also here: https://github.com/Amsterdam-Music-Lab/MUSCLE/blob/3c0382b70b63742d7f0d0f75d8e64383f3bd01ff/backend/section/models.py#L291-L293
