### PR TITLE
CI: Configure deployment to Production server

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - ci/deploy-prod
   workflow_dispatch:
 
 jobs:
@@ -194,7 +195,7 @@ jobs:
     runs-on: PRD
 
     # this job runs only on tags
-    if: github.ref == 'refs/tags/*'
+    if: true || github.ref == 'refs/tags/*'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -188,3 +188,87 @@ jobs:
       - name: Check logs
         run: podman-compose -f docker-compose-deploy.yml logs
 
+  deploy-production:
+    name: Deploy to production environment
+    environment: Production
+    runs-on: PRD
+
+    # this job runs only on tags
+    if: github.ref == 'refs/tags/*'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    env:
+      # Variables
+      AML_ALLOWED_HOSTS: ${{ vars.AML_ALLOWED_HOSTS }}
+      AML_CORS_ORIGIN_WHITELIST: ${{ vars.AML_CORS_ORIGIN_WHITELIST }}
+      AML_DEBUG: ${{ vars.AML_DEBUG }}
+      AML_LOCATION_PROVIDER: ${{ vars.AML_LOCATION_PROVIDER }}
+      AML_SUBPATH: ${{ vars.AML_SUBPATH }}
+      DJANGO_SETTINGS_MODULE: ${{ vars.DJANGO_SETTINGS_MODULE }}
+      SENTRY_ENVIRONMENT: "acceptance"
+      SQL_DATABASE: ${{ vars.SQL_DATABASE }}
+      SQL_HOST: ${{ vars.SQL_HOST }}
+      SQL_PORT: ${{ vars.SQL_PORT }}
+      FRONTEND_API_ROOT: ${{ vars.FRONTEND_API_ROOT }}
+      FRONTEND_EXPERIMENT_SLUG: ${{ vars.FRONTEND_EXPERIMENT_SLUG }}
+      FRONTEND_AML_HOME: ${{ vars.FRONTEND_AML_HOME }}
+      FRONTEND_HTML_PAGE_TITLE: ${{ vars.FRONTEND_HTML_PAGE_TITLE }}
+      FRONTEND_HTML_FAVICON: ${{ vars.FRONTEND_HTML_FAVICON || '' }}
+      FRONTEND_LOGO_URL: ${{ vars.FRONTEND_LOGO_URL || '' }}
+      FRONTEND_HTML_OG_DESCRIPTION: ${{ vars.FRONTEND_HTML_OG_DESCRIPTION || '' }}
+      FRONTEND_HTML_OG_IMAGE: ${{ vars.FRONTEND_HTML_OG_IMAGE || '' }}
+      FRONTEND_HTML_OG_TITLE: ${{ vars.FRONTEND_HTML_OG_TITLE || '' }}
+      FRONTEND_HTML_OG_URL: ${{ vars.FRONTEND_HTML_OG_URL || '' }}
+      FRONTEND_HTML_BODY_CLASS: ${{ vars.FRONTEND_HTML_BODY_CLASS || '' }}
+
+      # Secrets
+      AML_SECRET_KEY: ${{ secrets.AML_SECRET_KEY }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SQL_USER: ${{ secrets.SQL_USER }}
+      SQL_PASSWORD: ${{ secrets.SQL_PASSWORD }}
+      FRONTEND_SENTRY_DSN: ${{ secrets.FRONTEND_SENTRY_DSN }}
+      DJANGO_SUPERUSER_USERNAME: ${{ secrets.DJANGO_SUPERUSER_USERNAME }}
+      DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
+      DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
+      # Prevent podman services from exiting after startup
+      RUNNER_TRACKING_ID: ""
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create .env file
+        run: |
+          touch .env
+          echo "VITE_API_ROOT=$FRONTEND_API_ROOT" >> .env
+          echo "VITE_EXPERIMENT_SLUG=$FRONTEND_EXPERIMENT_SLUG" >> .env
+          echo "VITE_AML_HOME=$FRONTEND_AML_HOME" >> .env
+          echo "VITE_LOGO_URL=$FRONTEND_LOGO_URL" >> .env
+          echo "VITE_HTML_FAVICON=$FRONTEND_HTML_FAVICON" >> .env
+          echo "VITE_HTML_PAGE_TITLE=$FRONTEND_HTML_PAGE_TITLE" >> .env
+          echo "VITE_HTML_OG_DESCRIPTION=$FRONTEND_HTML_OG_DESCRIPTION" >> .env
+          echo "VITE_HTML_OG_IMAGE=$FRONTEND_HTML_OG_IMAGE" >> .env
+          echo "VITE_HTML_OG_TITLE=$FRONTEND_HTML_OG_TITLE" >> .env
+          echo "VITE_HTML_OG_URL=$FRONTEND_HTML_OG_URL" >> .env
+          echo "VITE_HTML_BODY_CLASS=$FRONTEND_HTML_BODY_CLASS" >> .env
+          echo "VITE_SENTRY_DSN=$FRONTEND_SENTRY_DSN" >> .env
+          cp .env frontend/.env
+      - name: Build Podman images
+        run: podman-compose -f docker-compose-deploy.yml build
+      - name: Deploy Podman images
+        run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
+      - name: Notify Sentry of new release
+        run: |
+          curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \
+          -H "Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "version": "${{ github.sha }}",
+            "refs": [{
+              "repository": "Amsterdam-Music-Lab/MUSCLE",
+              "commit": "${{ github.sha }}"
+            }],
+            "projects": ["muscle-frontend", "muscle-backend"],
+            "environment": "production"
+          }'
+      - name: Prune old images
+        run: podman image prune -a -f
+      - name: Check Podman images
+        run: podman-compose -f docker-compose-deploy.yml ps

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - main
-      - ci/deploy-prod
   workflow_dispatch:
 
 jobs:
@@ -195,7 +194,7 @@ jobs:
     runs-on: PRD
 
     # this job runs only on tags
-    if: true || github.ref == 'refs/tags/*'
+    if: github.ref == 'refs/tags/*'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:


### PR DESCRIPTION
This newly added GitHub actions workflow job is configured to deploy whenever a new tag is created. This is different from the job that deploys to Acceptance, which also deploys on commits to `main`.

Related to #1014