### PR TITLE
fix: return correct content for first_round

### DIFF
--- a/backend/experiment/rules/thats_my_song.py
+++ b/backend/experiment/rules/thats_my_song.py
@@ -55,7 +55,7 @@ class ThatsMySong(Hooked):
     def first_round(self, experiment):
         actions = super().first_round(experiment)
         # skip Consent and Playlist action
-        return actions[:1]
+        return [actions[0]]
 
     def next_round(self, session):	
         """Get action data for the next round"""


### PR DESCRIPTION
#1021 introduced a different ordering of the `hooked` rules file's `first_round` array. This meant that "That's My Song" picked the wrong action from it.