### PR TITLE
Fixed: Deploy to production on tags and release creation

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
       - main
+    tags:
+      - '*'
   workflow_dispatch:
   release:
     types: [created]
@@ -196,7 +198,7 @@ jobs:
     runs-on: PRD
 
     # this job runs only on tags
-    if: github.ref == 'refs/tags/*'
+    if: github.ref == 'refs/tags/*' || github.event_name == 'release'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -197,8 +197,8 @@ jobs:
     environment: Production
     runs-on: PRD
 
-    # this job runs only on tags
-    if: github.ref == 'refs/tags/*' || github.event_name == 'release'
+    # this job runs only on tags or when a release is created, or when manually triggered for a tag
+    if: github.ref == 'refs/tags/*' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/tags/*')
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     env:


### PR DESCRIPTION
The workflow and individual job seemed to have conflicting conditions:

- The workflow was configured to run after a release creation
- The deploy to production job was configured to run on a commit with a tag

Now, the workflow and the deploy to production job should run on _both_ a release creation as well as a tag creation. Additionally, one can do a manual workflow trigger on a tag to deploy to production.