### PR TITLE
Fix return value in the experiment form's clean_playlists method

### DIFF
--- a/backend/experiment/forms.py
+++ b/backend/experiment/forms.py
@@ -182,6 +182,10 @@ class ExperimentForm(ModelForm):
         rules = cl()
 
         playlists = self.cleaned_data['playlists']
+
+        if not playlists:
+            return self.cleaned_data['playlists']
+        
         playlist_errors = []
 
         # Validate playlists
@@ -193,6 +197,8 @@ class ExperimentForm(ModelForm):
 
         if playlist_errors:
             self.add_error('playlists', playlist_errors)
+
+        return self.cleaned_data['playlists']
 
     class Meta:
         model = Experiment


### PR DESCRIPTION
This pull request fixes the return value in the `clean_playlists` method of the experiment form. Previously, if there were no playlists, the method would return `None`, but now it correctly returns the cleaned data. This ensures that the form validation works as expected.