### PR TITLE
Added: Validate file existence validation in Experiment & Playlist forms

### DIFF
--- a/backend/experiment/forms.py
+++ b/backend/experiment/forms.py
@@ -192,6 +192,8 @@ class ExperimentForm(ModelForm):
         for playlist in playlists:
             errors = rules.validate_playlist(playlist)
 
+            playlist.clean()
+
             for error in errors:
                 playlist_errors.append(f"Playlist [{playlist.name}]: {error}")
 

--- a/backend/experiment/forms.py
+++ b/backend/experiment/forms.py
@@ -192,15 +192,13 @@ class ExperimentForm(ModelForm):
         for playlist in playlists:
             errors = rules.validate_playlist(playlist)
 
-            playlist.clean()
-
             for error in errors:
                 playlist_errors.append(f"Playlist [{playlist.name}]: {error}")
 
         if playlist_errors:
             self.add_error('playlists', playlist_errors)
 
-        return self.cleaned_data['playlists']
+        return playlists
 
     class Meta:
         model = Experiment

--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -3,10 +3,11 @@ import logging
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 from django.conf import settings
+from django.core.exceptions import ValidationError
 
 from experiment.actions import Final, Form, Trial
-from experiment.models import Experiment
 from section.models import Playlist
+import section.validators
 from experiment.questions.demographics import DEMOGRAPHICS
 from experiment.questions.goldsmiths import MSI_OTHER
 from experiment.questions.utils import question_by_key, unanswered_questions
@@ -170,5 +171,10 @@ class Base(object):
 
         if not sections:
             errors.append('The experiment must have at least one section.')
+
+        try:
+            Playlist.clean_csv(playlist)
+        except ValidationError as e:
+            errors += e.error_list
 
         return errors

--- a/backend/section/forms.py
+++ b/backend/section/forms.py
@@ -1,5 +1,4 @@
 import csv
-import os
 from http import HTTPStatus
 
 from django import forms

--- a/backend/section/forms.py
+++ b/backend/section/forms.py
@@ -19,7 +19,7 @@ class AddSections(forms.Form):
     group = forms.CharField(max_length=128, required=False)
     files = forms.FileField(widget=MultipleFileInput(
         attrs={'accept': '.wav,.mp3,.aiff,.flac,.ogg'}),
-        validators=[audio_file_validator()]),
+        validators=[audio_file_validator()])
 
 
 class PlaylistAdminForm(forms.ModelForm):

--- a/backend/section/forms.py
+++ b/backend/section/forms.py
@@ -48,9 +48,13 @@ class PlaylistAdminForm(forms.ModelForm):
         """Validate the csv file"""
         super().clean()
 
-        print(self.cleaned_data['csv'])
+        url_prefix = self.cleaned_data['url_prefix']
 
         csv_data = self.cleaned_data['csv']
+
+        # We do not check external files
+        if url_prefix:
+            return csv_data
 
         try:
             reader = csv.DictReader(csv_data.splitlines(), fieldnames=(

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -47,18 +47,6 @@ class Playlist(models.Model):
     def __str__(self):
         return self.name
 
-    def clean(self):
-        super().clean()
-
-        sections = Section.objects.filter(playlist=self)
-
-        # Check if section files exist
-        for section in sections:
-            try:
-                file_exists_validator(str(section.filename))
-            except ValidationError as e:
-                self.add_error('csv', e)
-
     def section_count(self):
         """Number of sections"""
         return self.section_set.count()

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -262,7 +262,7 @@ class Section(models.Model):
     song = models.ForeignKey(Song, on_delete=models.CASCADE, blank=True, null=True)
     start_time = models.FloatField(db_index=True, default=0.0)  # sec
     duration = models.FloatField(default=0.0)  # sec
-    filename = models.FileField(upload_to=audio_upload_path, max_length=255, validators=[audio_file_validator(), file_exists_validator])
+    filename = models.FileField(upload_to=audio_upload_path, max_length=255, validators=[audio_file_validator()])
     play_count = models.PositiveIntegerField(default=0)
     code = models.PositiveIntegerField(default=random_code)
     tag = models.CharField(max_length=128, default='0', blank=True)

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -32,6 +32,23 @@ class Playlist(models.Model):
     CSV_OK = 0
     CSV_ERROR = 10
 
+    def clean_csv(self):
+        errors = []
+        sections = Section.objects.filter(playlist=self)
+
+        for section in sections:
+            filename = str(section.filename)
+
+            try:
+                file_exists_validator(filename)
+            except ValidationError as e:
+                errors.append(e)
+
+        if errors:
+            raise ValidationError(errors)
+
+        return self.csv
+
     def save(self, *args, **kwargs):
         """Update playlist csv field on every save"""
         if self.process_csv is False:

--- a/backend/section/validators.py
+++ b/backend/section/validators.py
@@ -1,3 +1,4 @@
+import os
 from django.core.validators import FileExtensionValidator
 from django.core.exceptions import ValidationError
 
@@ -7,6 +8,18 @@ audio_extensions = ['wav', 'mp3', 'aiff', 'flac', 'ogg']
 
 def audio_file_validator():
     return FileExtensionValidator(allowed_extensions=audio_extensions)
+
+
+def file_exists_validator(value: str):
+    filename = value
+
+    if not filename.startswith('http'):
+        full_file_path = f'./upload/{filename}'
+        if not os.path.isfile(full_file_path):
+            raise ValidationError(
+                (f"Error: File '{filename}' cannot be found"),
+                params={"value": value},
+            )
 
 
 def url_prefix_validator(value):

--- a/backend/section/validators.py
+++ b/backend/section/validators.py
@@ -2,7 +2,6 @@ import os
 from django.core.validators import FileExtensionValidator
 from django.core.exceptions import ValidationError
 
-
 audio_extensions = ['wav', 'mp3', 'aiff', 'flac', 'ogg']
 
 


### PR DESCRIPTION
This pull request fixes the file existence validation in the Playlist model and admin form. 

The `clean_csv` method in the Playlist model now performs file existence validation for section files. It checks if the referenced files exist using the `file_exists_validator` function. If any file is not found, a `ValidationError` is raised and added to the `csv` field errors.

Additionally, it fixes an existing problem in the experiment rules validation method.