### PR TITLE
Feature/display footer

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -188,10 +188,6 @@ class ExperimentCollectionGroupInline(admin.StackedInline):
     inlines = [GroupedExperimentInline]
 
 
-class MarkdownPreviewTextInput(TextInput):
-    template_name = 'widgets/markdown_preview_text_input.html'
-
-
 class ExperimentCollectionAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
     list_display = ('name', 'slug_link', 'description_excerpt', 'dashboard', 'groups')
     fields = ['slug', 'name', 'description', 'consent', 'theme_config', 'dashboard',

--- a/backend/section/admin.py
+++ b/backend/section/admin.py
@@ -1,4 +1,5 @@
 import csv
+from os.path import join
 
 from inline_actions.admin import InlineActionsModelAdminMixin
 from django.contrib import admin, messages
@@ -110,7 +111,8 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
                     song = get_or_create_song(this_artist, this_name)
                 new_section.song = song
 
-                file_path = settings.MEDIA_ROOT + '/' + str(new_section.filename)
+                file_path = join(settings.MEDIA_ROOT,
+                                 str(new_section.filename))
                 with audioread.audio_open(file_path) as f:
                     new_section.duration = f.duration
                 new_section.save()

--- a/backend/theme/serializers.py
+++ b/backend/theme/serializers.py
@@ -3,16 +3,29 @@ from os.path import join
 from django.conf import settings
 from django.utils.translation import activate, gettext_lazy as _
 
+from django_markup.markup import formatter
+
+from image.models import Image
 from theme.models import FooterConfig, HeaderConfig, ThemeConfig
 
 
 def serialize_footer(footer: FooterConfig) -> dict:
     return {
-        'disclaimer': footer.disclaimer,
+        'disclaimer': formatter(
+            footer.disclaimer, filter_name='markdown'),
         'logos': [
-            join(settings.MEDIA_URL, str(logo.file)) for logo in footer.logos.all()
+            serialize_logo(logo) for logo in footer.logos.all()
         ],
-        'privacy': footer.privacy
+        'privacy': formatter(
+            footer.privacy, filter_name='markdown'),
+    }
+
+
+def serialize_logo(logo: Image) -> dict:
+    return {
+        'file': join(settings.MEDIA_URL, str(logo.file)),
+        'href': logo.href,
+        'alt': logo.alt,
     }
 
 

--- a/backend/theme/tests/test_serializers.py
+++ b/backend/theme/tests/test_serializers.py
@@ -7,13 +7,19 @@ from theme.serializers import serialize_footer, serialize_header, serialize_them
 
 
 class ThemeConfigSerializerTest(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         logo_image = Image.objects.create(
-            file='someimage.jpg'
+            file='someimage.jpg',
+            href='someurl.com',
+            alt='Alt text'
         )
         background_image = Image.objects.create(
-            file='anotherimage.png'
+            file='anotherimage.png',
+            href='another.url.com',
+            alt='Another alt text'
         )
         cls.theme = ThemeConfig.objects.create(
             name='Default',
@@ -25,7 +31,8 @@ class ThemeConfigSerializerTest(TestCase):
         )
         cls.footer = FooterConfig.objects.create(
             theme=cls.theme,
-            disclaimer='Some [more information][https://example.com/our-team]'
+            disclaimer='Some [information](https://example.com/our-team)',
+            privacy='Some privacy message'
         )
         cls.footer.logos.add(logo_image)
         cls.footer.logos.add(background_image)
@@ -36,9 +43,20 @@ class ThemeConfigSerializerTest(TestCase):
 
     def test_footer_serializer(self):
         expected_json = {
-            'disclaimer': 'Some [more information][https://example.com/our-team]',
-            'logos': [f'{settings.MEDIA_URL}someimage.jpg', f'{settings.MEDIA_URL}anotherimage.png'],
-            'privacy': ''
+            'disclaimer': '<p>Some <a href="https://example.com/our-team">information</a></p>',
+            'logos': [
+                {
+                    'file': f'{settings.MEDIA_URL}someimage.jpg',
+                    'href': 'someurl.com',
+                    'alt': 'Alt text'
+                },
+                {
+                    'file': f'{settings.MEDIA_URL}anotherimage.png',
+                    'href': 'another.url.com',
+                    'alt': 'Another alt text'
+                }
+            ],
+            'privacy': '<p>Some privacy message</p>'
         }
         self.assertEqual(serialize_footer(self.footer), expected_json)
 

--- a/frontend/src/components/AppBar/AppBar.jsx
+++ b/frontend/src/components/AppBar/AppBar.jsx
@@ -8,7 +8,7 @@ const AppBar = ({ title, logoClickConfirm = null }) => {
 
     const theme = useBoundStore((state) => state.theme);
 
-    const logoUrl = theme?.logoUrl? (API_BASE_URL + theme.logoUrl) : LOGO_URL;
+    const logoUrl = theme?.logoUrl ? (API_BASE_URL + theme.logoUrl) : LOGO_URL;
 
     // Handle click on logo, to optionally confirm navigating
     const onLogoClick = (e) => {

--- a/frontend/src/components/AppBar/AppBar.jsx
+++ b/frontend/src/components/AppBar/AppBar.jsx
@@ -8,7 +8,7 @@ const AppBar = ({ title, logoClickConfirm = null }) => {
 
     const theme = useBoundStore((state) => state.theme);
 
-    const logoUrl = theme? (API_BASE_URL + theme.logo_url) : LOGO_URL;
+    const logoUrl = theme?.logoUrl? (API_BASE_URL + theme.logoUrl) : LOGO_URL;
 
     // Handle click on logo, to optionally confirm navigating
     const onLogoClick = (e) => {

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.test.tsx
@@ -5,7 +5,6 @@ import MockAdapter from "axios-mock-adapter";
 import axios from 'axios';
 
 import ExperimentCollection from './ExperimentCollection';
-
 let mock = new MockAdapter(axios);
 
 const getExperiment = (overrides = {}) => {
@@ -21,6 +20,26 @@ const experiment1 = getExperiment({
     slug: 'some_slug',
     name: 'Some Experiment'
 });
+
+const theme = {
+    backgroundUrl: 'someurl.com',
+    bodyFontUrl: 'bodyFontUrl.com',
+    description: 'Description of the theme',
+    headingFontUrl: 'headingFontUrl.com',
+    logoUrl: 'logoUrl.com',
+    name: 'Awesome theme',
+    footer: {
+        disclaimer: 'disclaimer',
+        logos: [
+            {
+                'file': 'some/logo.jpg',
+                'href': 'some.url.net',
+                'alt': 'Our beautiful logo',
+            }
+        ],
+        privacy: 'privacy'
+    }
+}
 
 const experimentWithAllProps = getExperiment({ image: 'some_image.jpg', description: 'Some description' });
 
@@ -85,15 +104,27 @@ describe('ExperimentCollection', () => {
         })
     });
 
-    it('shows consent first if available', () => {
+    it('shows consent first if available', async () => {
         mock.onGet().replyOnce(200, { consent: '<p>This is our consent form!</p>', dashboard: [experimentWithAllProps], next_experiment: experiment1} );
         render(
             <MemoryRouter>
                 <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
             </MemoryRouter>
         );
-        waitFor(() => {
-            expect(screen.getByText('This is our consent form!')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(document.querySelector('.consent-text')).not.toBeNull();
+        })
+    });
+
+    it('shows a footer if a theme with footer is available', async () => {
+        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], next_experiment: experiment1, theme });
+        render(
+            <MemoryRouter>
+                <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
+            </MemoryRouter>
+        );
+        await waitFor( () => {
+            expect(document.querySelector('.aha__footer')).not.toBeNull();
         })
     })
 })

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
@@ -9,6 +9,7 @@ import {
 import useBoundStore from "../../util/stores";
 import { useExperimentCollection } from "@/API";
 import Consent from "../Consent/Consent";
+import Footer from "../Footer/Footer";
 import DefaultPage from "../Page/DefaultPage";
 import Loading from "../Loading/Loading";
 import ExperimentCollectionAbout from "./ExperimentCollectionAbout/ExperimentCollectionAbout";
@@ -34,6 +35,10 @@ const ExperimentCollection = ({ match }: ExperimentCollectionProps) => {
     const nextExperiment = experimentCollection?.next_experiment;
     const displayDashboard = experimentCollection?.dashboard.length;
     const showConsent = experimentCollection?.consent;
+
+    if (experimentCollection?.theme) {
+        setTheme(experimentCollection.theme);
+    }
 
     const onNext = () => {
         setHasShownConsent(true);
@@ -74,6 +79,13 @@ const ExperimentCollection = ({ match }: ExperimentCollectionProps) => {
                 <Route path={URLS.experimentCollectionAbout} component={() => <ExperimentCollectionAbout content={experimentCollection?.aboutContent} slug={experimentCollection.slug} />} />
                 <Route path={URLS.experimentCollection} exact component={() => <ExperimentCollectionDashboard experimentCollection={experimentCollection} participantIdUrl={participantIdUrl} />} />
             </Switch>
+            {experimentCollection.theme?.footer && (
+                <Footer
+                    disclaimer={experimentCollection.theme.footer.disclaimer}
+                    logos={experimentCollection.theme.footer.logos}
+                    privacy={experimentCollection.theme.footer.privacy}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/components/Footer/Footer.scss
+++ b/frontend/src/components/Footer/Footer.scss
@@ -8,7 +8,7 @@
     flex-direction: column;
     text-align: center;
 
-    .disclaimer > * {
+    .disclaimer, .privacy > * {
         max-width: 700px;
         margin: 0 auto;
     }
@@ -17,7 +17,7 @@
         padding-top: 30px;
         padding-bottom: 30px;
         display: flex;
-       gap: 45px;
+        gap: 45px;
         flex-wrap: wrap;
         align-items: center;
         justify-content: center;

--- a/frontend/src/components/Footer/Footer.scss
+++ b/frontend/src/components/Footer/Footer.scss
@@ -1,0 +1,56 @@
+.aha__footer {
+    margin-top: 30px;
+    padding-top: 20px;
+    padding-bottom: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    text-align: center;
+
+    p {
+        max-width: 700px;
+    }
+
+    .logos {
+        padding-top: 30px;
+        padding-bottom: 30px;
+        display: flex;
+        column-gap: 45px;
+        row-gap: 45px;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
+
+        a {
+            max-width: 80%;
+            width: 330px;
+            display: block;
+            position: relative;
+            transition: opacity 0.3s ease-out;
+            opacity: 0.8;
+            padding: 15px;
+
+            &:hover {
+                opacity: 1;
+            }
+
+            img {
+                width: 200px;
+            }
+        }
+    }
+
+    .privacy, .disclaimer {
+        width: 100%;
+        padding: 20px;
+        text-align: center;
+        font-size: 0.9em;
+        color: white;
+    }
+
+    .privacy {
+        border-top: 2px solid rgba(white, 0.2);
+    }
+}
+

--- a/frontend/src/components/Footer/Footer.scss
+++ b/frontend/src/components/Footer/Footer.scss
@@ -8,8 +8,9 @@
     flex-direction: column;
     text-align: center;
 
-    p {
+    .disclaimer > * {
         max-width: 700px;
+        margin: 0 auto;
     }
 
     .logos {

--- a/frontend/src/components/Footer/Footer.scss
+++ b/frontend/src/components/Footer/Footer.scss
@@ -16,8 +16,7 @@
         padding-top: 30px;
         padding-bottom: 30px;
         display: flex;
-        column-gap: 45px;
-        row-gap: 45px;
+       gap: 45px;
         flex-wrap: wrap;
         align-items: center;
         justify-content: center;

--- a/frontend/src/components/Footer/Footer.test.tsx
+++ b/frontend/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import Footer from "./Footer";
+
+describe('Footer', () => {
+    const defaultProps = {
+        disclaimer: 'This project was conceived by the <a href="mcg.uva.nl">Music Cognition Gorup</a>',
+        logos: [
+            {
+                'file': 'some/logo.jpg',
+                'href': 'some.url.net',
+                'alt': 'Our beautiful logo',
+            },
+            {
+                'file': 'another/path.jpg',
+                'href': 'another.url.net',
+                'alt': 'And another logo',
+            }
+        ],
+        privacy: 'Some privacy statement'
+    }
+
+    it('renders a disclaimer', async () => {
+        render(
+            <Footer {... defaultProps}></Footer>
+        )
+        expect(screen.findByText('project'));
+    });
+
+    it('renders the logos', async () => {
+        render(
+            <Footer {... defaultProps}></Footer>
+        )
+        expect(document.querySelectorAll('img').length).toEqual(2);
+    });
+
+    it('renders the disclaimer', async () => {
+        render(
+            <Footer {... defaultProps}></Footer>
+        )
+        expect(screen.getByText('Some privacy statement'));
+    });
+});

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -12,11 +12,12 @@ export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
                 }}
             />
             <div className="logos">
-                {logos.map((logo: ILogo) => (
+                {logos.map((logo: ILogo, index: number) => (
                     <a
                         href={logo.href}
                         target="_blank"
                         rel="noopener noreferrer"
+                        key={index}
                     >
                         <img src={API_BASE_URL + logo.file} alt={logo.alt} />
                     </a>

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -23,7 +23,7 @@ export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
                     </a>
                 ))}
             </div>
-            <div className="disclaimer" dangerouslySetInnerHTML={{
+            <div className="privacy" dangerouslySetInnerHTML={{
                 __html: privacy,
                 }}
             />

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -22,11 +22,10 @@ export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
                     </a>
                 ))};
             </div>
-            <div className="privacy">
-                <p>
-                    {privacy}
-                </p>
-            </div>
+            <p className="disclaimer" dangerouslySetInnerHTML={{
+                __html: privacy,
+                }}
+            />
         </div>
     )
 }

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { API_BASE_URL } from "@/config";
+
+import { Footer as IFooter, Logo as ILogo } from "@types/Footer";
+
+export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
+    return (
+        <div className="aha__footer">
+            <p className="disclaimer" dangerouslySetInnerHTML={{
+                __html: disclaimer,
+                }}
+            />
+            <div className="logos">
+                {logos.map((logo: ILogo) => (
+                    <a
+                        href={logo.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <img src={API_BASE_URL + logo.file} alt={logo.alt} />
+                    </a>
+                ))};
+            </div>
+            <div className="privacy">
+                <p>
+                    {privacy}
+                </p>
+            </div>
+        </div>
+    )
+}
+
+export default Footer;

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -21,7 +21,7 @@ export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
                     >
                         <img src={API_BASE_URL + logo.file} alt={logo.alt} />
                     </a>
-                ))};
+                ))}
             </div>
             <div className="disclaimer" dangerouslySetInnerHTML={{
                 __html: privacy,

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import { Footer as IFooter, Logo as ILogo } from "@types/Footer";
 export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
     return (
         <div className="aha__footer">
-            <p className="disclaimer" dangerouslySetInnerHTML={{
+            <div className="disclaimer" dangerouslySetInnerHTML={{
                 __html: disclaimer,
                 }}
             />
@@ -23,7 +23,7 @@ export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
                     </a>
                 ))};
             </div>
-            <p className="disclaimer" dangerouslySetInnerHTML={{
+            <div className="disclaimer" dangerouslySetInnerHTML={{
                 __html: privacy,
                 }}
             />

--- a/frontend/src/components/components.scss
+++ b/frontend/src/components/components.scss
@@ -42,3 +42,6 @@
 @import "./FeedbackForm/FeedbackForm";
 @import "./ToontjeHoger/ToontjeHoger";
 @import "./UserFeedback/UserFeedback";
+
+// ExperimentCollection
+@import "./Footer/Footer";

--- a/frontend/src/types/Theme.ts
+++ b/frontend/src/types/Theme.ts
@@ -4,6 +4,25 @@ export interface Header {
     showScore: boolean;
 };
 
+export interface Header {
+    nextExperimentButtonText: string;
+    aboutButtonText: string;
+    showScore: boolean;
+};
+
+export interface Logo {
+    href: string;
+    file: string;
+    alt: string;
+}
+
+export interface Footer {
+    disclaimer: string;
+    logos: Logo[];
+    privacy: string;
+}
+
+
 export default interface Theme {
     backgroundUrl: string;
     bodyFontUrl: string;
@@ -11,6 +30,6 @@ export default interface Theme {
     headingFontUrl: string;
     logoUrl: string;
     name: string;
-    footer: null;
+    footer: Footer | null;
     header: Header | null;
 }


### PR DESCRIPTION
Close #980 . Display a disclaimer, logos and privacy statement, cf. [Toontjehoger](https://toontjehoger.amsterdammusiclab.nl/toontjehoger). The styling may still need to be adjusted, but leaving this for later.