### PR TITLE
Fixed: Fix theme serialization in get_experiment view

### DIFF
--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -271,6 +271,10 @@ class Experiment(models.Model):
     def get_rules(self):
         """Get instance of rules class to be used for this session"""
         from experiment.rules import EXPERIMENT_RULES
+
+        if self.rules not in EXPERIMENT_RULES:
+            raise ValueError(f"Rules do not exist (anymore): {self.rules} for experiment {self.name} ({self.slug})")
+
         cl = EXPERIMENT_RULES[self.rules]
         return cl()
 

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -11,8 +11,10 @@ from experiment.models import (
     ExperimentCollectionGroup,
     GroupedExperiment,
 )
+from experiment.rules.hooked import Hooked
 from participant.models import Participant
 from session.models import Session
+from theme.models import ThemeConfig, FooterConfig, HeaderConfig
 
 
 class TestExperimentCollectionViews(TestCase):
@@ -20,9 +22,11 @@ class TestExperimentCollectionViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.participant = Participant.objects.create()
+        theme_config = create_theme_config()
         collection = ExperimentCollection.objects.create(
             name='Test Series',
-            slug='test_series'
+            slug='test_series',
+            theme_config=theme_config
         )
         introductory_group = ExperimentCollectionGroup.objects.create(
             name='introduction',
@@ -41,7 +45,7 @@ class TestExperimentCollectionViews(TestCase):
             order=2
         )
         cls.experiment2 = Experiment.objects.create(
-            name='experiment2', slug='experiment2')
+            name='experiment2', slug='experiment2', theme_config=theme_config)
         cls.experiment3 = Experiment.objects.create(
             name='experiment3', slug='experiment3')
         GroupedExperiment.objects.create(
@@ -94,8 +98,15 @@ class TestExperimentCollectionViews(TestCase):
             finished_at=timezone.now()
         )
         response = self.client.get('/experiment/collection/test_series/')
-        self.assertEqual(response.json().get(
+        response_json = response.json()
+        self.assertEqual(response_json.get(
             'next_experiment').get('slug'), 'experiment4')
+        self.assertEqual(response_json.get('dashboard'), [])
+        self.assertEqual(response_json.get('theme').get('name'), 'test_theme')
+        self.assertEqual(response_json.get('theme').get('header').get(
+            'showScore'), True)
+        self.assertEqual(response_json.get('theme').get('footer').get(
+            'disclaimer'), 'Test Disclaimer')
 
     def test_experiment_collection_with_dashboard(self):
         # if ExperimentCollection has dashboard set True, return list of random experiments
@@ -127,7 +138,8 @@ class ExperimentViewsTest(TestCase):
             description='This is a test experiment',
             image=Image.objects.create(
                 file='test-image.jpg'
-            )
+            ),
+            theme_config=create_theme_config()
         )
         participant = Participant.objects.create()
         Session.objects.bulk_create([
@@ -156,3 +168,61 @@ class ExperimentViewsTest(TestCase):
         self.assertEqual(
             serialized_experiment['started_session_count'], 3
         )
+
+    def test_get_experiment(self):
+        # Create an experiment
+        experiment = Experiment.objects.create(
+            slug='test-experiment',
+            name='Test Experiment',
+            description='This is a test experiment',
+            image=Image.objects.create(
+                file='test-image.jpg'
+            ),
+            rules=Hooked.ID,
+            theme_config=create_theme_config()
+        )
+        participant = Participant.objects.create()
+        Session.objects.bulk_create([
+            Session(experiment=experiment, participant=participant, finished_at=timezone.now()) for index in range(3)
+        ])
+
+        response = self.client.get('/experiment/test-experiment/')
+
+        self.assertEqual(
+            response.json()['slug'], 'test-experiment'
+        )
+        self.assertEqual(
+            response.json()['name'], 'Test Experiment'
+        )
+        self.assertEqual(
+            response.json()['theme']['name'], 'test_theme'
+        )
+        self.assertEqual(
+            response.json()['theme']['header']['showScore'], True
+        )
+        self.assertEqual(
+            response.json()['theme']['footer']['disclaimer'], 'Test Disclaimer'
+        )
+
+
+def create_theme_config():
+    theme_config = ThemeConfig.objects.create(
+            name='test_theme',
+            description='Test Theme',
+            heading_font_url='https://fonts.googleapis.com/css2?family=Architects+Daughter&family=Micro+5&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap',
+            body_font_url='https://fonts.googleapis.com/css2?family=Architects+Daughter&family=Micro+5&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap',
+            logo_image=Image.objects.create(file='test-logo.jpg'),
+            background_image=Image.objects.create(file='test-background.jpg'),
+    )
+    HeaderConfig.objects.create(
+        theme=theme_config,
+        show_score=True
+    )
+    footer_config = FooterConfig.objects.create(
+        theme=theme_config,
+        disclaimer='Test Disclaimer',
+        privacy='Test Privacy',
+    )
+    footer_config.logos.add(Image.objects.create(file='test-logo.jpg'))
+
+    return theme_config

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -153,3 +153,6 @@ class ExperimentViewsTest(TestCase):
         self.assertEqual(
             serialized_experiment['finished_session_count'], 3
         )
+        self.assertEqual(
+            serialized_experiment['started_session_count'], 3
+        )

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -12,6 +12,7 @@ from experiment.serializers import serialize_actions, serialize_experiment_colle
 from experiment.rules import EXPERIMENT_RULES
 from experiment.actions.utils import COLLECTION_KEY
 from participant.utils import get_participant
+from theme.serializers import serialize_theme
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ def get_experiment(request, slug):
         'id': experiment.id,
         'slug': experiment.slug,
         'name': experiment.name,
-        'theme': experiment.theme_config.to_json() if experiment.theme_config else None,
+        'theme': serialize_theme(experiment.theme_config) if experiment.theme_config else None,
         'class_name': class_name,  # can be used to override style
         'rounds': experiment.rounds,
         'playlists': [

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -76,7 +76,7 @@ def default_questions(request, rules):
 
 
 def get_experiment_collection(request: HttpRequest, slug: str, group_index: int = 0) -> JsonResponse:
-    ''' 
+    '''
     check which `ExperimentCollectionGroup` objects are related to the `ExperimentCollection` with the given slug
     retrieve the group with the lowest order (= current_group)
     return the next experiment from the current_group without a finished session


### PR DESCRIPTION
This pull request fixes the serialization of the theme in the `get_experiment` view. Previously, the theme was not being serialized correctly, resulting in an internal server error. This PR updates the serialization logic to correctly serialize the theme.

Additionally, extra tests are added to test the serialization of get_experiment and get_experiment_collection.

PS. @BeritJanssen  I noted that we don't use `serialize_experiment` in the `get_experiment` view method. Is that on purpose? Because the `get_experiment_collection` view method does seem to use `serialize_experiment_collection`. 🤔

Resolves #1049 