### PR TITLE
Bugfix/final on next

### DIFF
--- a/frontend/src/components/Experiment/Experiment.tsx
+++ b/frontend/src/components/Experiment/Experiment.tsx
@@ -93,7 +93,7 @@ const Experiment = ({ match }) => {
     };
 
     // trigger next action from next_round array, or call session/next_round
-    const onNext = async (doBreak) => {
+    const onNext = async (doBreak: boolean = false) => {
         if (!doBreak && actions.length) {
             updateActions(actions);
         } else {

--- a/frontend/src/components/Final/Final.jsx
+++ b/frontend/src/components/Final/Final.jsx
@@ -65,9 +65,9 @@ const Final = ({ experiment, participant, score, final_text, action_texts, butto
             </div>
             {button && (
                 <div className="text-center pt-4">
-                    <Link className='btn btn-primary btn-lg' to={button.link} onClick={button.link ? undefined : onNext}>
+                    <a className='btn btn-primary btn-lg' href={button.link} onClick={() => onNext()}>
                         {button.text}
-                    </Link>
+                    </a>
                 </div>
             )}
             {logo && (


### PR DESCRIPTION
The ToontjeHoger experiments continue after the "Final" round, but the `onNext` method would get a `SyntheticBaseEvent` instead of undefined / false for the `doBreak` condition. This could be solved through wrapping the onNext call from the `onClick` in a function, which would not pass through an event anymore.

Also changed the `Link` to an `a` element. This to avoid an error being thrown when `button` was defined, but `button.link`, and therefore `<Link to='...`>` was not defined.