### PR TITLE
Fixed: Fix internal Final button link (v2)

### DIFF
--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -18,6 +18,7 @@ import Profile from "../Profile/Profile";
 import Reload from "../Reload/Reload";
 import StoreProfile from "../StoreProfile/StoreProfile";
 import useDisableRightClickOnTouchDevices from "../../hooks/useDisableRightClickOnTouchDevices";
+import { InternalRedirect } from "../InternalRedirect/InternalRedirect";
 
 
 // App is the root component of our application
@@ -74,6 +75,8 @@ const App = () => {
                     <Route path={URLS.profile} exact>
                         <Profile slug={EXPERIMENT_SLUG} />
                     </Route>
+
+                    <Route path={URLS.internalRedirect} component={InternalRedirect} />
 
                     {/* Experiment Collection */}
                     <Route path={URLS.experimentCollection} component={ExperimentCollection} />

--- a/frontend/src/components/Final/Final.test.jsx
+++ b/frontend/src/components/Final/Final.test.jsx
@@ -146,7 +146,7 @@ session="session-id"
 
         const el = screen.getByTestId('button-link');
         expect(el).to.exist;
-        expect(el.getAttribute('href')).toBe('/aml');
+        expect(el.getAttribute('href')).toBe('/redirect/aml');
     });
 
     it('Uses an anchor tag to navigate when button link is absolute', () => {
@@ -161,5 +161,22 @@ session="session-id"
         const el = screen.getByTestId('button-link');
         expect(el).to.exist;
         expect(el.getAttribute('href')).toBe('https://example.com');
+    });
+
+    it('Calls onNext when there is no button link and the user clicks the button', async () => {
+        const onNextMock = vi.fn();
+        render(
+            <BrowserRouter>
+                <Final
+                    button={{ text: 'Next' }}
+                    onNext={onNextMock}
+                />
+            </BrowserRouter>
+        );
+
+        fireEvent.click(screen.getByTestId('button'));
+        await waitFor(() => {
+            expect(onNextMock).toHaveBeenCalled();
+        });
     });
 });

--- a/frontend/src/components/Final/FinalButton.tsx
+++ b/frontend/src/components/Final/FinalButton.tsx
@@ -30,8 +30,10 @@ const FinalButton: React.FC<FinalButtonProps> = ({ button, onNext }) => {
 
     // If the button has a link, it will render a Link component if the link is a relative URL
     if (isRelativeUrl(button.link)) {
+        const url = `/redirect${button.link}`
+
         return (
-            <Link data-testid="button-link" className='btn btn-primary btn-lg' to={button.link}>
+            <Link data-testid="button-link" className='btn btn-primary btn-lg' to={url}>
                 {button.text}
             </Link>
         )

--- a/frontend/src/components/InternalRedirect/InternalRedirect.tsx
+++ b/frontend/src/components/InternalRedirect/InternalRedirect.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+// this component is a route, so it will receive the route props
+interface InternalRedirectProps extends RouteComponentProps {}
+
+export const InternalRedirect: React.FC<InternalRedirectProps> = (props) => {
+    const { path } = props.match.params as { path: string };
+    const { search } = props.location;
+
+    // Redirect to the experiment path
+    return <Redirect to={`/${path}${search}`} />;
+}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -31,6 +31,7 @@ export const URLS = {
     experiment: "/:slug",
     experimentCollectionAbout: "/collection/:slug/about",
     experimentCollection: "/collection/:slug",
+    internalRedirect: "/redirect/:path",
     reloadParticipant: "/participant/reload/:id/:hash",
     theme: "/theme/:id",
     AMLHome:


### PR DESCRIPTION
Fix internal Final button link, which wouldn't cause an experiment to reload as the user was already on that page, by introducing an InternalRedirect.

The InternalRedirect has its own route and then redirects the user to the correct page with the correct search params. In short, it will lead you from `/thats_my_song?participant_id=123` to `/redirect/hats_my_song?participant_id=123`, which in turn will lead you back to `/thats_my_song?participant_id=123`, which will then trigger an experiment reload.

Alternatively, we could also just revert back to the earlier used anchor tag (<a>), which will do a full page reload but causes a little screen flash / glitch to appear as it reloads all the HTML / JS & CSS and shows an empty page for some milliseconds.

## Additional notes

There was an earlier attempt #1051  to fix problems related to the Play again button in the Final component, but it generated some unanticipated problems.

Resolves #1046