### PR TITLE
Fix: Teletunes questions import and circular import

### DIFF
--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -6,13 +6,11 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from experiment.actions import Final, Form, Trial
-from question.demographics import DEMOGRAPHICS
 from question.utils import unanswered_questions
-from section.models import Playlist
-from result.score import SCORING_RULES
-from session.models import Session
-
 from question.questions import get_questions_from_series, QUESTION_GROUPS
+from result.score import SCORING_RULES
+from section.models import Playlist
+from session.models import Session
 
 logger = logging.getLogger(__name__)
 

--- a/backend/experiment/rules/hooked.py
+++ b/backend/experiment/rules/hooked.py
@@ -8,16 +8,9 @@ from .base import Base
 from experiment.actions import Consent, Explainer, Final, Playlist, Score, Step, Trial
 from experiment.actions.form import BooleanQuestion, Form
 from experiment.actions.playback import Autoplay
-from question.questions import QUESTION_GROUPS
-from question.demographics import DEMOGRAPHICS
-from question.goldsmiths import MSI_OTHER
-from question.utils import question_by_key
-from question.utils import copy_shuffle
-from question.goldsmiths import MSI_FG_GENERAL, MSI_ALL
-from question.stomp import STOMP20
-from question.tipi import TIPI
 from experiment.actions.styles import STYLE_BOOLEAN_NEGATIVE_FIRST
 from experiment.actions.wrappers import song_sync
+from question.questions import QUESTION_GROUPS
 from result.utils import prepare_result
 
 

--- a/backend/experiment/rules/huang_2022.py
+++ b/backend/experiment/rules/huang_2022.py
@@ -7,12 +7,8 @@ from django.conf import settings
 from experiment.actions import HTML, Final, Explainer, Step, Consent, Redirect, Playlist, Trial
 from experiment.actions.form import BooleanQuestion, Form
 from experiment.actions.playback import Autoplay
-from question.demographics import EXTRA_DEMOGRAPHICS
-from question.goldsmiths import MSI_ALL, MSI_OTHER
-from question.other import OTHER
-from question.utils import question_by_key
-from question.questions import QUESTION_GROUPS
 from experiment.actions.styles import STYLE_BOOLEAN_NEGATIVE_FIRST
+from question.questions import QUESTION_GROUPS
 from result.utils import prepare_result
 from .hooked import Hooked
 

--- a/backend/experiment/rules/tele_tunes.py
+++ b/backend/experiment/rules/tele_tunes.py
@@ -1,6 +1,4 @@
-from question.musicgens import MUSICGENS_17_W_VARIANTS
-from question.demographics import DEMOGRAPHICS
-from question.utils import copy_shuffle
+from question.questions import QUESTION_GROUPS
 from .hooked import Hooked
 
 

--- a/backend/experiment/rules/thats_my_song.py
+++ b/backend/experiment/rules/thats_my_song.py
@@ -3,11 +3,9 @@ from django.conf import settings
 
 from experiment.actions import Final, Trial
 from experiment.actions.form import Form, ChoiceQuestion
-from question.utils import copy_shuffle, question_by_key
-from question.musicgens import MUSICGENS_17_W_VARIANTS
 from question.questions import QUESTION_GROUPS
-from .hooked import Hooked
 from result.utils import prepare_result
+from .hooked import Hooked
 
 
 class ThatsMySong(Hooked):

--- a/backend/question/demographics.py
+++ b/backend/question/demographics.py
@@ -4,6 +4,8 @@ from experiment.actions.form import ChoiceQuestion, NumberQuestion, TextQuestion
 from experiment.standards.iso_countries import ISO_COUNTRIES
 from experiment.standards.iso_languages import ISO_LANGUAGES
 from experiment.standards.isced_education import ISCED_EDUCATION_LEVELS
+from .utils import question_by_key
+
 
 ATTAINED_EDUCATION_CHOICES = dict(
     ISCED_EDUCATION_LEVELS,
@@ -148,19 +150,20 @@ EXTRA_DEMOGRAPHICS = [
 
 
 def demographics_other():
-    from .utils import question_by_key
-
     questions = []
 
-    question =  question_by_key('dgf_education', drop_choices=['isced-2', 'isced-5'])
+    question = question_by_key('dgf_education', DEMOGRAPHICS, drop_choices=[
+                               'isced-2', 'isced-5'])
     question.key = 'dgf_education_matching_pairs'
     questions.append(question)
 
-    question = question_by_key('dgf_education', drop_choices=['isced-1'])
+    question = question_by_key(
+        'dgf_education', DEMOGRAPHICS, drop_choices=['isced-1'])
     question.key = 'dgf_education_gold_msi'
     questions.append(question)
 
-    question = question_by_key('dgf_education', drop_choices=['isced-5'])
+    question = question_by_key(
+        'dgf_education', DEMOGRAPHICS, drop_choices=['isced-5'])
     question.key = 'dgf_education_huang_2022'
     questions.append(question)
 

--- a/backend/question/utils.py
+++ b/backend/question/utils.py
@@ -3,8 +3,6 @@ import random
 
 from result.utils import prepare_profile_result
 
-from .demographics import DEMOGRAPHICS
-
 
 def copy_shuffle(questions):
     qcopy = deepcopy(questions)
@@ -12,13 +10,13 @@ def copy_shuffle(questions):
     return qcopy
 
 
-def total_unanswered_questions(participant, questions=DEMOGRAPHICS):
+def total_unanswered_questions(participant, questions):
     """ Return how many questions have not been answered yet by the participant"""
     profile_questions = participant.profile().values_list('question_key', flat=True)
     return len([question for question in questions if question.key not in profile_questions])
 
 
-def question_by_key(key, questions=DEMOGRAPHICS, is_skippable=None, drop_choices=[]):
+def question_by_key(key, questions, is_skippable=None, drop_choices=[]):
     """Return question by given key"""
     for question in questions:
         if question.key == key:


### PR DESCRIPTION
After merging, as discussed on another channel, I ran into problems due to a missing import in the Teletunes questions, which in turn, revealed a problem with a circular import, which I propose to fix by removing the defaults for the `questions=` argument in `question_by_key` and `total_unanswered_questions` of `question.utils`.