### PR TITLE
Refactor deployment process to properly stop containers before deployment

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Shut down running containers
         run: podman compose -f docker-compose-deploy.yml down
       - name: Deploy Podman images
-        run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
+        run: podman-compose -f docker-compose-deploy.yml up -d
       - name: Notify Sentry of new release
         run: |
           curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Shut down running containers
         run: podman compose -f docker-compose-deploy.yml down
       - name: Deploy Podman images
-        run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
+        run: podman-compose -f docker-compose-deploy.yml up -d
       - name: Notify Sentry of new release
         run: |
           curl -X POST "https://sentry.io/api/0/organizations/uva-aml/releases/" \

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -172,6 +172,8 @@ jobs:
           cp .env frontend/.env
       - name: Build Podman images
         run: podman-compose -f docker-compose-deploy.yml build
+      - name: Shut down running containers
+        run: podman compose -f docker-compose-deploy.yml down
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
       - name: Notify Sentry of new release
@@ -259,6 +261,8 @@ jobs:
           cp .env frontend/.env
       - name: Build Podman images
         run: podman-compose -f docker-compose-deploy.yml build
+      - name: Shut down running containers
+        run: podman compose -f docker-compose-deploy.yml down
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d --force-recreate
       - name: Notify Sentry of new release

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -62,8 +62,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Shut down running containers
-        run: podman compose -f docker-compose-deploy.yml down
       - name: Create .env file
         run: |
           touch .env
@@ -82,6 +80,8 @@ jobs:
           cp .env frontend/.env
       - name: Build Podman images
         run: podman-compose -f docker-compose-deploy.yml build
+      - name: Shut down running containers
+        run: podman compose -f docker-compose-deploy.yml down
       - name: Deploy Podman images
         run: podman-compose -f docker-compose-deploy.yml up -d
       - name: Notify Sentry of new release


### PR DESCRIPTION
This PR properly stops the running containers before deployment using `podman-compose down` before deploying the containers using `podman-compose up` in both ACC & PROD. Additionally, I've moved the `podman-compose down` command for the TST environment to run *after* the build step to minimze downtime.