### PR TITLE
fix: include `BASE_URL` in image file serialization

### DIFF
--- a/backend/aml/base_settings.py
+++ b/backend/aml/base_settings.py
@@ -195,4 +195,4 @@ MARKUP_SETTINGS = {
     }
 }
 
-SUBPATH = os.getenv('AML_SUBPATH', None)
+SUBPATH = os.getenv('AML_SUBPATH', '')

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 
@@ -190,7 +191,7 @@ class ExperimentViewsTest(TestCase):
         )
         self.assertEqual(
             serialized_experiment['image'], {
-                'file': '/upload/test-image.jpg', 'href': '', 'alt': ''}
+                'file': f'{settings.BASE_URL}/upload/test-image.jpg', 'href': '', 'alt': ''}
         )
         self.assertEqual(
             serialized_experiment['finished_session_count'], 3

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -167,7 +167,9 @@ class ExperimentViewsTest(TestCase):
             name='Test Experiment',
             description='This is a test experiment',
             image=Image.objects.create(
-                file='test-image.jpg'
+                file='test-image.jpg',
+                alt='Test',
+                href='https://www.example.com'
             ),
             theme_config=create_theme_config()
         )
@@ -191,7 +193,7 @@ class ExperimentViewsTest(TestCase):
         )
         self.assertEqual(
             serialized_experiment['image'], {
-                'file': f'{settings.BASE_URL}/upload/test-image.jpg', 'href': '', 'alt': ''}
+                'file': f'{settings.BASE_URL}/upload/test-image.jpg', 'href': 'https://www.example.com', 'alt': 'Test'}
         )
         self.assertEqual(
             serialized_experiment['finished_session_count'], 3

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -11,6 +11,7 @@ from section.models import Playlist
 from experiment.serializers import serialize_actions, serialize_experiment_collection, serialize_experiment_collection_group
 from experiment.rules import EXPERIMENT_RULES
 from experiment.actions.utils import COLLECTION_KEY
+from image.serializers import serialize_image
 from participant.utils import get_participant
 from theme.serializers import serialize_theme
 
@@ -36,7 +37,7 @@ def get_experiment(request, slug):
         'name': experiment.name,
         'theme': serialize_theme(experiment.theme_config) if experiment.theme_config else None,
         'description': experiment.description,
-        'image': experiment.image.file.url if experiment.image else '',
+        'image': serialize_image(experiment.image) if experiment.image else None,
         'class_name': class_name,  # can be used to override style
         'rounds': experiment.rounds,
         'playlists': [

--- a/backend/image/serializers.py
+++ b/backend/image/serializers.py
@@ -7,7 +7,7 @@ from .models import Image
 
 def serialize_image(image: Image) -> dict:
     return {
-        'file': join(settings.MEDIA_URL, settings.SUBPATH, str(image.file)),
+        'file': f'{settings.BASE_URL.strip("/")}/{settings.MEDIA_URL.strip("/")}/{image.file}',
         'href': image.href,
         'alt': image.alt,
     }

--- a/backend/image/serializers.py
+++ b/backend/image/serializers.py
@@ -7,7 +7,7 @@ from .models import Image
 
 def serialize_image(image: Image) -> dict:
     return {
-        'file': join(settings.MEDIA_URL, str(image.file)),
+        'file': join(settings.MEDIA_URL, settings.SUBPATH, str(image.file)),
         'href': image.href,
         'alt': image.alt,
     }

--- a/backend/theme/serializers.py
+++ b/backend/theme/serializers.py
@@ -5,7 +5,7 @@ from django.utils.translation import activate, gettext_lazy as _
 
 from django_markup.markup import formatter
 
-from image.models import Image
+from image.serializers import serialize_image
 from theme.models import FooterConfig, HeaderConfig, ThemeConfig
 
 
@@ -14,18 +14,10 @@ def serialize_footer(footer: FooterConfig) -> dict:
         'disclaimer': formatter(
             footer.disclaimer, filter_name='markdown'),
         'logos': [
-            serialize_logo(logo) for logo in footer.logos.all()
+            serialize_image(logo) for logo in footer.logos.all()
         ],
         'privacy': formatter(
             footer.privacy, filter_name='markdown'),
-    }
-
-
-def serialize_logo(logo: Image) -> dict:
-    return {
-        'file': join(settings.MEDIA_URL, str(logo.file)),
-        'href': logo.href,
-        'alt': logo.alt,
     }
 
 

--- a/backend/theme/tests/test_serializers.py
+++ b/backend/theme/tests/test_serializers.py
@@ -46,12 +46,12 @@ class ThemeConfigSerializerTest(TestCase):
             'disclaimer': '<p>Some <a href="https://example.com/our-team">information</a></p>',
             'logos': [
                 {
-                    'file': f'{settings.MEDIA_URL}someimage.jpg',
+                    'file': f'{settings.BASE_URL}{settings.MEDIA_URL}someimage.jpg',
                     'href': 'someurl.com',
                     'alt': 'Alt text'
                 },
                 {
-                    'file': f'{settings.MEDIA_URL}anotherimage.png',
+                    'file': f'{settings.BASE_URL}{settings.MEDIA_URL}anotherimage.png',
                     'href': 'another.url.com',
                     'alt': 'Another alt text'
                 }

--- a/frontend/src/components/Experiment/Experiment.jsx
+++ b/frontend/src/components/Experiment/Experiment.jsx
@@ -115,7 +115,7 @@ const Experiment = ({ match }) => {
                 setHeadData({
                     title: experiment.name,
                     description: experiment.description,
-                    image: experiment.image.file,
+                    image: experiment.image?.file,
                     url: window.location.href,
                     structuredData: {
                         "@type": "Experiment",

--- a/frontend/src/components/Experiment/Experiment.jsx
+++ b/frontend/src/components/Experiment/Experiment.jsx
@@ -19,7 +19,6 @@ import FloatingActionButton from "@/components/FloatingActionButton/FloatingActi
 import UserFeedback from "@/components/UserFeedback/UserFeedback";
 import FontLoader from "@/components/FontLoader/FontLoader";
 import useResultHandler from "@/hooks/useResultHandler";
-import { API_ROOT } from "../../config";
 
 // Experiment handles the main experiment flow:
 // - Loads the experiment and participant
@@ -116,7 +115,7 @@ const Experiment = ({ match }) => {
                 setHeadData({
                     title: experiment.name,
                     description: experiment.description,
-                    image: `${API_ROOT}/${experiment.image}`,
+                    image: experiment.image.file,
                     url: window.location.href,
                     structuredData: {
                         "@type": "Experiment",

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { API_ROOT } from "@/config";
 import ExperimentCollection from "@/types/ExperimentCollection";
 import AppBar from "@/components/AppBar/AppBar";
 import Header from "@/components/Header/Header";
@@ -54,7 +53,7 @@ export const ExperimentCollectionDashboard: React.FC<ExperimentCollectionDashboa
 }
 
 const ImageOrPlaceholder = ({ imagePath, alt }: { imagePath: string, alt: string }) => {
-    const imgSrc = imagePath ? `${API_ROOT}/${imagePath}` : null;
+    const imgSrc = imagePath ?? null;
 
     return imgSrc ? <img src={imgSrc} alt={alt} /> : <div className="placeholder" />;
 }

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import { API_BASE_URL } from "@/config";
-
 import { Footer as IFooter, Logo as ILogo } from "@types/Footer";
 
 export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
@@ -19,7 +17,7 @@ export const Footer: React.FC<IFooter> = ({disclaimer, logos, privacy}) => {
                         rel="noopener noreferrer"
                         key={index}
                     >
-                        <img src={API_BASE_URL + logo.file} alt={logo.alt} />
+                        <img src={logo.file} alt={logo.alt} />
                     </a>
                 ))}
             </div>


### PR DESCRIPTION
This branch fixes a problem on the servers, in which image requests are incorrectly prefixed with `API_ROOT`. Instead, this branch prefixes the `BASE_URL` for the backend image serialization.