### PR TITLE
Fix/next experiment

### DIFF
--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -58,8 +58,8 @@ def serialize_experiment_collection_group(group: ExperimentCollectionGroup, part
 
     return {
         'dashboard': [serialize_experiment(experiment.experiment, participant) for experiment in grouped_experiments] if group.dashboard else [],
-        'next_experiment': next_experiment,
-        'total_score': total_score
+        'nextExperiment': next_experiment,
+        'totalScore': total_score
     }
 
 
@@ -67,8 +67,6 @@ def serialize_experiment(experiment_object: Experiment, participant: Participant
     return {
         'slug': experiment_object.slug,
         'name': experiment_object.name,
-        'started_session_count': get_started_session_count(experiment_object, participant),
-        'finished_session_count': get_finished_session_count(experiment_object, participant),
         'description': experiment_object.description,
         'image': serialize_image(experiment_object.image) if experiment_object.image else None,
     }

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -77,7 +77,7 @@ class TestExperimentCollectionViews(TestCase):
         # check that first_experiments is returned correctly
         response = self.client.get('/experiment/collection/test_series/')
         self.assertEqual(response.json().get(
-            'next_experiment').get('slug'), 'experiment1')
+            'nextExperiment').get('slug'), 'experiment1')
         # create session
         Session.objects.create(
             experiment=self.experiment1,
@@ -85,7 +85,7 @@ class TestExperimentCollectionViews(TestCase):
             finished_at=timezone.now()
         )
         response = self.client.get('/experiment/collection/test_series/')
-        self.assertIn(response.json().get('next_experiment').get(
+        self.assertIn(response.json().get('nextExperiment').get(
             'slug'), ('experiment2', 'experiment3'))
         self.assertEqual(response.json().get('dashboard'), [])
         Session.objects.create(
@@ -101,7 +101,7 @@ class TestExperimentCollectionViews(TestCase):
         response = self.client.get('/experiment/collection/test_series/')
         response_json = response.json()
         self.assertEqual(response_json.get(
-            'next_experiment').get('slug'), 'experiment4')
+            'nextExperiment').get('slug'), 'experiment4')
         self.assertEqual(response_json.get('dashboard'), [])
         self.assertEqual(response_json.get('theme').get('name'), 'test_theme')
         self.assertEqual(len(response_json['theme']['header']['score']), 3)
@@ -144,7 +144,7 @@ class TestExperimentCollectionViews(TestCase):
         intermediate_group.dashboard = True
         intermediate_group.save()
         serialized_coll_1 = serialize_experiment_collection_group(intermediate_group, self.participant)
-        total_score_1 = serialized_coll_1['total_score']
+        total_score_1 = serialized_coll_1['totalScore']
         self.assertEqual(total_score_1, 8)
         Session.objects.create(
             experiment=self.experiment3,
@@ -153,7 +153,7 @@ class TestExperimentCollectionViews(TestCase):
             final_score=8
         )
         serialized_coll_2 = serialize_experiment_collection_group(intermediate_group, self.participant)
-        total_score_2 = serialized_coll_2['total_score']
+        total_score_2 = serialized_coll_2['totalScore']
         self.assertEqual(total_score_2, 16)
 
 
@@ -191,12 +191,6 @@ class ExperimentViewsTest(TestCase):
         self.assertEqual(
             serialized_experiment['image'], {
                 'file': '/upload/test-image.jpg', 'href': '', 'alt': ''}
-        )
-        self.assertEqual(
-            serialized_experiment['finished_session_count'], 3
-        )
-        self.assertEqual(
-            serialized_experiment['started_session_count'], 3
         )
 
     def test_get_experiment(self):

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.test.tsx
@@ -10,7 +10,7 @@ let mock = new MockAdapter(axios);
 const getExperiment = (overrides = {}) => {
     return {
         slug: 'some_slug',
-        name: 'Some Experiment'
+        name: 'Some Experiment',
         ...overrides
     };
 }
@@ -45,7 +45,7 @@ const experimentWithAllProps = getExperiment({ image: 'some_image.jpg', descript
 describe('ExperimentCollection', () => {
 
     it('forwards to a single experiment if it receives an empty dashboard array', async () => {
-        mock.onGet().replyOnce(200, {dashboard: [], next_experiment: experiment1});
+        mock.onGet().replyOnce(200, {dashboard: [], nextExperiment: experiment1});
         render(
         <MemoryRouter>
             <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
@@ -68,7 +68,7 @@ describe('ExperimentCollection', () => {
     });
 
     it('shows a placeholder if no image is available', () => {
-        mock.onGet().replyOnce(200, { dashboard: [experiment1], next_experiment: experiment1 });
+        mock.onGet().replyOnce(200, { dashboard: [experiment1], nextExperiment: experiment1 });
         render(
         <MemoryRouter>
             <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
@@ -80,7 +80,7 @@ describe('ExperimentCollection', () => {
     });
 
     it('shows the image if it is available', () => {
-        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], next_experiment: experiment1 });
+        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], nextExperiment: experiment1 });
         render(
         <MemoryRouter>
             <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
@@ -92,7 +92,7 @@ describe('ExperimentCollection', () => {
     });
 
     it('shows the description if it is available', () => {
-        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], next_experiment: experiment1 });
+        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], nextExperiment: experiment1 });
         render(
         <MemoryRouter>
             <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
@@ -104,7 +104,7 @@ describe('ExperimentCollection', () => {
     });
 
     it('shows consent first if available', async () => {
-        mock.onGet().replyOnce(200, { consent: '<p>This is our consent form!</p>', dashboard: [experimentWithAllProps], next_experiment: experiment1} );
+        mock.onGet().replyOnce(200, { consent: '<p>This is our consent form!</p>', dashboard: [experimentWithAllProps], nextExperiment: experiment1} );
         render(
             <MemoryRouter>
                 <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>
@@ -116,7 +116,7 @@ describe('ExperimentCollection', () => {
     });
 
     it('shows a footer if a theme with footer is available', async () => {
-        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], next_experiment: experiment1, theme });
+        mock.onGet().replyOnce(200, { dashboard: [experimentWithAllProps], nextExperiment: experiment1, theme });
         render(
             <MemoryRouter>
                 <ExperimentCollection match={{params: {slug: 'some_collection'}}}/>

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.test.tsx
@@ -10,8 +10,7 @@ let mock = new MockAdapter(axios);
 const getExperiment = (overrides = {}) => {
     return {
         slug: 'some_slug',
-        name: 'Some Experiment',
-        finished_session_count: 0,
+        name: 'Some Experiment'
         ...overrides
     };
 }

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
@@ -32,10 +32,10 @@ const ExperimentCollection = ({ match }: ExperimentCollectionProps) => {
     const participant = useBoundStore((state) => state.participant);
     const setTheme = useBoundStore((state) => state.setTheme);
     const participantIdUrl = participant?.participant_id_url;
-    const nextExperiment = experimentCollection?.next_experiment;
+    const nextExperiment = experimentCollection?.nextExperiment;
     const displayDashboard = experimentCollection?.dashboard.length;
     const showConsent = experimentCollection?.consent;
-    const totalScore = experimentCollection?.total_score;
+    const totalScore = experimentCollection?.totalScore;
     const score = experimentCollection?.score;
 
     if (experimentCollection?.theme) {

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
@@ -26,7 +26,6 @@ const experiment2 = getExperiment({
     id: 2,
     slug: 'another_slug',
     name: 'Another Experiment',
-    finished_session_count: 2,
     description: 'Some description',
 });
 

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
@@ -12,8 +12,6 @@ const getExperiment = (overrides = {}) => {
         name: 'Some Experiment',
         description: 'Some description',
         image: {},
-        started_session_count: 2,
-        finished_session_count: 1,
         ...overrides
     } as Experiment
 }

--- a/frontend/src/types/Experiment.ts
+++ b/frontend/src/types/Experiment.ts
@@ -6,6 +6,4 @@ export default interface Experiment {
     slug: string;
     description: string;
     image?: IImage;
-    started_session_count: number;
-    finished_session_count: number;
 }


### PR DESCRIPTION
I noticed that the `Next experiment` button did not show. This was due to the frontend expecting camel case, while the backend sent snake case. I also removed the `started_session_count` and `finished_session_count` objects, as they are not used anymore (we agreed that these kinds of overview should be offered via the admin interface after #979 .)