### PR TITLE
fix: TH Preverbal styles and player labels

### DIFF
--- a/backend/experiment/actions/playback.py
+++ b/backend/experiment/actions/playback.py
@@ -86,7 +86,6 @@ class Multiplayer(PlayButton):
     '''
     This is a player with multiple play buttons
     - stop_audio_after: after how many seconds to stop audio
-    - label_style: set if players should be labeled in alphabetic / numeric  / roman style (based on player index)
     - labels: pass list of strings if players should have custom labels
     '''
 
@@ -109,7 +108,7 @@ class Multiplayer(PlayButton):
             self.labels = labels
 
 
-class ImagePlayer(PlayButton):
+class ImagePlayer(Multiplayer):
     '''
     This is a special case of the Multiplayer:
     it shows an image next to each play button

--- a/backend/experiment/rules/toontjehoger_2_preverbal.py
+++ b/backend/experiment/rules/toontjehoger_2_preverbal.py
@@ -7,7 +7,9 @@ from .toontjehoger_1_mozart import toontjehoger_ranks
 from experiment.actions import Trial, Explainer, Step, Score, Final, Playlist, Info, HTML
 from experiment.actions.form import ButtonArrayQuestion, ChoiceQuestion, Form
 from experiment.actions.playback import ImagePlayer
-from experiment.actions.styles import STYLE_NEUTRAL
+from experiment.actions.styles import STYLE_NEUTRAL_INVERTED
+from experiment.actions.frontend_style import FrontendStyle, EFrontendStyle
+from experiment.utils import create_player_labels
 from .base import Base
 from result.utils import prepare_result
 from section.models import Playlist
@@ -153,7 +155,8 @@ class ToontjeHoger2Preverbal(Base):
             submits=True,
             result_id=prepare_result(
                 key, session, expected_response="C"
-            )
+            ),
+            style=STYLE_NEUTRAL_INVERTED
         )
         form = Form([question])
 
@@ -194,18 +197,19 @@ class ToontjeHoger2Preverbal(Base):
                 "Error: could not find section C for round 1")
 
         # Player
+        sections = [sectionA, sectionB, sectionC]
         playback = ImagePlayer(
-            [sectionA, sectionB, sectionC],
-            label_style='ALPHABETIC',
+            sections,
+            labels=create_player_labels(len(sections), 'alphabetic'),
             images=["/images/experiments/toontjehoger/spectrogram-trumpet.webp", "/images/experiments/toontjehoger/spectrogram-whale.webp", "/images/experiments/toontjehoger/spectrogram-human.webp"],
-            image_labels = ['Trompet', 'Walvis', 'Mens']
+            image_labels=['Trompet', 'Walvis', 'Mens'],
+            style=FrontendStyle(EFrontendStyle.NEUTRAL_INVERTED)
         )
 
         trial = Trial(
             playback=playback,
             feedback_form=None,
-            title=self.TITLE,
-            style='primary-form'
+            title=self.TITLE
         )
         return [trial]
     
@@ -226,9 +230,10 @@ class ToontjeHoger2Preverbal(Base):
                 "Error: could not find section B for round 2")
 
         # Player
+        sections = [sectionA, sectionB]
         playback = ImagePlayer(
-            [sectionA, sectionB],
-            label_style='ALPHABETIC',
+            sections,
+            labels=create_player_labels(len(sections), 'alphabetic'),
             images=["/images/experiments/toontjehoger/spectrogram-baby-french.webp", "/images/experiments/toontjehoger/spectrogram-baby-german.webp"],
         )
 
@@ -244,7 +249,7 @@ class ToontjeHoger2Preverbal(Base):
             view='BUTTON_ARRAY',
             submits=True,
             result_id=prepare_result(key, session, expected_response="A"),
-            style=STYLE_NEUTRAL
+            style=STYLE_NEUTRAL_INVERTED
         )
         form = Form([question])
 

--- a/backend/experiment/rules/toontjehoger_2_preverbal.py
+++ b/backend/experiment/rules/toontjehoger_2_preverbal.py
@@ -235,6 +235,7 @@ class ToontjeHoger2Preverbal(Base):
             sections,
             labels=create_player_labels(len(sections), 'alphabetic'),
             images=["/images/experiments/toontjehoger/spectrogram-baby-french.webp", "/images/experiments/toontjehoger/spectrogram-baby-german.webp"],
+            style=FrontendStyle(EFrontendStyle.NEUTRAL_INVERTED)
         )
 
         # Question

--- a/frontend/src/components/Playback/Multiplayer.scss
+++ b/frontend/src/components/Playback/Multiplayer.scss
@@ -57,5 +57,17 @@
             }
         }
 
+        .player-wrapper:nth-child(3) {
+
+            .aha__play-button {
+                background-color: $teal;
+                box-shadow: 0 0 0 0.2em rgba($teal, 0.5);
+            }
+
+            .banner {
+                background-color: rgba($teal, 0.75);
+            }
+        }
+
     }
 }

--- a/frontend/src/components/Playback/Playback.jsx
+++ b/frontend/src/components/Playback/Playback.jsx
@@ -160,6 +160,7 @@ const Playback = ({
         const attrs = {
             autoAdvance,
             finishedPlaying: onFinishedPlaying,
+            labels: playbackArgs.labels,
             lastPlayerIndex,
             playSection,
             playerIndex,
@@ -210,6 +211,7 @@ const Playback = ({
                 return (
                     <ImagePlayer
                         {...attrs}
+                        images={playbackArgs.images}
                         disabledPlayers={playbackArgs.play_once ? hasPlayed : undefined}
                     />
                 );

--- a/frontend/src/scss/color-schemes.scss
+++ b/frontend/src/scss/color-schemes.scss
@@ -34,8 +34,11 @@
         &:first-of-type {
             @include btn-style($yellow);
         }
-        &:last-of-type {
+        &:nth-of-type(2) {
             @include btn-style($blue);
+        }
+        &:nth-of-type(3) {
+            @include btn-style($teal);
         }
     }
 }
@@ -46,8 +49,11 @@
         &:first-of-type {
             @include btn-style($blue);
         }
-        &:last-of-type {
+        &:nth-of-type(2) {
             @include btn-style($yellow);
+        }
+        &:nth-of-type(3) {
+            @include btn-style($teal);
         }
     }
 }


### PR DESCRIPTION
I noticed that the "Preverbal" experiment, which uses the "ImagePlayer", still had unstyled play and response buttons. I added an extra colour category for `neutral` and `neutral-inverted`, which styles the last element in an array to teal in both cases.

I also fixed a bug: the preverbal rules file still passed a `label_style` argument (which was originally picked up by the frontend), instead of `labels`.