### PR TITLE
Added: Show experiment collection title & description

### DIFF
--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -24,7 +24,10 @@ def serialize_experiment_collection(
     serialized = {
         'slug': experiment_collection.slug,
         'name': experiment_collection.name,
-        'description': experiment_collection.description,
+        'description': formatter(
+            experiment_collection.description,
+            filter_name='markdown'
+        ),
     }
 
     if experiment_collection.consent:
@@ -32,11 +35,14 @@ def serialize_experiment_collection(
 
     if experiment_collection.theme_config:
         serialized['theme'] = serialize_theme(
-            experiment_collection.theme_config)
+            experiment_collection.theme_config
+        )
 
     if experiment_collection.about_content:
         serialized['aboutContent'] = formatter(
-            experiment_collection.about_content, filter_name='markdown')
+            experiment_collection.about_content,
+            filter_name='markdown'
+        )
 
     return serialized
 

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.test.tsx
@@ -34,7 +34,6 @@ const collectionWithDashboard = { dashboard: [experiment1, experiment2] }
 const header = {
     nextExperimentButtonText: 'Next experiment',
     aboutButtonText: 'About us',
-    showScore: true
 }
 const collectionWithTheme = {
     dashboard: [experiment1, experiment2],

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
@@ -10,29 +10,32 @@ import IExperiment from "@/types/Experiment";
 interface ExperimentCollectionDashboardProps {
     experimentCollection: ExperimentCollection;
     participantIdUrl: string | null;
+    totalScore: number;
 }
 
 export const ExperimentCollectionDashboard: React.FC<ExperimentCollectionDashboardProps> = ({ experimentCollection, participantIdUrl, totalScore }) => {
-    
+
     const dashboard = experimentCollection.dashboard;
     const nextExperimentSlug = experimentCollection.nextExperiment?.slug;
-    
-    const headerProps = experimentCollection.theme?.header? {
-        nextExperimentSlug,        
+
+    const headerProps = experimentCollection.theme?.header ? {
+        nextExperimentSlug,
         collectionSlug: experimentCollection.slug,
         ...experimentCollection.theme.header,
-        totalScore: totalScore
-        
+        totalScore,
+        experimentCollectionTitle: experimentCollection.name,
+        experimentCollectionDescription: experimentCollection.description
+
     } : undefined;
-    
+
     const getExperimentHref = (slug: string) => `/${slug}${participantIdUrl ? `?participant_id=${participantIdUrl}` : ""}`;
 
     return (
         <div className="aha__dashboard">
-        <Logo logoClickConfirm={null} />
-        {headerProps && (
-            <Header { ...headerProps }></Header>
-        )}
+            <Logo logoClickConfirm={null} />
+            {headerProps && (
+                <Header {...headerProps}></Header>
+            )}
             {/* Experiments */}
             <div role="menu" className="dashboard toontjehoger">
                 <ul>

--- a/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollectionDashboard/ExperimentCollectionDashboard.tsx
@@ -23,7 +23,6 @@ export const ExperimentCollectionDashboard: React.FC<ExperimentCollectionDashboa
         collectionSlug: experimentCollection.slug,
         ...experimentCollection.theme.header,
         totalScore,
-        experimentCollectionTitle: experimentCollection.name,
         experimentCollectionDescription: experimentCollection.description
 
     } : undefined;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import Rank from "../Rank/Rank";
 import Social from "../Social/Social"
+import HTML from '@/components/HTML/HTML';
 
 interface HeaderProps {
     experimentCollectionTitle: string;
@@ -21,7 +22,6 @@ interface Score {
 }
 
 export const Header: React.FC<HeaderProps> = ({
-    experimentCollectionTitle,
     experimentCollectionDescription,
     nextExperimentSlug,
     nextExperimentButtonText,
@@ -37,7 +37,6 @@ export const Header: React.FC<HeaderProps> = ({
         'url': 'wwww.amsterdammusiclab.nl',
         'hashtags': ["amsterdammusiclab", "citizenscience"]
     }
-
 
     const useAnimatedScore = (targetScore: number) => {
         const [score, setScore] = useState(0);
@@ -95,8 +94,7 @@ export const Header: React.FC<HeaderProps> = ({
     return (
         <div className="hero aha__header">
             <div className="intro">
-                <h1>{experimentCollectionTitle}</h1>
-                <p>{experimentCollectionDescription}</p>
+                <HTML body={experimentCollectionDescription} innerClassName="py-3" />
                 <nav className="actions">
                     {nextExperimentSlug && <a className="btn btn-lg btn-primary" href={`/${nextExperimentSlug}`}>{nextExperimentButtonText}</a>}
                     {aboutButtonText && <Link className="btn btn-lg btn-outline-primary" to={`/collection/${collectionSlug}/about`}>{aboutButtonText}</Link>}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -5,6 +5,8 @@ import Rank from "../Rank/Rank";
 import Social from "../Social/Social"
 
 interface HeaderProps {
+    experimentCollectionTitle: string;
+    experimentCollectionDescription: string;
     nextExperimentSlug: string | undefined;
     nextExperimentButtonText: string;
     collectionSlug: string;
@@ -18,8 +20,17 @@ interface Score {
     noScoreLabel: string;
 }
 
-export const Header: React.FC<HeaderProps> = ({ nextExperimentSlug, nextExperimentButtonText, collectionSlug, aboutButtonText, showScore, totalScore, score }) => {
-    
+export const Header: React.FC<HeaderProps> = ({
+    experimentCollectionTitle,
+    experimentCollectionDescription,
+    nextExperimentSlug,
+    nextExperimentButtonText,
+    collectionSlug,
+    aboutButtonText,
+    totalScore,
+    score,
+}) => {
+
     const social = {
         'apps': ['facebook', 'twitter'],
         'message': `I scored ${totalScore} points`,
@@ -27,42 +38,43 @@ export const Header: React.FC<HeaderProps> = ({ nextExperimentSlug, nextExperime
         'hashtags': ["amsterdammusiclab", "citizenscience"]
     }
 
+
     const useAnimatedScore = (targetScore: number) => {
         const [score, setScore] = useState(0);
-    
+
         useEffect(() => {
             if (targetScore === 0) {
                 setScore(0);
                 return;
             }
-    
+
             let animationFrameId: number;
-    
+
             const nextStep = () => {
                 setScore((prevScore) => {
                     const difference = targetScore - prevScore;
                     const scoreStep = Math.max(1, Math.min(10, Math.ceil(Math.abs(difference) / 10)));
-    
+
                     if (difference === 0) {
                         cancelAnimationFrame(animationFrameId);
                         return prevScore;
                     }
-    
+
                     const newScore = prevScore + Math.sign(difference) * scoreStep;
                     animationFrameId = requestAnimationFrame(nextStep);
                     return newScore;
                 });
             };
-    
+
             // Start the animation
             animationFrameId = requestAnimationFrame(nextStep);
-    
+
             // Cleanup function to cancel the animation frame
             return () => {
                 cancelAnimationFrame(animationFrameId);
             };
         }, [targetScore]);
-    
+
         return score;
     };
 
@@ -79,10 +91,12 @@ export const Header: React.FC<HeaderProps> = ({ nextExperimentSlug, nextExperime
             </div>
         );
     };
-    
+
     return (
         <div className="hero aha__header">
             <div className="intro">
+                <h1>{experimentCollectionTitle}</h1>
+                <p>{experimentCollectionDescription}</p>
                 <nav className="actions">
                     {nextExperimentSlug && <a className="btn btn-lg btn-primary" href={`/${nextExperimentSlug}`}>{nextExperimentButtonText}</a>}
                     {aboutButtonText && <Link className="btn btn-lg btn-outline-primary" to={`/collection/${collectionSlug}/about`}>{aboutButtonText}</Link>}
@@ -91,14 +105,14 @@ export const Header: React.FC<HeaderProps> = ({ nextExperimentSlug, nextExperime
             {score && totalScore !== 0 && (
                 <div className="results">
                     <Score
-                    score={totalScore}
-                    scoreClass={score.scoreClass}
-                    label={score.scoreLabel}
+                        score={totalScore}
+                        scoreClass={score.scoreClass}
+                        label={score.scoreLabel}
                     />
                     <Social
-                        social={social}                        
+                        social={social}
                     />
-                </div>                
+                </div>
             )}
             {score && totalScore === 0 && (
                 <h3>{score.noScoreLabel}</h3>
@@ -106,5 +120,7 @@ export const Header: React.FC<HeaderProps> = ({ nextExperimentSlug, nextExperime
         </div>
     );
 }
+
+
 
 export default Header;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -9,9 +9,7 @@ interface HeaderProps {
     nextExperimentButtonText: string;
     collectionSlug: string;
     aboutButtonText: string;
-    showScore: boolean;
     totalScore: Number;
-    score: Score;    
 }
 
 interface Score {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -94,7 +94,7 @@ export const Header: React.FC<HeaderProps> = ({
     return (
         <div className="hero aha__header">
             <div className="intro">
-                <HTML body={experimentCollectionDescription} innerClassName="py-3" />
+                <HTML body={experimentCollectionDescription} innerClassName="" />
                 <nav className="actions">
                     {nextExperimentSlug && <a className="btn btn-lg btn-primary" href={`/${nextExperimentSlug}`}>{nextExperimentButtonText}</a>}
                     {aboutButtonText && <Link className="btn btn-lg btn-outline-primary" to={`/collection/${collectionSlug}/about`}>{aboutButtonText}</Link>}

--- a/frontend/src/components/Logo/Logo.tsx
+++ b/frontend/src/components/Logo/Logo.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import useBoundStore from "@/util/stores";
 
 
-const Logo: React.FC<{logoClickConfirm: string | null}> = ({logoClickConfirm=null}) => {
+const Logo: React.FC<{ logoClickConfirm: string | null }> = ({ logoClickConfirm = null }) => {
     const theme = useBoundStore((state) => state.theme);
 
     const logoUrl = theme?.logoUrl ?? LOGO_URL;
@@ -26,14 +26,14 @@ const Logo: React.FC<{logoClickConfirm: string | null}> = ({logoClickConfirm=nul
         "aria-label": "Logo",
         style: { backgroundImage: `url(${logoUrl})` },
     };
-    
+
     return (
         <>
-            { URLS.AMLHome.startsWith("http") ? (
+            {URLS.AMLHome.startsWith("http") ? (
                 <a href={URLS.AMLHome} {...logoProps}>
                     {LOGO_TITLE}
                 </a>
-                ) : (
+            ) : (
                 <Link to={URLS.AMLHome} {...logoProps}>
                     {LOGO_TITLE}
                 </Link>

--- a/frontend/src/types/Theme.ts
+++ b/frontend/src/types/Theme.ts
@@ -1,13 +1,6 @@
 export interface Header {
     nextExperimentButtonText: string;
     aboutButtonText: string;
-    showScore: boolean;    
-};
-
-export interface Header {
-    nextExperimentButtonText: string;
-    aboutButtonText: string;
-    showScore: boolean;
 };
 
 export interface Logo {
@@ -21,7 +14,6 @@ export interface Footer {
     logos: Logo[];
     privacy: string;
 }
-
 
 export default interface Theme {
     backgroundUrl: string;


### PR DESCRIPTION
This pull request includes the following changes:

- Removed unused code in the header component.

- Formatted the Logo component.

- Convert markdown to html in the get experiment collection endpoint serializer.

- Added the ability to show the experiment collection title and as formatted html.

## Screenshot of local environment

![image](https://github.com/Amsterdam-Music-Lab/MUSCLE/assets/8208970/3d452056-a5ee-4698-9bf4-e00ee4b540d1)

Resolves #1100