### PR TITLE
Fixed(CI): Add needs dependency for acceptance deployment in podman workflow

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -290,6 +290,9 @@ jobs:
     # temporarily true to test e2e tests
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/*' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
 
+    # needs to happen after the deployment to the acceptance environment
+    needs: deploy-acceptance
+
     env:
       BASE_URL: "https://acc.amsterdammusiclab.nl"
 


### PR DESCRIPTION
The e2e job for running the e2e tests would already start before the deployment to acceptance was done, i.e. in parallel. This extra configuration parameter ensures that the e2e tests will be run *after* the deployment to acceptance has been completed.