### PR TITLE
Fixed: Also apply filter_by filter on section filter in `section_from_any_song` session model method

### DIFF
--- a/backend/experiment/rules/toontjehogerkids_5_tempo.py
+++ b/backend/experiment/rules/toontjehogerkids_5_tempo.py
@@ -48,7 +48,7 @@ class ToontjeHogerKids5Tempo(ToontjeHoger5Tempo):
 
         if not section_original:
             raise Exception(
-                "Error: could not find original section: {}".format(tag_original))
+                "Error: could not find original section: {}".format(section_original))
 
         section_changed = self.get_section_changed(
             session=session, song=section_original.song)

--- a/backend/session/models.py
+++ b/backend/session/models.py
@@ -145,11 +145,15 @@ class Session(models.Model):
         To ensure appropriate IP restrictions, most rules should use this
         method instead of operating on the playlist directly.
         """
-        
+
         pks = self.filter_songs(filter_by)
         if pks:
             # Return a random section
-            sections = self.playlist.section_set.filter(song_id=random.choice(pks))
+            sections = self.playlist.section_set.filter(
+                song_id=random.choice(pks)
+            ).filter(
+                **filter_by
+            )
             return random.choice(sections)
 
     def all_sections(self, filter_by={}):


### PR DESCRIPTION
See also this comment: https://github.com/Amsterdam-Music-Lab/MUSCLE/issues/1106#issuecomment-2163369748

This seems to fix the problems in TH5 Kids - Tempo experiment as discussed in #1106, but I'm not completely sure what effect it might have on many other experiments. Maybe other experiments *do* want to pick a random section from the same song? It almost seems like it's the whole point of this method...

Maybe we need something like a `get_specific_section_from_song` method; in which the filter is leading and not a random pick?

Related to #1106