### PR TITLE
Fixed: Update fetch URL in markdown_preview_text_input.html

### DIFF
--- a/backend/experiment/templates/widgets/markdown_preview_text_input.html
+++ b/backend/experiment/templates/widgets/markdown_preview_text_input.html
@@ -237,7 +237,7 @@ class MarkdownPreview extends HTMLElement {
 
     function renderMarkdown(textarea, markdownPreview) {
         // render markdown through http post request to /experiment/render_markdown
-        return fetch('/experiment/render_markdown/', {
+        return fetch('{% url "experiment:render_markdown" %}', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
Instead of a hard-coded `/experiment/render_markdown` url, it now uses the reverse url feature which is less error prone and automatically adds the SUBPATH if present.

Resolves #1119 