### PR TITLE
Added: Add error message for missing experiment collection

### DIFF
--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
@@ -56,6 +56,10 @@ const ExperimentCollection = ({ match }: ExperimentCollectionProps) => {
         );
     }
 
+    if (!loadingExperimentCollection && !experimentCollection) {
+        return <p className="aha__error">Experiment collection not found</p>;
+    }
+
     if (!hasShownConsent && showConsent) {
         const attrs = {
             participant,
@@ -68,7 +72,6 @@ const ExperimentCollection = ({ match }: ExperimentCollectionProps) => {
                 <Consent {...attrs}/>
             </DefaultPage>
         )
-       
     }
 
     if (!displayDashboard && nextExperiment) {

--- a/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
+++ b/frontend/src/components/ExperimentCollection/ExperimentCollection.tsx
@@ -57,7 +57,7 @@ const ExperimentCollection = ({ match }: ExperimentCollectionProps) => {
     }
 
     if (!loadingExperimentCollection && !experimentCollection) {
-        return <p className="aha__error">Experiment collection not found</p>;
+        return <p className="aha__error">Experiment not found</p>;
     }
 
     if (!hasShownConsent && showConsent) {


### PR DESCRIPTION
This will probably fix several Sentry errors related to missing properties on the experiment collection (which is null) when it is not found.

And of course it's a better message to show to users. :-)