### PR TITLE
Chore(deps): Remove IPToCC and numpy from base requirements

### DIFF
--- a/backend/experiment/rules/speech2song.py
+++ b/backend/experiment/rules/speech2song.py
@@ -1,4 +1,4 @@
-import numpy as np
+import random
 
 from django.utils.translation import gettext as _
 from django.template.loader import render_to_string
@@ -75,8 +75,8 @@ class Speech2Song(Base):
     def next_round(self, session):
         blocks = [1, 2, 3]
         # shuffle blocks based on session.id as seed -> always same order for same session
-        np.random.seed(session.id)
-        np.random.shuffle(blocks)
+        random.seed(session.id)
+        random.shuffle(blocks)
         # group_ids for practice (0), or one of the speech blocks (1-3)
         actions = []
         is_speech = True

--- a/backend/experiment/rules/speech2song.py
+++ b/backend/experiment/rules/speech2song.py
@@ -24,7 +24,7 @@ n_rounds_per_block = n_trials_per_block * 2  # each trial has two rounds
 class Speech2Song(Base):
     """ Rules for a speech-to-song experiment """
     ID = 'SPEECH_TO_SONG'
-    
+
     def __init__(self):
         self.question_series = [
             {

--- a/backend/experiment/rules/util/practice.py
+++ b/backend/experiment/rules/util/practice.py
@@ -1,5 +1,4 @@
 import random
-import numpy as np
 
 from django.utils.translation import gettext as _
 
@@ -135,5 +134,5 @@ def get_trial_condition(n_choices):
     """ get randomized trial condition
     return an integer between 0 and n_choices-2
     """
-    options = np.arange(n_choices)
-    return np.random.choice(options)
+    options = list(range(n_choices))
+    return random.choice(options)

--- a/backend/experiment/rules/util/practice.py
+++ b/backend/experiment/rules/util/practice.py
@@ -7,7 +7,7 @@ from experiment.actions import Explainer, Step
 
 
 def get_practice_views(
-    session, 
+    session,
     intro_explainer,
     first_trial_callback,
     trial_callback,
@@ -30,7 +30,7 @@ def get_practice_views(
     trial_condition = get_trial_condition_block(session, 2)
     previous_results = session.result_set.order_by('-created_at')
     if not results_count:
-        # first practice trial 
+        # first practice trial
         return trial_callback(session, trial_condition, difficulty)
     last_result = previous_results.first()
     if results_count < 4:
@@ -116,7 +116,7 @@ def start_experiment_explainer():
 
 
 def get_trial_condition_block(session, n_trials_per_block):
-    """ make a list of n_trials_per_blocks conditions, of which one is catch (=1) 
+    """ make a list of n_trials_per_blocks conditions, of which one is catch (=1)
     store updates in the session.json_data field
     """
     json_data = session.load_json_data()
@@ -132,9 +132,8 @@ def get_trial_condition_block(session, n_trials_per_block):
 
 
 def get_trial_condition(n_choices):
-    """ get randomized trial condition 
+    """ get randomized trial condition
     return an integer between 0 and n_choices-2
     """
     options = np.arange(n_choices)
     return np.random.choice(options)
-    

--- a/backend/requirements.in/base.txt
+++ b/backend/requirements.in/base.txt
@@ -13,10 +13,6 @@ django-cors-headers
 # Dotenv, for loading configuration from .env file
 python-dotenv
 
-# Get country code from IP address;
-# It uses a local DB the get its data from the regional Internet registries
-IPToCC
-
 # PostgrSQL database client
 psycopg[binary]
 

--- a/backend/requirements.in/base.txt
+++ b/backend/requirements.in/base.txt
@@ -33,3 +33,6 @@ genbadge[coverage]
 
 # Convert markdown to html
 django-markup[all_filter_dependencies]
+
+# Numpy
+numpy

--- a/backend/requirements.in/base.txt
+++ b/backend/requirements.in/base.txt
@@ -33,6 +33,3 @@ genbadge[coverage]
 
 # Convert markdown to html
 django-markup[all_filter_dependencies]
-
-# Numpy
-numpy

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -67,6 +67,8 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
+numpy==2.0.0
+    # via -r requirements.in/base.txt
 packaging==23.2
     # via build
 pillow==10.3.0

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -67,8 +67,6 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-numpy==2.0.0
-    # via -r requirements.in/base.txt
 packaging==23.2
     # via build
 pillow==10.3.0

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -59,8 +59,6 @@ html5lib==1.1
     # via textile
 idna==3.7
     # via requests
-iptocc==2.1.2
-    # via -r requirements.in/base.txt
 isort==5.13.2
     # via pylint
 markdown==3.5.2
@@ -69,12 +67,8 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-numpy==1.22.0
-    # via pandas
 packaging==23.2
     # via build
-pandas==1.3.4
-    # via iptocc
 pillow==10.3.0
     # via genbadge
 pip-tools==7.3.0
@@ -106,12 +100,8 @@ pyproject-hooks==1.0.0
     # via build
 python-creole==1.4.10
     # via django-markup
-python-dateutil==2.8.2
-    # via pandas
 python-dotenv==0.19.1
     # via -r requirements.in/base.txt
-pytz==2021.3
-    # via pandas
 regex==2023.12.25
     # via textile
 requests==2.32.0
@@ -126,7 +116,6 @@ six==1.16.0
     # via
     #   bleach
     #   html5lib
-    #   python-dateutil
 smartypants==2.0.1
     # via django-markup
 sqlparse==0.5.0

--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -46,16 +46,10 @@ html5lib==1.1
     # via textile
 idna==3.7
     # via requests
-iptocc==2.1.2
-    # via -r requirements.in/base.txt
 markdown==3.5.2
     # via django-markup
-numpy==1.24.3
-    # via pandas
 packaging==24.1
     # via gunicorn
-pandas==1.5.3
-    # via iptocc
 pillow==10.3.0
     # via genbadge
 psycopg[binary]==3.1.18
@@ -66,12 +60,8 @@ pygments==2.17.2
     # via django-markup
 python-creole==1.4.10
     # via django-markup
-python-dateutil==2.8.2
-    # via pandas
 python-dotenv==1.0.0
     # via -r requirements.in/base.txt
-pytz==2023.3
-    # via pandas
 regex==2023.12.25
     # via textile
 requests==2.32.0
@@ -84,7 +74,6 @@ six==1.16.0
     # via
     #   bleach
     #   html5lib
-    #   python-dateutil
 smartypants==2.0.1
     # via django-markup
 sqlparse==0.5.0

--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -48,6 +48,8 @@ idna==3.7
     # via requests
 markdown==3.5.2
     # via django-markup
+numpy==2.0.0
+    # via -r requirements.in/base.txt
 packaging==24.1
     # via gunicorn
 pillow==10.3.0

--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -48,8 +48,6 @@ idna==3.7
     # via requests
 markdown==3.5.2
     # via django-markup
-numpy==2.0.0
-    # via -r requirements.in/base.txt
 packaging==24.1
     # via gunicorn
 pillow==10.3.0


### PR DESCRIPTION
The commit removes the `IPToCC` package from the base requirements file. This package was used to get the country code from an IP address, but it is no longer needed and caused 15m Docker image build times due to its dependency on the `pandas` library, which had to be rebuilt every time.

Additionally, it also removes `numpy` as a dependency as there were only 4 lines of code in 2 files that were using it and which were very easy to replace with the already built-in python library of `random`. NB: you can't see `numpy` removed from `base.txt` as it was a dependency of `IPToCC` too.