### PR TITLE
Refactor: Refactor URL matching and references to Experiment to use Block

### DIFF
--- a/backend/experiment/static/block_admin.js
+++ b/backend/experiment/static/block_admin.js
@@ -2,7 +2,7 @@
 document.addEventListener("DOMContentLoaded", (event) => {
 
     // Get experiment id from URL
-    match = window.location.href.match(/\/experiment\/experiment\/(.+)\/change/)
+    match = window.location.href.match(/\/experiment\/block\/(.+)\/change/)
     experiment_id = match && match[1]
 
     let buttonAddDefaultQuestions = document.createElement("input")
@@ -23,12 +23,12 @@ document.addEventListener("DOMContentLoaded", (event) => {
     function toggleButton(e) {
 
         // Check if we are on a Change Experiment (not Add Experiment) and if selection for Experiment rules has not changed
-        if ( experiment_id && (selectRules[selectRules.selectedIndex] === selectRules.querySelector("option[selected]")) ) {
+        if (experiment_id && (selectRules[selectRules.selectedIndex] === selectRules.querySelector("option[selected]"))) {
             buttonAddDefaultQuestions.disabled = false
             message.innerText = ""
         } else {
             buttonAddDefaultQuestions.disabled = true
-            message.innerText = "Save Experiment first"
+            message.innerText = "Save Block first"
         }
     }
 
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
 
         const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
         let response = await fetch(`/experiment/add_default_question_series/${experiment_id}/`,
-            {method:"POST", mode: 'same-origin',headers: {'X-CSRFToken': csrftoken}})
+            { method: "POST", mode: 'same-origin', headers: { 'X-CSRFToken': csrftoken } })
 
         if (response.ok) {
             location.reload()

--- a/backend/experiment/templates/collection-dashboard-sessions.html
+++ b/backend/experiment/templates/collection-dashboard-sessions.html
@@ -6,7 +6,7 @@
         <thead>
             <tr>
                 <th>Session *</th>
-                <th>Experiment *</th>
+                <th>Block *</th>
                 <th>Participant *</th>
                 <th>Started</th>
                 <th>Finished</th>
@@ -17,7 +17,7 @@
         </thead>
 
         <tbody>
-            <!-- List and hide all sessions in this collection with a unique id per experiment -->
+            <!-- List and hide all sessions in this collection with a unique id per block -->
             {% for session in sessions %}
                 <tr class="session-row hide experiment-{{ session.block.id }} participant-session-{{ session.participant.id }}">
 
@@ -85,7 +85,7 @@
                     <h3>
                         Session: <a href="{% url 'admin:session_session_change' session.id %}" target="_blank">{{ session.id }}</a><br>
                         Participant: <a href="{% url 'admin:participant_participant_change' session.participant.id %}" target="_blank">{{ session.participant.participant_id_url }}</a><br>
-                        Experiment: <a href="{% url 'admin:experiment_block_change' session.block.id %}" target="_blank">{{ session.block.name }}</a>
+                        Block: <a href="{% url 'admin:experiment_block_change' session.block.id %}" target="_blank">{{ session.block.name }}</a>
                     </h3>
 
                     <pre>


### PR DESCRIPTION
This pull request includes changes to update the URL matching and references to "Experiment" to use "Block" instead. The `block_admin.js` file has been updated to use "block" in the URL matching, and references to "Experiment" have been changed to "Block" in the HTML template.

See also https://github.com/Amsterdam-Music-Lab/MUSCLE/pull/1169#issuecomment-2217424810