### PR TITLE
Refactor: Start phasing out `first_round` and create session in `get_block`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tests/__pycache__
 
 e2e/screenshots
 e2e/tests/__pycache__
+
+temp/

--- a/backend/experiment/rules/tests/test_beat_alignment.py
+++ b/backend/experiment/rules/tests/test_beat_alignment.py
@@ -2,6 +2,8 @@
 from django.test import TestCase
 from experiment.models import Block
 from result.models import Result
+from participant.models import Participant
+from participant.utils import PARTICIPANT_KEY
 from section.models import Playlist
 from session.models import Session
 import json
@@ -43,7 +45,15 @@ class BeatAlignmentRuleTest(TestCase):
         return json.loads(response.content)
 
     def test_block(self):
+        participant = Participant.objects.create()
+        participant.save()
+
+        session = self.client.session
+        session.update({PARTICIPANT_KEY: participant.id})
+        session.save()
+
         response = self.client.get('/experiment/block/ba/')
+
         response_json = self.load_json(response)
         self.assertTrue({'id', 'slug', 'name', 'class_name', 'rounds',
                         'playlists', 'next_round', 'loading_text'} <= response_json.keys())

--- a/backend/experiment/rules/toontjehoger_1_mozart.py
+++ b/backend/experiment/rules/toontjehoger_1_mozart.py
@@ -6,6 +6,7 @@ from experiment.actions import Trial, Explainer, Step, Score, Final, Info, HTML
 from experiment.actions.form import ButtonArrayQuestion, Form
 from experiment.actions.playback import Autoplay
 from experiment.actions.styles import STYLE_TOONTJEHOGER
+from experiment.models import Session
 from .base import Base
 from experiment.utils import non_breaking_spaces
 from experiment.actions.utils import get_current_experiment_url
@@ -18,17 +19,17 @@ logger = logging.getLogger(__name__)
 def toontjehoger_ranks(session):
     score = session.final_score
     if score < 25:
-        return 'PLASTIC'
+        return "PLASTIC"
     elif score < 50:
-        return 'BRONZE'
+        return "BRONZE"
     elif score < 75:
-        return 'SILVER'
+        return "SILVER"
     else:
-        return 'GOLD'
+        return "GOLD"
 
 
 class ToontjeHoger1Mozart(Base):
-    ID = 'TOONTJE_HOGER_1_MOZART'
+    ID = "TOONTJE_HOGER_1_MOZART"
     TITLE = ""
     SCORE_CORRECT = 50
     SCORE_WRONG = 0
@@ -38,9 +39,15 @@ class ToontjeHoger1Mozart(Base):
     ANSWER_URL1 = "/images/experiments/toontjehoger/mozart-effect1-answer.webp"
     ANSWER_URL2 = "/images/experiments/toontjehoger/mozart-effect2-answer.webp"
 
-    def first_round(self, block):
+    def _first_round(self, block):
+        """@deprecated. Use next_round instead."""
         """Create data for the first block rounds."""
 
+    def next_round(self, session: Session):
+        """Get action data for the next round"""
+        rounds_passed = session.rounds_passed()
+
+        # Round 1
         # 1. Explain game.
         explainer = Explainer(
             instruction="Het Mozart effect",
@@ -50,38 +57,31 @@ class ToontjeHoger1Mozart(Base):
                 Step("Lukt het om het juiste antwoord te vinden?"),
             ],
             step_numbers=True,
-            button_label="Start"
+            button_label="Start",
         )
 
-        return [
-            explainer
-        ]
-
-    def next_round(self, session):
-        """Get action data for the next round"""
-        rounds_passed = session.rounds_passed()
-
-        # Round 1
         if rounds_passed == 0:
-            round = self.get_image_trial(session,
-                                        section_group='1',
-                                         image_url=self.QUESTION_URL1,
-                                         question=self.get_task_explainer(),
-                                        expected_response='B'
-                                        )
+            round = self.get_image_trial(
+                session,
+                section_group="1",
+                image_url=self.QUESTION_URL1,
+                question=self.get_task_explainer(),
+                expected_response="B",
+            )
             # No combine_actions because of inconsistent next_round array wrapping in first round
-            return round
+            return [explainer, *round]
 
         # Round 2
         if rounds_passed == 1:
             answer_explainer = self.get_answer_explainer(session, round=1)
             score = self.get_score(session)
-            round = self.get_image_trial(session,
-                                        section_group='2',
-                                         image_url=self.QUESTION_URL2,
-                                         question=self.get_task_explainer(),
-                                        expected_response='B'
-                                        )
+            round = self.get_image_trial(
+                session,
+                section_group="2",
+                image_url=self.QUESTION_URL2,
+                question=self.get_task_explainer(),
+                expected_response="B",
+            )
             return [*answer_explainer, *score, *round]
 
         # Final
@@ -98,14 +98,19 @@ class ToontjeHoger1Mozart(Base):
         heading = "Goed gedaan!" if correct_answer_given else "Helaas!"
 
         feedback_correct = "Het juiste antwoord was inderdaad {}.".format(
-            last_result.expected_response)
-        feedback_incorrect = "Antwoord {} is niet goed! Het juiste antwoord was {}.".format(
-            last_result.given_response, last_result.expected_response)
+            last_result.expected_response
+        )
+        feedback_incorrect = (
+            "Antwoord {} is niet goed! Het juiste antwoord was {}.".format(
+                last_result.given_response, last_result.expected_response
+            )
+        )
         feedback = feedback_correct if correct_answer_given else feedback_incorrect
 
         image_url = self.ANSWER_URL1 if round == 1 else self.ANSWER_URL2
         body = '<div class="center"><div><img src="{}"></div><h4 style="margin-top: 15px;">{}</h4></div>'.format(
-            image_url, feedback)
+            image_url, feedback
+        )
 
         # Return answer info view
         info = Info(
@@ -119,19 +124,25 @@ class ToontjeHoger1Mozart(Base):
         # Feedback message
         last_result = session.last_result()
         section = last_result.section
-        feedback = "Je hoorde {} van {}.".format(
-            section.song.name, non_breaking_spaces(section.song.artist)) if section else ""
+        feedback = (
+            "Je hoorde {} van {}.".format(
+                section.song.name, non_breaking_spaces(section.song.artist)
+            )
+            if section
+            else ""
+        )
 
         # Return score view
-        config = {'show_total_score': True}
+        config = {"show_total_score": True}
         score = Score(session, config=config, feedback=feedback)
         return [score]
 
-    def get_image_trial(self, session, section_group, image_url, question, expected_response):
+    def get_image_trial(
+        self, session, section_group, image_url, question, expected_response
+    ):
         # Config
         # -----------------
-        section = session.section_from_any_song(
-            filter_by={'group': section_group})
+        section = session.section_from_any_song(filter_by={"group": section_group})
         if section is None:
             raise Exception("Error: could not find section")
 
@@ -142,9 +153,9 @@ class ToontjeHoger1Mozart(Base):
         playback = Autoplay([section], show_animation=True)
 
         listen_config = {
-            'auto_advance': True,
-            'show_continue_button': False,
-            'response_time': section.duration
+            "auto_advance": True,
+            "show_continue_button": False,
+            "response_time": section.duration,
         }
 
         listen = Trial(
@@ -157,29 +168,32 @@ class ToontjeHoger1Mozart(Base):
         # --------------------
 
         # Question
-        key = 'expected_shape'
+        key = "expected_shape"
         question = ButtonArrayQuestion(
             question=question,
             key=key,
             choices={
-                'A': 'A',
-                'B': 'B',
-                'C': 'C',
-                'D': 'D',
-                'E': 'E',
+                "A": "A",
+                "B": "B",
+                "C": "C",
+                "D": "D",
+                "E": "E",
             },
-            view='BUTTON_ARRAY',
+            view="BUTTON_ARRAY",
             result_id=prepare_result(
-            key, session, section=section, expected_response=expected_response),
+                key, session, section=section, expected_response=expected_response
+            ),
             submits=True,
-            style=STYLE_TOONTJEHOGER
+            style=STYLE_TOONTJEHOGER,
         )
         form = Form([question])
 
         image_trial = Trial(
             html=HTML(
                 body='<img src="{}" style="height:calc(100% - 260px);max-height:326px;max-width: 100%;"/>'.format(
-                image_url)),
+                    image_url
+                )
+            ),
             feedback_form=form,
             title=self.TITLE,
         )
@@ -195,13 +209,17 @@ class ToontjeHoger1Mozart(Base):
                 Step("Lukt het nu om de juiste te kiezen?"),
             ],
             step_numbers=True,
-            button_label="Start"
+            button_label="Start",
         )
 
         return [explainer]
 
     def calculate_score(self, result, data):
-        score = self.SCORE_CORRECT if result.expected_response == result.given_response else self.SCORE_WRONG
+        score = (
+            self.SCORE_CORRECT
+            if result.expected_response == result.given_response
+            else self.SCORE_WRONG
+        )
         return score
 
     def get_final_round(self, session):
@@ -217,23 +235,25 @@ class ToontjeHoger1Mozart(Base):
         score = self.get_score(session)
 
         # Final
-        final_text = "Je hebt het uitstekend gedaan!" if session.final_score >= 2 * \
-            self.SCORE_CORRECT else "Dat bleek toch even lastig!"
+        final_text = (
+            "Je hebt het uitstekend gedaan!"
+            if session.final_score >= 2 * self.SCORE_CORRECT
+            else "Dat bleek toch even lastig!"
+        )
         final = Final(
             session=session,
             final_text=final_text,
             rank=toontjehoger_ranks(session),
-            button={'text': 'Wat hebben we getest?'}
+            button={"text": "Wat hebben we getest?"},
         )
 
         # Info page
-        body = render_to_string(
-            join('info', 'toontjehoger', 'experiment1.html'))
+        body = render_to_string(join("info", "toontjehoger", "experiment1.html"))
         info = Info(
             body=body,
             heading="Het Mozart effect",
             button_label="Terug naar ToontjeHoger",
-            button_link=get_current_experiment_url(session)
+            button_link=get_current_experiment_url(session),
         )
 
         return [*answer_explainer, *score, final, info]
@@ -254,7 +274,7 @@ class ToontjeHoger1Mozart(Base):
             errors.append("The sections should have different groups")
 
         # Check if sections have group 1 and 2
-        if sorted(groups) != ['1', '2']:
+        if sorted(groups) != ["1", "2"]:
             errors.append("The sections should have groups 1 and 2")
 
         return errors

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -15,6 +15,7 @@ from experiment.models import (
 )
 from experiment.rules.hooked import Hooked
 from participant.models import Participant
+from participant.utils import PARTICIPANT_KEY
 from session.models import Session
 from theme.models import ThemeConfig, FooterConfig, HeaderConfig
 
@@ -251,6 +252,14 @@ class ExperimentViewsTest(TestCase):
             bonus_points=42,
         )
         participant = Participant.objects.create()
+        participant.save()
+
+        # Request session (not to be confused with experiment block session)
+        request_session = self.client.session
+        request_session.update({PARTICIPANT_KEY: participant.id})
+        request_session.save()
+
+        # Experiment block session
         Session.objects.bulk_create([
             Session(block=block, participant=participant, finished_at=timezone.now()) for index in range(3)
         ])

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -6,9 +6,13 @@ from django.conf import settings
 from django.utils.translation import activate, gettext_lazy as _
 from django_markup.markup import formatter
 
-from .models import Block, Experiment, Phase, Feedback
+from .models import Block, Experiment, Phase, Feedback, Session
 from section.models import Playlist
-from experiment.serializers import serialize_actions, serialize_experiment, serialize_phase
+from experiment.serializers import (
+    serialize_actions,
+    serialize_experiment,
+    serialize_phase,
+)
 from experiment.rules import BLOCK_RULES
 from experiment.actions.utils import EXPERIMENT_KEY
 from image.serializers import serialize_image
@@ -30,6 +34,15 @@ def get_block(request, slug):
     if block.language:
         activate(block.language)
 
+    participant = get_participant(request)
+    session = Session(block=block, participant=participant)
+
+    playlist = block.playlists.first()
+    if playlist:
+        session.playlist = playlist
+
+    session.save()
+
     # create data
     block_data = {
         'id': block.id,
@@ -46,8 +59,17 @@ def get_block(request, slug):
             for playlist in block.playlists.all()
         ],
         'feedback_info': block.get_rules().feedback_info(),
-        'next_round': serialize_actions(block.get_rules().first_round(block)),
-        'loading_text': _('Loading')
+
+        # only call first round if the (deprecated) first_round method exists
+        # otherwise, call next_round
+        'next_round': (
+            serialize_actions(block.get_rules().first_round(block))
+            if hasattr(block.get_rules(), "first_round")
+            and block.get_rules().first_round
+            else serialize_actions(block.get_rules().next_round(session))
+        ),
+        'loading_text': _('Loading'),
+        'session_id': session.id,
     }
 
     response = JsonResponse(block_data, json_dumps_params={'indent': 4})
@@ -82,10 +104,10 @@ def add_default_question_series(request, id):
 
 
 def get_experiment(
-            request: HttpRequest,
-            slug: str,
-            phase_index: int = 0,
-        ) -> JsonResponse:
+    request: HttpRequest,
+    slug: str,
+    phase_index: int = 0,
+) -> JsonResponse:
     '''
     check which `Phase` objects are related to the `Experiment` with the given slug
     retrieve the phase with the lowest order (= current_phase)
@@ -100,8 +122,10 @@ def get_experiment(
     except Exception as e:
         logger.error(e)
         return JsonResponse(
-            {'error': 'Something went wrong while fetching the experiment. Please try again later.'},
-            status=500
+            {
+                "error": "Something went wrong while fetching the experiment. Please try again later."
+            },
+            status=500,
         )
 
     request.session[EXPERIMENT_KEY] = slug

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -22,7 +22,7 @@ from theme.serializers import serialize_theme
 logger = logging.getLogger(__name__)
 
 
-def get_block(request, slug):
+def get_block(request: HttpRequest, slug: str) -> JsonResponse:
     """Get block data from active block with given :slug
     DO NOT modify session data here, it will break participant_id system
        (/participant and /block/<slug> are called at the same time by the frontend)"""

--- a/backend/image/tests/test_admin.py
+++ b/backend/image/tests/test_admin.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 from django.contrib.admin.sites import AdminSite
 from django.utils.safestring import mark_safe
 

--- a/backend/participant/utils.py
+++ b/backend/participant/utils.py
@@ -2,6 +2,8 @@ import logging
 import urllib
 import urllib.request
 from django.conf import settings
+from django.http import HttpRequest
+
 
 from .models import Participant
 PARTICIPANT_KEY = 'participant_id'
@@ -71,9 +73,13 @@ def visitor_ip_address(request):
     return request.META.get('REMOTE_ADDR')
 
 
-def get_participant(request) -> Participant:
+def get_participant(request: HttpRequest) -> Participant:
     # get participant from session
     participant_id = request.session.get(PARTICIPANT_KEY, -1)
+
+    if not participant_id or participant_id == -1:
+        raise Participant.DoesNotExist("No participant in session")
+
     try:
         return Participant.objects.get(
                 pk=int(participant_id))

--- a/backend/session/models.py
+++ b/backend/session/models.py
@@ -80,16 +80,6 @@ class Session(models.Model):
         """Get json data as object"""
         return self.json_data if self.json_data else {}
 
-    def save_json_data_key(self, key: str, value):
-        """Set json data key"""
-        data = self.load_json_data()
-        data[key] = value
-        self.save_json_data(data)
-
-    def load_json_data_key(self, key: str, default=None):
-        """Get json data key"""
-        return self.load_json_data()[key] if key in self.load_json_data() else default
-
     def export_admin(self):
         """Export data for admin"""
         return {

--- a/frontend/src/API.ts
+++ b/frontend/src/API.ts
@@ -2,7 +2,7 @@ import { API_BASE_URL } from "@/config";
 import useGet from "./util/useGet";
 import axios from "axios";
 import qs from "qs";
-import Block from "@/types/Block";
+import Block, { ExtendedBlock } from "@/types/Block";
 import Participant from "./types/Participant";
 import Session from "./types/Session";
 
@@ -43,8 +43,8 @@ export const URLS = {
     }
 };
 
-export const useBlock = (slug: string) =>
-    useGet(API_BASE_URL + URLS.block.get(slug));
+export const useBlock = (slug: string): [ExtendedBlock | null, boolean] =>
+    useGet<ExtendedBlock>(API_BASE_URL + URLS.block.get(slug));
 
 export const useExperiment = (slug: string) => {
     const data = useGet(API_BASE_URL + URLS.experiment.get(slug));

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -18,6 +18,7 @@ import FloatingActionButton from "@/components/FloatingActionButton/FloatingActi
 import UserFeedback from "@/components/UserFeedback/UserFeedback";
 import FontLoader from "@/components/FontLoader/FontLoader";
 import useResultHandler from "@/hooks/useResultHandler";
+import Session from "@/types/Session";
 
 // Block handles the main (experiment) block flow:
 // - Loads the block and participant
@@ -66,10 +67,20 @@ const Block = () => {
         updateState(newState);
     }, [updateState]);
 
-    const checkSession = async () => {
+    /**
+     * @deprecated
+     */
+    const checkSession = async (): Promise<Session | void> => {
         if (session) {
             return session;
         }
+
+        if (block?.session_id) {
+            const newSession = { id: block.session_id };
+            setSession(newSession);
+            return newSession;
+        }
+
         try {
             const newSession = await createSession({ block, participant, playlist })
             setSession(newSession);
@@ -77,6 +88,7 @@ const Block = () => {
         }
         catch (err) {
             setError(`Could not create a session: ${err}`, err)
+            return;
         };
     };
 
@@ -124,6 +136,10 @@ const Block = () => {
                 });
 
                 setBlock(block);
+
+                if (block.session_id) {
+                    setSession({ id: block.session_id });
+                }
 
                 // Set theme
                 if (block.theme) {

--- a/frontend/src/components/Trial/Trial.tsx
+++ b/frontend/src/components/Trial/Trial.tsx
@@ -13,15 +13,18 @@ import Button from "../Button/Button";
  * If "html" is provided, it will show html content
  * If "feedback_form" is provided, it will present a form of questions to the user
  */
-const Trial = ({
-    playback,
-    html,
-    feedback_form,
-    config,
-    result_id,
-    onNext,
-    onResult,
-}) => {
+const Trial = (props) => {
+
+    const {
+        playback,
+        html,
+        feedback_form,
+        config,
+        result_id,
+        onNext,
+        onResult,
+    } = props;
+
     // Main component state
     const [formActive, setFormActive] = useState(!config.listen_first);
     // Preload is immediately set to ready if we don't have a playback object

--- a/frontend/src/types/Block.ts
+++ b/frontend/src/types/Block.ts
@@ -1,10 +1,26 @@
 import IImage from "@/types/Image";
+import Theme from "./Theme";
 
 export default interface Block {
     id: number;
-    name: string;
     slug: string;
+    name: string;
     description: string;
     image?: IImage;
     bonus_points: number;
+}
+
+export interface ExtendedBlock extends Block {
+    theme?: Theme;
+    class_name: string;
+    rounds: number;
+    playlists: { id: number; name: string }[];
+    feedback_info: {
+        header: string;
+        button: string;
+        contact_body: string;
+        thank_you: string;
+        show_float_button: boolean;
+    }
+    session_id: number;
 }


### PR DESCRIPTION
This pull request includes a refactoring of the `get_block` function to phase out the `first_round` methods and create a session directly in the `get_block` function. If the `first_round` does not exist anymore in a block's rules file, it will call `next_round` directly. The frontend has also been updated to take the session_id from the get_block response. `get_block` will still call `first_round` if it does exist on the block's rules file in question. This allows us to phase it out over time and prevent this PR from becoming a monster to review.

Additionally, tests have been fixed and added after the refactoring of the `first_round` methods and session creation in `get_block`.

Finally, the `Block` and `Trial` component have been partially configured to TypeScript and some types have been updated/added to accomodate this.

Related to #973