### PR TITLE
Fixed: Fix block filter in ParticipantAdmin

### DIFF
--- a/backend/participant/admin.py
+++ b/backend/participant/admin.py
@@ -4,25 +4,23 @@ from result.models import Result
 
 
 class ResultInline(admin.TabularInline):
-    """Inline to show results linked to given participant
-    """
+    """Inline to show results linked to given participant"""
 
     model = Result
-    fields = ['created_at', 'question_key', 'given_response']
+    fields = ["created_at", "question_key", "given_response"]
     extra = 0
 
 
 class ParticipantAdmin(admin.ModelAdmin):
     inlines = [ResultInline]
     list_per_page = 50
-    search_fields = ['unique_hash', 'id', 'country_code']
-    list_display = ('__str__',
-                    'country_code',
-                    'session_count',
-                    )
-    list_filter = [
-        ('session__experiment', admin.RelatedOnlyFieldListFilter)
-    ]
+    search_fields = ["unique_hash", "id", "country_code"]
+    list_display = (
+        "__str__",
+        "country_code",
+        "session_count",
+    )
+    list_filter = [("session__block", admin.RelatedOnlyFieldListFilter)]
 
 
 admin.site.register(Participant, ParticipantAdmin)


### PR DESCRIPTION
Fix block filter where it still tried to filter on a session's experiment, which we now call "block".