### PR TITLE
CI: Update GitHub Actions checkout action to v4

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run Backend Tests
         run: sudo docker compose --env-file .env-github-actions run server bash -c "coverage run manage.py test"
       - name: Generate Backend Coverage Report (Inline)
@@ -63,7 +63,7 @@ jobs:
     name: Lint Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint Backend
         continue-on-error: false
         run: sudo docker compose --env-file .env-github-actions run server bash -c "ruff check"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run Frontend Tests
         run: sudo docker compose --env-file .env-github-actions run client yarn test:ci
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Generate Frontend Coverage Report (XML) and Badge
         run: |
           sudo docker compose --env-file .env-github-actions run client yarn test:ci
@@ -64,5 +64,5 @@ jobs:
     name: Lint Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo docker compose --env-file .env-github-actions run client yarn lint

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn
         working-directory: ./frontend


### PR DESCRIPTION
This pull request updates the GitHub Actions checkout action from v3 to v4. The updated action is used in the backend and frontend test and lint jobs. This update ensures that the latest version of the checkout action is being used, which may include bug fixes or new features.