### PR TITLE
fix: missing max_length of TextQuestion

### DIFF
--- a/backend/experiment/actions/form.py
+++ b/backend/experiment/actions/form.py
@@ -59,7 +59,7 @@ class NumberQuestion(Question):
 class TextQuestion(Question):
     def __init__(self, input_type='text', max_length=64, **kwargs):
         super().__init__(**kwargs)
-        self.max_length = max_length
+        self.max_length = max_length # the maximum length of the question's answer in characters
         self.input_type = input_type
         self.view = 'STRING'
 

--- a/backend/experiment/actions/form.py
+++ b/backend/experiment/actions/form.py
@@ -57,7 +57,7 @@ class NumberQuestion(Question):
 
 
 class TextQuestion(Question):
-    def __init__(self, input_type='text', max_length=None, **kwargs):
+    def __init__(self, input_type='text', max_length=64, **kwargs):
         super().__init__(**kwargs)
         self.max_length = max_length
         self.input_type = input_type


### PR DESCRIPTION
I discovered this while testing the Speech2Song experiment: `TextQuestion` types wouldn't display anymore, since the default value for `max_length` is `None` instead of a number. This teensy PR fixes that.