### PR TITLE
Add participant score_sum()

### DIFF
--- a/backend/participant/models.py
+++ b/backend/participant/models.py
@@ -4,6 +4,8 @@ import uuid
 from django.contrib.humanize.templatetags.humanize import naturalday
 from django.db import models
 
+from question.models import QuestionGroup
+from django.db.models import Sum
 
 class Participant(models.Model):
     """Main participant, base for profile and sessions"""
@@ -92,3 +94,10 @@ class Participant(models.Model):
             })
 
         return scores
+
+    def score_sum(self, question_group_key):
+        """ Sums scores of all profile results with questions in a question group"""
+
+        question_keys = QuestionGroup.objects.get(key=question_group_key).questions.values_list("key", flat=True)
+
+        return self.result_set.all().filter(question_key__in=question_keys).aggregate(Sum("score"))['score__sum']

--- a/backend/participant/tests.py
+++ b/backend/participant/tests.py
@@ -30,6 +30,25 @@ class ParticipantTest(TestCase):
             question_key='test2'
         )
 
+        cls.result3 = Result.objects.create(
+            participant=cls.participant,
+            question_key='msi_01_music_activities',
+            score=1
+        )
+
+        cls.result4 = Result.objects.create(
+            participant=cls.participant,
+            question_key='msi_08_intrigued_styles',
+            score=2
+        )
+
+        cls.result5 = Result.objects.create(
+            participant=cls.participant,
+            question_key='msi_24_music_addiction',
+            score=5
+        )
+
+
     def setUp(self):
         self.client = Client(
             HTTP_USER_AGENT='Agent 007'
@@ -104,3 +123,9 @@ class ParticipantTest(TestCase):
         self.client.get('/participant/')
         participant = Participant.objects.last()
         assert participant.country_code == 'BLA'
+
+    def test_score_sum(self):
+        score_sum = self.participant.score_sum("MSI_F1_ACTIVE_ENGAGEMENT")
+        assert score_sum == 8
+        score_sum = self.participant.score_sum("MSI_F2_PERCEPTUAL_ABILITIES")
+        assert score_sum is None


### PR DESCRIPTION
Allows to sum participant profile scores based on QuestionGroup key.
Closes #135