### PR TITLE
Fixed: Fix warning about key in spread props and make key explicit

### DIFF
--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import { useParams } from "react-router-dom";
 import classNames from "classnames";
@@ -25,7 +25,6 @@ type BlockView = PlaybackView | "TRIAL_VIEW" | "EXPLAINER" | "SCORE" | "FINAL" |
 
 interface BlockState {
     view: BlockView;
-    key: number;
     title?: string;
     url?: string;
     next_round?: any[];
@@ -40,7 +39,7 @@ interface BlockState {
 //   Empty URL parameter "participant_id" is the same as no URL parameter at all
 const Block = () => {
     const { slug } = useParams();
-    const startState = { view: "LOADING", key: Math.random() } as BlockState;
+    const startState = { view: "LOADING" } as BlockState;
     // Stores
     const setError = useBoundStore(state => state.setError);
     const participant = useBoundStore((state) => state.participant);
@@ -64,18 +63,11 @@ const Block = () => {
     const loadingText = block ? block.loading_text : "";
     const className = block ? block.class_name : "";
 
-    /** set random key before setting state
-     * this will assure that `state` will be recognized as an updated object
-     */
+    /** Set new state as spread of current state to force re-render */
     const updateState = useCallback((state: BlockState) => {
         if (!state) return;
 
-        const newState = {
-            ...state,
-            key: Math.random(),
-        };
-
-        setState(newState);
+        setState({ ...state });
     }, []);
 
     const updateActions = useCallback((currentActions) => {
@@ -216,27 +208,27 @@ const Block = () => {
             // Block views
             // -------------------------
             case "TRIAL_VIEW":
-                return <Trial {...attrs} key={state?.key} />;
+                return <Trial {...attrs} />;
 
             // Information & Scoring
             // -------------------------
             case "EXPLAINER":
-                return <Explainer {...attrs} key={state?.key} />;
+                return <Explainer {...attrs} />;
             case "SCORE":
-                return <Score {...attrs} key={state?.key} />;
+                return <Score {...attrs} />;
             case "FINAL":
-                return <Final {...attrs} key={state?.key} />;
+                return <Final {...attrs} />;
 
             // Generic / helpers
             // -------------------------
             case "PLAYLIST":
-                return <Playlist {...attrs} key={state?.key} />;
+                return <Playlist {...attrs} />;
             case "LOADING":
-                return <Loading {...attrs} key={state?.key} />;
+                return <Loading {...attrs} />;
             case "CONSENT":
-                return <Consent {...attrs} key={state?.key} />;
+                return <Consent {...attrs} />;
             case "INFO":
-                return <Info {...attrs} key={state?.key} />;
+                return <Info {...attrs} />;
             case "REDIRECT":
                 return window.location.replace(state.url);
 
@@ -269,7 +261,6 @@ const Block = () => {
             data-testid="experiment-wrapper"
         >
             <CSSTransition
-                key={view}
                 timeout={{ enter: 300, exit: 0 }}
                 classNames={"transition"}
                 unmountOnExit

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -19,6 +19,16 @@ import UserFeedback from "@/components/UserFeedback/UserFeedback";
 import FontLoader from "@/components/FontLoader/FontLoader";
 import useResultHandler from "@/hooks/useResultHandler";
 import Session from "@/types/Session";
+import { PlaybackView } from "@/types/Playback";
+
+interface BlockState {
+    view: PlaybackView;
+    key: number;
+    title?: string;
+    url?: string;
+    next_round?: any[];
+}
+
 
 // Block handles the main (experiment) block flow:
 // - Loads the block and participant
@@ -28,7 +38,7 @@ import Session from "@/types/Session";
 //   Empty URL parameter "participant_id" is the same as no URL parameter at all
 const Block = () => {
     const { slug } = useParams();
-    const startState = { view: "LOADING" };
+    const startState = { view: "LOADING", key: Math.random() };
     // Stores
     const setError = useBoundStore(state => state.setError);
     const participant = useBoundStore((state) => state.participant);
@@ -43,8 +53,8 @@ const Block = () => {
 
     // Current block state
     const [actions, setActions] = useState([]);
-    const [state, setState] = useState(startState);
-    const playlist = useRef<string>(null);
+    const [state, setState] = useState<BlockState | null>(startState);
+    const playlist = useRef(null);
 
     // API hooks
     const [block, loadingBlock] = useBlock(slug);
@@ -54,10 +64,15 @@ const Block = () => {
 
     // set random key before setting state
     // this will assure that `state` will be recognized as an updated object
-    const updateState = useCallback((state) => {
+    const updateState = useCallback((state: typeof startState) => {
         if (!state) return;
-        state.key = Math.random();
-        setState(state);
+
+        const newState = {
+            ...state,
+            key: Math.random(),
+        };
+
+        setState(newState);
     }, []);
 
     const updateActions = useCallback((currentActions) => {
@@ -104,7 +119,7 @@ const Block = () => {
             setError(
                 "An error occured while loading the data, please try to reload the page. (Error: next_round data unavailable)"
             );
-            setState(undefined);
+            setState(null);
         }
     };
 
@@ -198,27 +213,27 @@ const Block = () => {
             // Block views
             // -------------------------
             case "TRIAL_VIEW":
-                return <Trial {...attrs} />;
+                return <Trial {...attrs} key={state?.key} />;
 
             // Information & Scoring
             // -------------------------
             case "EXPLAINER":
-                return <Explainer {...attrs} />;
+                return <Explainer {...attrs} key={state?.key} />;
             case "SCORE":
-                return <Score {...attrs} />;
+                return <Score {...attrs} key={state?.key} />;
             case "FINAL":
-                return <Final {...attrs} />;
+                return <Final {...attrs} key={state?.key} />;
 
             // Generic / helpers
             // -------------------------
             case "PLAYLIST":
-                return <Playlist {...attrs} />;
+                return <Playlist {...attrs} key={state?.key} />;
             case "LOADING":
-                return <Loading {...attrs} />;
+                return <Loading {...attrs} key={state?.key} />;
             case "CONSENT":
-                return <Consent {...attrs} />;
+                return <Consent {...attrs} key={state?.key} />;
             case "INFO":
-                return <Info {...attrs} />;
+                return <Info {...attrs} key={state?.key} />;
             case "REDIRECT":
                 return window.location.replace(state.url);
 

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -12,14 +12,17 @@ import Final from "@/components/Final/Final";
 import Loading from "@/components/Loading/Loading";
 import Playlist from "@/components/Playlist/Playlist";
 import Score from "@/components/Score/Score";
-import Trial from "@/components/Trial/Trial";
+import Trial, { IFeedbackForm } from "@/components/Trial/Trial";
 import Info from "@/components/Info/Info";
 import FloatingActionButton from "@/components/FloatingActionButton/FloatingActionButton";
 import UserFeedback from "@/components/UserFeedback/UserFeedback";
 import FontLoader from "@/components/FontLoader/FontLoader";
 import useResultHandler from "@/hooks/useResultHandler";
 import Session from "@/types/Session";
-import { PlaybackView } from "@/types/Playback";
+import { PlaybackArgs, PlaybackView } from "@/types/Playback";
+import { FeedbackInfo, Step } from "@/types/Block";
+import { TrialConfig } from "@/types/Trial";
+import Social from "@/types/Social";
 
 type BlockView = PlaybackView | "TRIAL_VIEW" | "EXPLAINER" | "SCORE" | "FINAL" | "PLAYLIST" | "LOADING" | "CONSENT" | "INFO" | "REDIRECT";
 
@@ -28,6 +31,58 @@ interface BlockState {
     title?: string;
     url?: string;
     next_round?: any[];
+
+    // Some views require additional data
+    button_label?: string;
+    instruction?: string;
+    timer?: number;
+    steps: Step[];
+    body?: string;
+    html?: string;
+    feedback_form?: IFeedbackForm;
+    playback?: PlaybackArgs;
+    config?: TrialConfig;
+
+    // TODO: Think about how to properly handle the typing of different views
+
+    // Score-related
+    score?: number;
+    score_message?: string;
+    texts?: {
+        score: string;
+        next: string;
+        listen_explainer: string;
+    };
+    feedback?: string;
+    icon?: string;
+
+    // Final related
+    feedback_info?: FeedbackInfo;
+    rank?: string;
+    button?: {
+        text: string;
+        link: string;
+    };
+    final_text?: string | TrustedHTML;
+    show_participant_link?: boolean;
+    participant_id_only?: boolean;
+    show_profile_link?: boolean;
+    action_texts?: {
+        all_experiments: string;
+        profile: string;
+        play_again: string;
+    }
+    points?: string;
+    social?: Social;
+    logo?: {
+        image: string;
+        link: string;
+    };
+
+    // Consent related
+    text?: string;
+    confirm?: string;
+    deny?: string;
 }
 
 

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -21,8 +21,10 @@ import useResultHandler from "@/hooks/useResultHandler";
 import Session from "@/types/Session";
 import { PlaybackView } from "@/types/Playback";
 
+type BlockView = PlaybackView | "TRIAL_VIEW" | "EXPLAINER" | "SCORE" | "FINAL" | "PLAYLIST" | "LOADING" | "CONSENT" | "INFO" | "REDIRECT";
+
 interface BlockState {
-    view: PlaybackView;
+    view: BlockView;
     key: number;
     title?: string;
     url?: string;
@@ -38,7 +40,7 @@ interface BlockState {
 //   Empty URL parameter "participant_id" is the same as no URL parameter at all
 const Block = () => {
     const { slug } = useParams();
-    const startState = { view: "LOADING", key: Math.random() };
+    const startState = { view: "LOADING", key: Math.random() } as BlockState;
     // Stores
     const setError = useBoundStore(state => state.setError);
     const participant = useBoundStore((state) => state.participant);
@@ -62,9 +64,10 @@ const Block = () => {
     const loadingText = block ? block.loading_text : "";
     const className = block ? block.class_name : "";
 
-    // set random key before setting state
-    // this will assure that `state` will be recognized as an updated object
-    const updateState = useCallback((state: typeof startState) => {
+    /** set random key before setting state
+     * this will assure that `state` will be recognized as an updated object
+     */
+    const updateState = useCallback((state: BlockState) => {
         if (!state) return;
 
         const newState = {
@@ -196,7 +199,7 @@ const Block = () => {
     });
 
     // Render block state
-    const render = (view) => {
+    const render = (view: BlockView) => {
         // Default attributes for every view
         const attrs = {
             block,
@@ -251,7 +254,7 @@ const Block = () => {
         setError('No valid state');
     }
 
-    const view = state.view;
+    const view = state?.view;
 
     return (<>
         <FontLoader fontUrl={theme?.heading_font_url} fontType="heading" />

--- a/frontend/src/components/Final/Final.tsx
+++ b/frontend/src/components/Final/Final.tsx
@@ -11,7 +11,7 @@ import ParticipantLink from "../ParticipantLink/ParticipantLink";
 import UserFeedback from "../UserFeedback/UserFeedback";
 import FinalButton from "./FinalButton";
 import ISocial from "@/types/Social";
-import Block from "@/types/Block";
+import Block, { FeedbackInfo } from "@/types/Block";
 import Participant from "@/types/Participant";
 
 interface FinalProps {
@@ -33,7 +33,7 @@ interface FinalProps {
     participant_id_only: boolean;
     show_profile_link: boolean;
     social: ISocial;
-    feedback_info: any;
+    feedback_info?: FeedbackInfo;
     points: string;
     rank: {
         class: string;

--- a/frontend/src/components/Playback/Playback.tsx
+++ b/frontend/src/components/Playback/Playback.tsx
@@ -40,10 +40,8 @@ const Playback = ({
     const activeAudioEndedListener = useRef<() => void>();
     const [state, setState] = useState<PlaybackState>({ view: PRELOAD });
 
-    /** FIXME: Nowhere is setView used with the data argument.
-     * We might want to remove the data argument from setView */
-    const setView = (view: PlaybackView, data = {}) => {
-        setState({ view, ...data });
+    const setView = (view: PlaybackView) => {
+        setState({ view });
     }
 
     // check if the users device is webaudio compatible

--- a/frontend/src/components/Playback/Playback.tsx
+++ b/frontend/src/components/Playback/Playback.tsx
@@ -39,6 +39,9 @@ const Playback = ({
     const lastPlayerIndex = useRef(-1);
     const activeAudioEndedListener = useRef<() => void>();
     const [state, setState] = useState<PlaybackState>({ view: PRELOAD });
+
+    /** FIXME: Nowhere is setView used with the data argument.
+     * We might want to remove the data argument from setView */
     const setView = (view: PlaybackView, data = {}) => {
         setState({ view, ...data });
     }

--- a/frontend/src/components/Trial/Trial.tsx
+++ b/frontend/src/components/Trial/Trial.tsx
@@ -10,7 +10,7 @@ import Question from "@/types/Question";
 import { OnResultType } from "@/hooks/useResultHandler";
 import { TrialConfig } from "@/types/Trial";
 
-interface IFeedbackForm {
+export interface IFeedbackForm {
     form: Question[];
     submit_label: string;
     skip_label: string;

--- a/frontend/src/types/Block.ts
+++ b/frontend/src/types/Block.ts
@@ -23,6 +23,11 @@ export interface FeedbackInfo {
     show_float_button: boolean;
 }
 
+export interface Step {
+    id: number;
+    description: string;
+}
+
 export interface ExtendedBlock extends Block {
     theme?: Theme;
     class_name: string;
@@ -31,4 +36,6 @@ export interface ExtendedBlock extends Block {
     feedback_info: FeedbackInfo;
     session_id: number;
     loading_text: string;
+    timer?: number;
+    steps?: Step[];
 }


### PR DESCRIPTION
Resolves 🐛 [BUG] - Warning: A props object containing a "key" prop is being spread into JSX in `Block.tsx` #1221

Propose removing unused data argument from setView function in Playback.tsx

## Question to reviewer

Do we even need to pass a `key` to the children components? Perhaps we can simplify it and remove it.