### PR TITLE
feat(Block): Add key prop to force child component re-renders

### DIFF
--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -27,6 +27,9 @@ import Social from "@/types/Social";
 type BlockView = PlaybackView | "TRIAL_VIEW" | "EXPLAINER" | "SCORE" | "FINAL" | "PLAYLIST" | "LOADING" | "CONSENT" | "INFO" | "REDIRECT";
 
 interface BlockState {
+    // Unique key to force re-render
+    key: number;
+
     view: BlockView;
     title?: string;
     url?: string;
@@ -122,7 +125,9 @@ const Block = () => {
     const updateState = useCallback((state: BlockState) => {
         if (!state) return;
 
-        setState({ ...state });
+        const key = state.key ? state.key + 1 : 1;
+
+        setState({ ...state, key });
     }, []);
 
     const updateActions = useCallback((currentActions) => {


### PR DESCRIPTION
- Add 'key' property to BlockState interface
- Implement key increment in updateState function
- Ensure child components re-render on state changes

This change addresses an issue where child components weren't
re-rendering properly when the state was updated multiple times
with similar data.