### PR TITLE
Fixed(migration): Refactor block content migration script

### DIFF
--- a/backend/experiment/migrations/0054_migrate_block_content.py
+++ b/backend/experiment/migrations/0054_migrate_block_content.py
@@ -35,9 +35,9 @@ def migrate_block_content(apps, schema_editor):
             description=block.description,
         )
 
-        # Attempt to add consent file
-        rules = block.get_rules()
         try:
+            # Attempt to add consent file
+            rules = block.get_rules()
             consent_path = Path("experiment", "templates", rules.default_consent_file)
             with consent_path.open(mode="rb") as f:
                 content.consent = File(f, name=consent_path.name)


### PR DESCRIPTION
This pull request includes a fix for the migration script that was causing some errors as it tried to get the rules of one or more blocks whose configured rules id was invalid on the test environment.