### PR TITLE
CI: Refactor workflow file to build and publish Documentation website and Storybook simultaneously

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build ER/MKDOCS site
         run: |
           mkdir -p docs-pages
-          mkdocs build -d ../docs-pages
+          sudo docker compose --env-file .env-github-actions run server bash -c "mkdocs build -d ../docs-pages"
         working-directory: ./backend
 
       - name: Install dependencies
@@ -41,7 +41,6 @@ jobs:
       - name: Build Storybook
         run: yarn storybook:build --output-dir ../docs-pages/storybook
         working-directory: ./frontend
-
 
       - name: Setup Github Pages
         uses: actions/configure-pages@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build ER/MKDOCS site
         run: |
           mkdir -p docs-pages
-          sudo docker compose --env-file .env-github-actions run server bash -c "mkdocs build -d ../docs-pages"
+          sudo docker compose run server bash -c "mkdocs build -d ../docs-pages"
         working-directory: ./backend
 
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Replace this step with the ER/MKDOCS build step
       - name: Create dummy index.html
         run: |
           mkdir -p docs-pages
           echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/MUSCLE/storybook">Storybook</a></li></ul></body></html>' > ./docs-pages/index.html
+
+      # Build ER/MKDOCS documentation site,
+      # @Evert-R - for you to fix :-)
+      # - name: Build ER/MKDOCS site
+      #   run: |
+      #     mkdocs build -d ../docs-pages
+      #   working-directory: ./backend
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           mkdir -p docs-pages
           sudo docker compose --env-file .env-github-actions run server bash -c "mkdocs build -d ./docs-pages-build"
-          cp -r ./docs-pages-build/* ./docs-pages
+          cp -r ./backend/docs-pages-build/* ./docs-pages
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Build ER/MKDOCS site
         run: |
           mkdir -p docs-pages
-          sudo docker compose run server bash -c "mkdocs build -d ../docs-pages"
+          pip install mkdocs
+          mkdocs build -d ../docs-pages
         working-directory: ./backend
 
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./frontend
 
       - name: Build Storybook
-        run: yarn storybook:build --output-dir ../docs/storybook --base-path /storybook
+        run: yarn storybook:build --output-dir ../docs/storybook
         working-directory: ./frontend
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,8 +58,7 @@ jobs:
 
   deploy-gh-pages:
     # only deploy on develop branch
-    # temporarily turn off for testing
-    # if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Build ER/MKDOCS site
         run: |
           mkdir -p docs-pages
-          sudo docker compose --env-file .env-github-actions run server bash -c "mkdocs build -d ../docs-pages"
+          sudo docker compose --env-file .env-github-actions run server bash -c "mkdocs build -d ./docs-pages-build"
+          cp -r ./docs-pages-build/* ./docs-pages
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create main index.html
+      - name: Create dummy index.html
         run: |
           mkdir -p docs-pages
           echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/MUSCLE/storybook">Storybook</a></li></ul></body></html>' > ./docs-pages/index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Create main index.html
         run: |
-          mkdir -p docs
-          echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/MUSCLE/storybook">Storybook</a></li></ul></body></html>' > ./docs/index.html
+          mkdir -p docs-pages
+          echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/MUSCLE/storybook">Storybook</a></li></ul></body></html>' > ./docs-pages/index.html
 
       - name: Install dependencies
         run: yarn
         working-directory: ./frontend
 
       - name: Build Storybook
-        run: yarn storybook:build --output-dir ../docs/storybook
+        run: yarn storybook:build --output-dir ../docs-pages/storybook
         working-directory: ./frontend
 
 
@@ -48,13 +48,13 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./docs
+          path: ./docs-pages
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:
           name: build
-          path: ./docs
+          path: ./docs-pages
 
   deploy-gh-pages:
     # only deploy on develop branch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create main index.html
         run: |
           mkdir -p docs
-          echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/storybook">Storybook</a></li><li><a href="/api">API Documentation</a></li></ul></body></html>' > ./docs/index.html
+          echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/MUSCLE/storybook">Storybook</a></li></ul></body></html>' > ./docs/index.html
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build & Publish Storybook
+name: Build & Publish Docs & Storybook
 
 on:
   push:
@@ -7,13 +7,13 @@ on:
       - develop
     paths:
       - 'frontend/**'
-      - '.github/workflows/storybook.yml'
+      - '.github/workflows/docs.yml'
       - '.yarn/**'
       - '.storybook/**'
   pull_request:
     paths:
       - 'frontend/**'
-      - '.github/workflows/storybook.yml'
+      - '.github/workflows/docs.yml'
       - '.yarn/**'
       - '.storybook/**'
 
@@ -27,27 +27,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Create main index.html
+        run: |
+          mkdir -p docs
+          echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/storybook">Storybook</a></li><li><a href="/api">API Documentation</a></li></ul></body></html>' > ./docs/index.html
+
       - name: Install dependencies
         run: yarn
         working-directory: ./frontend
+
       - name: Build Storybook
-        run: yarn storybook:build
+        run: yarn storybook:build --output-dir ../docs/storybook --base-path /storybook
         working-directory: ./frontend
+
+
       - name: Setup Github Pages
         uses: actions/configure-pages@v2
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./frontend/storybook-static
+          path: ./docs
+
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:
           name: build
-          path: ./frontend/storybook-static
+          path: ./docs
 
   deploy-gh-pages:
     # only deploy on develop branch
-    if: github.ref == 'refs/heads/develop'
+    # temporarily turn off for testing
+    # if: github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,9 +31,7 @@ jobs:
       - name: Build ER/MKDOCS site
         run: |
           mkdir -p docs-pages
-          pip install mkdocs
-          mkdocs build -d ../docs-pages
-        working-directory: ./backend
+          sudo docker compose --env-file .env-github-actions run server bash -c "mkdocs build -d ../docs-pages"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,18 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Replace this step with the ER/MKDOCS build step
-      - name: Create dummy index.html
+      - name: Build ER/MKDOCS site
         run: |
           mkdir -p docs-pages
-          echo '<html><head><title>Project Documentation</title></head><body><h1>Project Documentation</h1><ul><li><a href="/MUSCLE/storybook">Storybook</a></li></ul></body></html>' > ./docs-pages/index.html
-
-      # Build ER/MKDOCS documentation site,
-      # @Evert-R - for you to fix :-)
-      # - name: Build ER/MKDOCS site
-      #   run: |
-      #     mkdocs build -d ../docs-pages
-      #   working-directory: ./backend
+          mkdocs build -d ../docs-pages
+        working-directory: ./backend
 
       - name: Install dependencies
         run: yarn

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -30,6 +30,7 @@ const config = {
 
     viteFinal: (config) => {
         return mergeConfig(config, {
+            base: "/storybook/",
             resolve: {
                 alias: {
                     '@/': '/src/',

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -30,7 +30,7 @@ const config = {
 
     viteFinal: (config) => {
         return mergeConfig(config, {
-            base: "/storybook/",
+            base: "/MUSCLE/storybook/",
             resolve: {
                 alias: {
                     '@/': '/src/',


### PR DESCRIPTION
This pull request refactors the workflow file to build and publish both the documentation and Storybook simultaneously.

Instead of directly artifacting and deploying the `frontend/storybook-static` directory, the workflow is now configured to create and use the `docs-pages` directory in the root of the repository which gets published to Github Pages. Storybook is then configured to publish its build into `docs-pages/storybook` and update its internal links (`config.base`) to be prefixed with `/MUSCLE/storybook/` (`MUSCLE` is this repository's Github Pages' path, `storybook` is the subdirectory of storybook)

I've created a dummy `index.html` with a link to the Storybook site that shows that it works: https://amsterdam-music-lab.github.io/MUSCLE. This should probably removed when the Documentation website is integrated into this workflow. So, remove these lines:

https://github.com/Amsterdam-Music-Lab/MUSCLE/blob/c15fe455d74773970cce34e2570cb51192fd63d1/.github/workflows/docs.yml#L31-L35

## New directory / file structure for Github Pages

```
(root)
  - frontend
  - backend
  - docs-pages (this directory will be published to Github Pages and should serve as the root of the built documentation website made by Evert)
    - index.html (index.html from Documentation website)
    - storybook
      - index.html (of storybook)
```

## Important to know:

Currently, the workflow is configured to deploy for this branch too (besides `develop`) in order to test the updated workflow.

See the commented out condition for `refs/heads/develop` here:

https://github.com/Amsterdam-Music-Lab/MUSCLE/blob/c15fe455d74773970cce34e2570cb51192fd63d1/.github/workflows/docs.yml#L59-L62

If I'm on vacation and @Evert-R wants to test the Documentation website being deployed to Github Pages correctly, it's probably a good idea to leave this turned on until we can verify it works as expected. BUT, Github Pages doesn't just publish from _every_ git branch as there is a protection layer. So if you are trying to test your branch to be deployed correctly, you have to add your branch here (Settings > Environments > github-pages > Deployment tags & branches): https://github.com/Amsterdam-Music-Lab/MUSCLE/settings/environments/1801563345/edit