### PR TITLE
Fixed: Fix duplicate `next_round` call by handling theme logic in a separate effect

### DIFF
--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -54,6 +54,7 @@ const Block = () => {
     const session = useBoundStore((state) => state.session);
     const theme = useBoundStore((state) => state.theme);
     const setTheme = useBoundStore((state) => state.setTheme);
+    const resetTheme = useBoundStore((state) => state.resetTheme);
     const setBlock = useBoundStore((state) => state.setBlock);
 
     const setHeadData = useBoundStore((state) => state.setHeadData);
@@ -135,13 +136,6 @@ const Block = () => {
                     setError('Session could not be created');
                 }
 
-                // Set theme
-                if (block.theme) {
-                    setTheme(block.theme);
-                } else if (!block.theme && theme) {
-                    setTheme(null);
-                }
-
                 continueToNextRound({ id: block.session_id });
 
             } else {
@@ -160,9 +154,17 @@ const Block = () => {
         participant,
         setError,
         updateActions,
-        theme,
-        setTheme,
     ]);
+
+    useEffect(() => {
+        if (block?.theme) {
+            // Set theme if block has theme
+            setTheme(block.theme);
+        } else if (!block?.theme && theme) {
+            // Reset theme if new block has no theme
+            resetTheme();
+        }
+    }, [block, theme, setTheme, resetTheme]);
 
     const onResult = useResultHandler({
         session,

--- a/frontend/src/util/stores.ts
+++ b/frontend/src/util/stores.ts
@@ -109,11 +109,13 @@ const createSessionSlice: StateCreator<SessionSlice> = (set) => ({
 interface ThemeSlice {
     theme: ITheme | null;
     setTheme: (theme: ITheme) => void;
+    resetTheme: () => void;
 }
 
 const createThemeSlice: StateCreator<ThemeSlice> = (set) => ({
     theme: null,
     setTheme: (theme: ITheme) => set(() => ({ theme })),
+    resetTheme: () => set(() => ({ theme: null })),
 });
 
 export const useBoundStore = create<BlockSlice & DocumentHeadSlice & ErrorSlice & ParticipantSlice & SessionSlice & ThemeSlice>((...args) => ({


### PR DESCRIPTION
Fixes 🐛 [BUG] - `next_round` gets called twice on initialization #1261

This pull request fixes the issue where the `next_round` endpoint is called twice on initialization. As the `theme` was set using `setTheme` in the same `useEffect`, it re-triggered this same `useEffect` before the initial `continueToNextRound` was resolved, thereby calling the `continueToNextRound` function a second time.