### PR TITLE
Fix button array spacing

### DIFF
--- a/frontend/src/components/Question/_ButtonArray.scss
+++ b/frontend/src/components/Question/_ButtonArray.scss
@@ -12,7 +12,18 @@
 
     .btn-group-toggle-custom {
         display: flex;
-        column-gap: 2.5vw;
+        &:has(> :last-child:nth-child(2)) {
+            column-gap: 8vw;
+        }
+        &:has(> :last-child:nth-child(3)) {
+            column-gap: 6vw;
+        }
+        &:has(> :last-child:nth-child(4)) {
+            column-gap: 3vw;
+        }
+        &:has(> :last-child:nth-child(5)) {
+            column-gap: 2vw;
+        }
 
         &.buttons-large-gap {
             column-gap: 5rem;

--- a/frontend/src/components/Question/_ButtonArray.scss
+++ b/frontend/src/components/Question/_ButtonArray.scss
@@ -12,7 +12,7 @@
 
     .btn-group-toggle-custom {
         display: flex;
-        column-gap: 3rem;
+        column-gap: 2.5vw;
 
         &.buttons-large-gap {
             column-gap: 5rem;


### PR DESCRIPTION
This branch sets different column gaps between buttons in an array, based on the number of buttons, and the viewport width.


<img width="254" alt="Screenshot 2024-09-24 at 14 18 29" src="https://github.com/user-attachments/assets/4a84faa1-8f97-4fac-8d65-5a8ed5bada61">
<img width="259" alt="Screenshot 2024-09-24 at 14 18 50" src="https://github.com/user-attachments/assets/6444cbe3-f05e-414e-82dd-aa6dbbd71e6e">
<img width="268" alt="Screenshot 2024-09-24 at 14 19 22" src="https://github.com/user-attachments/assets/5952c115-8be3-48bb-8419-67c2ba3abff6">
