### PR TITLE
Fixed (style): Prevent percentage circle from overlapping background circle

### DIFF
--- a/frontend/src/components/Circle/Circle.scss
+++ b/frontend/src/components/Circle/Circle.scss
@@ -3,20 +3,20 @@
     margin-bottom: 15px;
     margin-top: 15px;
 
-    > svg,
+    >svg,
     .content {
         position: absolute;
         left: 0;
         top: 0;
     }
 
-    > svg {
+    >svg {
         @extend .circleIntro;
     }
 
     .circle-percentage {
         transition: stroke-dashoffset 0.1s linear;
         transform: rotate(-90deg);
-        transform-origin: 50% 50%;
+        transform-origin: 0% 0%;
     }
 }


### PR DESCRIPTION
Resolves #1271

This worked in my local storybook, let's first see if it transfers to staging too