### PR TITLE
Fixed(style): Move percentage circle down 100% to align with background circle

### DIFF
--- a/frontend/src/components/Circle/Circle.scss
+++ b/frontend/src/components/Circle/Circle.scss
@@ -16,7 +16,9 @@
 
     .circle-percentage {
         transition: stroke-dashoffset 0.1s linear;
-        transform: rotate(-90deg);
-        transform-origin: 0% 0%;
+
+        // 102.5px is the radius of the circle
+        // translateX because the circle is rotated -90deg
+        transform: rotate(-90deg) translateX(calc(-102.5px * 2));
     }
 }

--- a/frontend/src/stories/Circle.stories.jsx
+++ b/frontend/src/stories/Circle.stories.jsx
@@ -113,7 +113,7 @@ export const LongDuration = {
         radius: 100,
         strokeWidth: 5,
         color: "white",
-        duration: 30,
+        duration: 60,
         animateCircle: true,
         running: true,
     },


### PR DESCRIPTION

## Screenshots

<img width="810" alt="image" src="https://github.com/user-attachments/assets/025a7168-cbe4-4463-83e4-fc8c8205e9a3">

* 1. is on Firefox, 2. is on Safari

Resolves #1271