### PR TITLE
CI(coverage): Exclude a whole bunch of unneeded directories and files used to calculate the frontend code coverage percentages

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,12 +10,27 @@ export default defineConfig({
     coverage: {
       reportsDirectory: 'public/coverage',
       provider: 'v8',
-      reporter: "json-summary",
+      reporter: ["text", "json-summary"],
+      exclude: [
+        'node_modules/**',
+        'storybook-static/**',
+        'src/stories/**',
+        'src/config/**',
+        'src/**/*.stories.{js,jsx,ts,tsx}',
+        'src/index.tsx',
+        'src/serviceWorker.js',
+        '.pnp.cjs',
+        '.pnp.loader.mjs',
+        '.storybook/**',
+        '.yarn/**',
+        'src/util/testUtils/useEffectDebugger.js',
+        'src/util/__mocks__/**',
+      ],
     },
   },
   resolve: {
     alias: {
-        '@/': '/src/',
+      '@/': '/src/',
     },
-},
+  },
 })


### PR DESCRIPTION
Previously, a bunch of files such as stories, yarn-related, storybook-static-related files would also be taken into account to calculate the code coverages percentages. It therefore resulted into a lower percentage than the "actual" code coverage percentage.

Additionally, I updated the vitest configuration file to also output code coverage line information in the terminal (next to the already existent json file)