### PR TITLE
ToontjeHoger Kids hotfix

### DIFF
--- a/backend/experiment/rules/toontjehoger_1_mozart.py
+++ b/backend/experiment/rules/toontjehoger_1_mozart.py
@@ -7,7 +7,7 @@ from experiment.actions.form import ButtonArrayQuestion, Form
 from experiment.actions.playback import Autoplay
 from experiment.actions.styles import STYLE_TOONTJEHOGER
 from .base import Base
-from experiment.utils import non_breaking_spaces
+from experiment.actions.utils import get_current_experiment_url
 
 from result.utils import prepare_result
 
@@ -118,8 +118,11 @@ class ToontjeHoger1Mozart(Base):
         # Feedback message
         last_result = session.last_result()
         section = last_result.section
-        feedback = "Je hoorde {} van {}.".format(
-            section.song.name, non_breaking_spaces(section.song.artist)) if section else ""
+        feedback = (
+            "Je hoorde {} van {}.".format(section.song.name, section.song.artist)
+            if section
+            else ""
+        )
 
         # Return score view
         config = {'show_total_score': True}
@@ -177,8 +180,10 @@ class ToontjeHoger1Mozart(Base):
 
         image_trial = Trial(
             html=HTML(
-                body='<img src="{}" style="height:calc(100% - 260px);max-height:326px;max-width: 100%;"/>'.format(
-                image_url)),
+                body='<img src="{}" style="max-height:326px;max-width: 100%;"/>'.format(
+                    image_url
+                )
+            ),
             feedback_form=form,
             title=self.TITLE,
         )

--- a/backend/experiment/rules/toontjehoger_1_mozart.py
+++ b/backend/experiment/rules/toontjehoger_1_mozart.py
@@ -7,7 +7,6 @@ from experiment.actions.form import ButtonArrayQuestion, Form
 from experiment.actions.playback import Autoplay
 from experiment.actions.styles import STYLE_TOONTJEHOGER
 from .base import Base
-from experiment.actions.utils import get_current_experiment_url
 
 from result.utils import prepare_result
 

--- a/backend/experiment/rules/toontjehoger_2_preverbal.py
+++ b/backend/experiment/rules/toontjehoger_2_preverbal.py
@@ -162,8 +162,10 @@ class ToontjeHoger2Preverbal(Base):
 
         image_trial = Trial(
             html=HTML(
-            body='<img src="{}" style="height:calc(100% - 260px);max-height:326px;max-width: 100%;"/>'.format(
-                "/images/experiments/toontjehoger/preverbal_1.webp")),
+                body='<img src="{}" style="max-height:326px;max-width: 100%;"/>'.format(
+                    "/images/experiments/toontjehoger/preverbal_1.webp"
+                )
+            ),
             feedback_form=form,
             title=self.TITLE,
         )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "muscle",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "private": false,
     "description": "The MUSCLE platform is an application that provides an easy way to implement and run online listening experiments for music research.",
     "license": "MIT",


### PR DESCRIPTION
This branch fixes the following issues:
- on Safari, some images would be squashed on narrow viewports. This was caused by the height setting, I removed it. I'm not sure what the intention was behind it, but after the fix I don't see any problems on Safari or Chrome with different viewports.
- the name & composer of sections used in the Toontjehoger Mozart Effect are very long (they include not only the name of the composer, but also of the ensemble and conductor), so I removed the formatting with non-breaking-spaces to address this problem:
![screenshot 3](https://github.com/user-attachments/assets/1d4418fd-dbfb-4933-81db-40306cde0bc9)
Again, I couldn't see obvious drawbacks of allowing the interface to break between words in the section's name / artist description.
