### PR TITLE
Style: Improve styling & stories of profile view, rank & cup

### DIFF
--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -73,7 +73,7 @@ const App = () => {
                         />
 
                         {/* Profile */}
-                        <Route path={URLS.profile} exact element={<Profile />} />
+                        <Route path={URLS.profile} element={<Profile />} />
 
                         {/* Internal redirect */}
                         <Route path={URLS.internalRedirect} element={<InternalRedirect />} />
@@ -84,13 +84,9 @@ const App = () => {
                         {/* Experiment */}
                         <Route path={URLS.experiment} element={<Experiment />} />
 
-                        {/* Session - ⚠️ What is the purpose of this non-functional route? */}
-                        <Route path={URLS.session} />
-
                         {/* Store profile */}
                         <Route
                             path={URLS.storeProfile}
-                            exact
                             element={StoreProfile}
                         />
                     </Routes>

--- a/frontend/src/components/Cup/Cup.scss
+++ b/frontend/src/components/Cup/Cup.scss
@@ -7,7 +7,6 @@
     box-shadow: 13px 0 64px $yellow;
     border: 5px solid white;
     box-sizing: border-box;
-    margin-bottom: 20px;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/src/components/Profile/Profile.scss
+++ b/frontend/src/components/Profile/Profile.scss
@@ -19,35 +19,32 @@
         .scores {
             padding: 10px;
             display: flex;
+            gap: 1rem;
 
             @media (min-width: 720px) {
                 flex-wrap: wrap;
                 justify-content: center;
                 width: auto !important;
             }
+
             .score {
-                width: 290px;
                 display: flex;
-                justify-content: stretch;
                 align-items: center;
+                justify-content: center;
+                gap: 1rem;
                 border: 1px solid rgba(white, 0.3);
                 border-radius: 5px;
-                margin-right: 5px;
-                padding-right: 5px;
+                padding: 2rem;
 
                 @media (min-width: 720px) {
-                    margin-bottom: 10px;
                     flex-direction: column;
-                    width: 40%;
                     justify-content: center;
-                    padding-bottom: 10px;
+                    padding: 2rem;
                 }
 
                 .rank {
-                    margin-right: 5px;
-                    width: 210px;
-                    height: 140px;
                     position: relative;
+
                     @media (min-width: 720px) {
                         margin-right: 0;
                         width: 100%;
@@ -76,6 +73,7 @@
                     padding-left: 10px;
                     flex-grow: 1;
                     width: 100%;
+
                     @media (min-width: 720px) {
                         text-align: center;
                         padding-left: 0;
@@ -84,15 +82,18 @@
                     h5 {
                         margin-bottom: 0;
                     }
+
                     a {
                         color: white;
                         transition: opacity 0.3s ease-out;
                         border-bottom: 2px solid $pink;
                         text-decoration: none !important;
+
                         &:hover {
                             opacity: 0.8;
                         }
                     }
+
                     p {
                         color: $gray;
                         margin-bottom: 0;
@@ -102,12 +103,15 @@
             }
         }
     }
+
     .store {
         padding-top: 10px;
+
         .copy {
             width: 100%;
             display: flex;
             justify-content: stretch;
+
             input {
                 width: 100%;
                 border-top-left-radius: 3px;

--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -1,116 +1,30 @@
-import { Link } from "react-router-dom";
 import DefaultPage from "../Page/DefaultPage";
 import Loading from "../Loading/Loading";
-import Cup from "../Cup/Cup";
 import { useParticipantScores } from "../../API";
-import { URLS } from "@/config";
-import ParticipantLink from "../ParticipantLink/ParticipantLink";
+import ProfileView, { ProfileViewProps } from "./ProfileView";
 
 /** Profile loads and shows the profile of a participant for a given experiment */
 const Profile = () => {
     // API hooks
     const [data, loadingData] = useParticipantScores<ProfileViewProps>();
 
-    // View
-    let view = null;
-    switch (true) {
-        case loadingData:
-            view = <Loading />;
-            break;
-        case data === null:
-            view = (
-                <Loading>
+    if (loadingData) {
+        return <Loading />;
+    }
+
+    return (
+        <DefaultPage title="Profile" className="aha__profile">
+            {data ? (
+                <ProfileView {...data} />
+            ) : (
+                <p>
                     An error occurred while
                     <br />
                     loading your profile
-                </Loading>
-            );
-            break;
-        default: {
-            view = ProfileView(data);
-        }
-    }
-
-    // Show profile
-
-    return <DefaultPage className="aha__profile">{view}</DefaultPage>;
-};
-
-interface ProfileViewProps {
-    messages: {
-        title: string;
-        summary: string;
-        continue: string;
-        points: string;
-    };
-    scores: {
-        block_slug: string;
-        block_name: string;
-        score: number;
-        date: string;
-        rank: {
-            class: string;
-            text: string;
-        };
-        finished_at: string;
-    }[];
-}
-
-export const ProfileView = (data: ProfileViewProps) => {
-
-    // Highest score
-    data.scores.sort((a, b) =>
-        a.finished_at === b.finished_at
-            ? 0
-            : a.finished_at > b.finished_at
-                ? -1
-                : 1
-    );
-
-    return (
-        <>
-            <h3 className="title">{data.messages.title}</h3>
-            <p>
-                {data.messages.summary}
-            </p>
-
-            <div className="scroller">
-                <div
-                    className="scores"
-                    style={{ width: 25 + data.scores.length * 290 }}
-                >
-                    {data.scores.map((score, index) => (
-                        <div key={index} className="score">
-                            <div className="rank">
-                                <Cup className={score.rank.class} text={score.rank.text} />
-                            </div>
-                            <div className="stats">
-                                <h4>
-                                    <Link
-                                        to={URLS.block.replace(
-                                            ":slug",
-                                            score.block_slug
-                                        )}
-                                    >
-                                        {score.block_name}
-                                    </Link>
-                                </h4>
-                                <h5>{score.score} {data.messages.points}</h5>
-                                <p>{score.date}</p>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </div>
-
-            <div className="store">
-                <p>
-                    {data.messages.continue}
                 </p>
-                <ParticipantLink></ParticipantLink>
-            </div>
-        </>
-    )
-}
+            )}
+        </DefaultPage>
+    );
+};
 
 export default Profile;

--- a/frontend/src/components/Profile/ProfileView.tsx
+++ b/frontend/src/components/Profile/ProfileView.tsx
@@ -1,0 +1,82 @@
+import { Link } from "react-router-dom";
+import Cup from "../Cup/Cup";
+import { URLS } from "@/config";
+import ParticipantLink from "../ParticipantLink/ParticipantLink";
+
+export interface ProfileViewProps {
+    messages: {
+        title: string;
+        summary: string;
+        continue: string;
+        points: string;
+    };
+    scores: {
+        block_slug: string;
+        block_name: string;
+        score: number;
+        date: string;
+        rank: {
+            class: string;
+            text: string;
+        };
+        finished_at: string;
+    }[];
+}
+
+export const ProfileView = (data: ProfileViewProps) => {
+
+    // Highest score
+    data.scores.sort((a, b) =>
+        a.finished_at === b.finished_at
+            ? 0
+            : a.finished_at > b.finished_at
+                ? -1
+                : 1
+    );
+
+    return (
+        <>
+            <h3 className="title">{data.messages.title}</h3>
+            <p>
+                {data.messages.summary}
+            </p>
+
+            <div className="scroller">
+                <div
+                    className="scores"
+                >
+                    {data.scores.map((score, index) => (
+                        <div key={index} className="score">
+                            <div className="rank">
+                                <Cup className={score.rank.class} text={score.rank.text} />
+                            </div>
+                            <div className="stats">
+                                <h4>
+                                    <Link
+                                        to={URLS.block.replace(
+                                            ":slug",
+                                            score.block_slug
+                                        )}
+                                    >
+                                        {score.block_name}
+                                    </Link>
+                                </h4>
+                                <h5>{score.score} {data.messages.points}</h5>
+                                <p>{score.date}</p>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="store">
+                <p>
+                    {data.messages.continue}
+                </p>
+                <ParticipantLink></ParticipantLink>
+            </div>
+        </>
+    )
+}
+
+export default ProfileView;

--- a/frontend/src/components/Rank/Rank.scss
+++ b/frontend/src/components/Rank/Rank.scss
@@ -1,0 +1,7 @@
+.aha__rank {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 1rem;
+}

--- a/frontend/src/components/Rank/Rank.tsx
+++ b/frontend/src/components/Rank/Rank.tsx
@@ -1,5 +1,6 @@
 import ScoreCounter, { ScoreCounterProps } from "../ScoreCounter/ScoreCounter";
 import Cup, { CupProps } from "../Cup/Cup";
+import "./Rank.scss";
 
 interface RankProps {
     cup: CupProps
@@ -8,7 +9,7 @@ interface RankProps {
 
 // Rank shows a decorated representation of a rank
 const Rank = ({ cup, score }: RankProps) => (
-    <div data-testid="rank" >
+    <div data-testid="rank" className="aha__rank">
         <Cup className={cup.className} text={cup.text} />
         <ScoreCounter score={score.score} label={score.label} />
     </div >

--- a/frontend/src/stories/ProfileView.stories.jsx
+++ b/frontend/src/stories/ProfileView.stories.jsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router } from "react-router-dom";
 
-import { ProfileView } from "../components/Profile/Profile";
+import ProfileView from "../components/Profile/ProfileView";
 
 export default {
     title: "ProfileView",
@@ -14,18 +14,48 @@ function getProfileData(overrides = {}) {
     return {
         messages: {
             title: "Profile",
-            summary: "Knorrum bipsum sulfur bit dalmatian",
+            summary: "You have participated in 6 Amsterdam Music Lab experiments. Your best scores are:",
+            points: "points",
         },
         scores: [
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "diamond",
+                    text: "1st",
+                },
+                score: '250',
+                date: "Never",
+                block_slug: "block-slug",
+            },
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "platinum",
+                    text: "1st",
+                },
+                score: '200',
+                date: "Tomorrow",
+                block_slug: "block-slug",
+            },
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "gold",
+                    text: "1st",
+                },
+                score: '150',
+                date: "Ereyesterday",
+                block_slug: "block-slug",
+            },
             {
                 finished_at: "2021-09-20T12:00:00Z",
                 rank: {
                     class: "silver",
                     text: "2nd",
                 },
-                score: 100,
-                points: "points",
-                date: "2021-09-20",
+                score: '100',
+                date: "Yesterday",
                 block_slug: "block-slug",
             },
             {
@@ -35,8 +65,17 @@ function getProfileData(overrides = {}) {
                     text: "3rd",
                 },
                 score: 50,
-                points: "points",
-                date: "2021-09-21",
+                date: "Today",
+                block_slug: "block-slug",
+            },
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "plastic",
+                    text: "100th",
+                },
+                score: '2',
+                date: "Last year",
                 block_slug: "block-slug",
             },
         ],
@@ -47,11 +86,18 @@ function getProfileData(overrides = {}) {
 
 const getDecorator = (Story) => (
     <div
-        style={{ width: "100%", height: "100%", backgroundColor: "#aaa", padding: "1rem" }}
+        style={{ width: "100%", height: "100%", backgroundColor: "#333", padding: "1rem" }}
+        className="aha__page aha__profile"
     >
-        <Router>
-            <Story />
-        </Router>
+        <div className="container">
+            <div className="row justify-content-center">
+                <div className="col-12">
+                    <Router>
+                        <Story />
+                    </Router>
+                </div>
+            </div>
+        </div>
     </div>
 );
 
@@ -59,3 +105,66 @@ export const Default = {
     args: getProfileData(),
     decorators: [getDecorator],
 };
+
+export const NoScores = {
+    args: getProfileData({
+        messages: {
+            title: "Profile",
+            summary: "You have not participated in any Amsterdam Music Lab experiments yet.",
+            points: "points",
+        },
+        scores: []
+    }),
+    decorators: [getDecorator],
+};
+
+export const SingleScore = {
+    args: getProfileData({
+        messages: {
+            title: "Profile",
+            summary: "You have participated in 1 Amsterdam Music Lab experiment. Your best score is:",
+            points: "points",
+        },
+        scores: [
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "gold",
+                    text: "1nd",
+                },
+                score: '150',
+                date: "Eergisteren",
+                block_slug: "block-slug",
+            },
+        ],
+    }),
+    decorators: [getDecorator],
+};
+
+export const TwoScores = {
+    args: getProfileData({
+        scores: [
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "gold",
+                    text: "1nd",
+                },
+                score: '150',
+                date: "Eergisteren",
+                block_slug: "block-slug",
+            },
+            {
+                finished_at: "2021-09-20T12:00:00Z",
+                rank: {
+                    class: "silver",
+                    text: "2nd",
+                },
+                score: '100',
+                date: "Gisteren",
+                block_slug: "block-slug",
+            },
+        ],
+    }),
+    decorators: [getDecorator],
+}


### PR DESCRIPTION
I noticed the code of the `Profile` page component and the `ProfileView` could be improved upon. I've also expanded on its story, adding more possible scenarios. When I was working on that, I also noticed the styling was a bit off. I subsequently found out some things that could also be improved in `Rank` / `Cup`, which I did. See the screenshots below for comparison.

Additionally, I updated the routes a bit, removing the `exact` prop, which [doesn't exist anymore](https://stackoverflow.com/a/69866593/4496102) in `react-router` v6, and by removing the non-existent route for "session".


# Screenshots

## Profile view

### Before

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/a7d8b7bb-fcea-4daf-8a8e-75dbdb58bdcf">

<img width="583" alt="image" src="https://github.com/user-attachments/assets/8f86a7a5-729a-48c5-96ab-e6d7eadb7fee">

### After

<img width="803" alt="image" src="https://github.com/user-attachments/assets/d7175741-f72c-4416-ad59-6c6115615ab5">

<img width="549" alt="image" src="https://github.com/user-attachments/assets/fd319bca-cfac-4e23-8598-f37eb4ed3299">


