### PR TITLE
Fix(Migration): Prevent duplicate QuestionInSeries entries during migration

### DIFF
--- a/backend/question/migrations/0005_recreate_default_questions.py
+++ b/backend/question/migrations/0005_recreate_default_questions.py
@@ -4,37 +4,34 @@ from question.models import QuestionInSeries, Question
 
 
 def recreate_default_questions(apps, schema_editor):
-
     # Save info of all QuestionInSeries objects, because they will be deleted when recreating questions
     qis_all = QuestionInSeries.objects.all()
     qis_all_list = []
     for qis in qis_all:
-        qis_all_list.append({'question_series':qis.question_series, "question_key":qis.question.key, "index":qis.index})
+        qis_all_list.append(
+            {"question_series": qis.question_series, "question_key": qis.question.key, "index": qis.index}
+        )
 
     create_default_questions(overwrite=True)
 
     # Recreate QuestionInSeries objects with new question objects
     for qis in qis_all_list:
-        QuestionInSeries.objects.create(
-            question_series=qis["question_series"],
-            question=Question.objects.get(key=qis["question_key"]),
-            index=qis["index"]
-        )
+        # Check if the combination already exists before creating
+        if not QuestionInSeries.objects.filter(
+            question_series=qis["question_series"], question=Question.objects.get(key=qis["question_key"])
+        ).exists():
+            QuestionInSeries.objects.create(
+                question_series=qis["question_series"],
+                question=Question.objects.get(key=qis["question_key"]),
+                index=qis["index"],
+            )
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('question', '0004_add_custom_question_fields_and_modeltranslation'),
+        ("question", "0004_add_custom_question_fields_and_modeltranslation"),
     ]
 
     operations = [
         migrations.RunPython(recreate_default_questions, reverse_code=migrations.RunPython.noop),
     ]
-
-
-
-
-
-
-    


### PR DESCRIPTION
Ensure that the migration process checks for existing QuestionInSeries entries before creating new ones, preventing duplicates. This prevents errors during this migration step for custom question (series) that are not deleted by the `create_default_questions` function.

## On hold

On hold per 2024-11-05 as Albertas wanted to fix some other stuff on this migration/branch.