### PR TITLE
Fix: adjust trial title logic for rhythm discrimination rounds

### DIFF
--- a/backend/experiment/rules/rhythm_discrimination.py
+++ b/backend/experiment/rules/rhythm_discrimination.py
@@ -202,11 +202,11 @@ def next_trial_actions(session, round_number):
     )
     form = Form([question])
     playback = Autoplay([section])
-    if round_number < 5:
+    if round_number < 4:
         title = _('practice')
     else:
         title = _('trial %(index)d of %(total)d') % (
-            {'index': round_number - 4, 'total': len(plan) - 4})
+            {'index': round_number - 3, 'total': len(plan) - 4})
     view = Trial(
         playback=playback,
         feedback_form=form,

--- a/backend/experiment/rules/tests/test_rhythm_discrimination.py
+++ b/backend/experiment/rules/tests/test_rhythm_discrimination.py
@@ -9,19 +9,15 @@ from session.models import Session
 
 
 class RhythmDiscriminationTest(TestCase):
-    fixtures = ['playlist', 'experiment']
+    fixtures = ["playlist", "experiment"]
 
     @classmethod
     def setUpTestData(cls):
         cls.participant = Participant.objects.create()
-        cls.playlist = Playlist.objects.get(name='RhythmDiscrimination')
+        cls.playlist = Playlist.objects.get(name="RhythmDiscrimination")
         cls.playlist._update_sections()
         cls.block = Block.objects.get(slug="rhdis")
-        cls.session = Session.objects.create(
-            block=cls.block,
-            participant=cls.participant,
-            playlist=cls.playlist
-        )
+        cls.session = Session.objects.create(block=cls.block, participant=cls.participant, playlist=cls.playlist)
 
     def test_next_trial_actions(self):
         plan_stimuli(self.session)
@@ -29,3 +25,142 @@ class RhythmDiscriminationTest(TestCase):
         self.session.save()
         trial = next_trial_actions(self.session, 6)
         assert trial
+
+    def test_block_flow(self):
+        participant_response = self.client.get("/participant/")
+        participant = self.load_json_or_fail(participant_response)
+        self.assertTrue("id" in participant)
+        self.assertTrue(participant["id"])
+        csrf_token = participant["csrf_token"]
+
+        session = self.client.session
+        session.update({"participant_id": participant["id"]})
+        session.save()
+
+        block_response = self.client.get("/experiment/block/rhdis/")
+
+        block_json = self.load_json_or_fail(block_response)
+        self.assertTrue(
+            {
+                "slug",
+                "class_name",
+                "rounds",
+                "playlists",
+                "loading_text",
+                "session_id",
+            }
+            <= block_json.keys()
+        )
+
+        session_id = block_json["session_id"]
+
+        # go to the next round (1st round | practice)
+        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
+        next_round = self.load_json_or_fail(next_round_response).get("next_round")
+
+        # first two actions should be 'EXPLAINER', then one 'TRIAL_VIEW'
+        self.assertEqual(next_round[0]["view"], "EXPLAINER")
+        self.assertEqual(next_round[1]["view"], "EXPLAINER")
+        self.assertEqual(next_round[2]["view"], "TRIAL_VIEW")
+
+        feedback_form_result_id = next_round[2]["feedback_form"]["form"][0]["result_id"]
+        expected_response = next_round[2]["feedback_form"]["form"][0]["expected_response"]
+
+        # post score
+        score_response = self.client.post(
+            "/result/score/",
+            {
+                "session_id": session_id,
+                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
+                % (expected_response, feedback_form_result_id),
+                "csrfmiddlewaretoken": csrf_token,
+            },
+        )
+        self.load_json_or_fail(score_response)
+
+        # go to the next round (2nd round | practice)
+        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
+        next_round = self.load_json_or_fail(next_round_response).get("next_round")
+
+        # check that 1st action is 'EXPLAINER' and 2nd is 'TRIAL_VIEW'
+        self.assertEqual(next_round[0]["view"], "EXPLAINER")
+        self.assertEqual(next_round[1]["view"], "TRIAL_VIEW")
+
+        # post score
+        feedback_form_result_id = next_round[1]["feedback_form"]["form"][0]["result_id"]
+        expected_response = next_round[1]["feedback_form"]["form"][0]["expected_response"]
+        score_response = self.client.post(
+            "/result/score/",
+            {
+                "session_id": session_id,
+                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
+                % (expected_response, feedback_form_result_id),
+                "csrfmiddlewaretoken": csrf_token,
+            },
+        )
+
+        self.load_json_or_fail(score_response)
+
+        # go to the next round (3rd round | practice)
+        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
+        next_round = self.load_json_or_fail(next_round_response).get("next_round")
+
+        # check that 1st action is 'EXPLAINER' and 2nd is 'TRIAL_VIEW'
+        self.assertEqual(next_round[0]["view"], "EXPLAINER")
+        self.assertEqual(next_round[1]["view"], "TRIAL_VIEW")
+
+        # post score
+        feedback_form_result_id = next_round[1]["feedback_form"]["form"][0]["result_id"]
+        expected_response = next_round[1]["feedback_form"]["form"][0]["expected_response"]
+        score_response = self.client.post(
+            "/result/score/",
+            {
+                "session_id": session_id,
+                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
+                % (expected_response, feedback_form_result_id),
+                "csrfmiddlewaretoken": csrf_token,
+            },
+        )
+
+        self.load_json_or_fail(score_response)
+
+        # go to the next round (4th round | practice)
+        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
+        next_round = self.load_json_or_fail(next_round_response).get("next_round")
+
+        # check that 1st action is 'EXPLAINER' and 2nd is 'TRIAL_VIEW'
+        self.assertEqual(next_round[0]["view"], "EXPLAINER")
+        self.assertEqual(next_round[1]["view"], "TRIAL_VIEW")
+
+        # post score
+        feedback_form_result_id = next_round[1]["feedback_form"]["form"][0]["result_id"]
+        expected_response = next_round[1]["feedback_form"]["form"][0]["expected_response"]
+        score_response = self.client.post(
+            "/result/score/",
+            {
+                "session_id": session_id,
+                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
+                % (expected_response, feedback_form_result_id),
+                "csrfmiddlewaretoken": csrf_token,
+            },
+        )
+
+        self.load_json_or_fail(score_response)
+
+        # go to the next round (5th round | real)
+        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
+        next_round = self.load_json_or_fail(next_round_response).get("next_round")
+
+        # check that 1st & 2nd action is 'EXPLAINER' and 3nd is 'TRIAL_VIEW'
+        self.assertEqual(next_round[0]["view"], "EXPLAINER")
+        self.assertEqual(next_round[1]["view"], "EXPLAINER")
+        self.assertEqual(next_round[2]["view"], "TRIAL_VIEW")
+
+        # check that the title of the TRIAL_VIEW does not contain 'practice' or 'oefenen'
+        self.assertNotIn("practice", next_round[2]["title"].lower())
+        self.assertNotIn("oefenen", next_round[2]["title"].lower())
+
+    def load_json_or_fail(self, response):
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/json")
+        return response.json()

--- a/backend/experiment/rules/tests/test_rhythm_discrimination.py
+++ b/backend/experiment/rules/tests/test_rhythm_discrimination.py
@@ -27,19 +27,110 @@ class RhythmDiscriminationTest(TestCase):
         assert trial
 
     def test_block_flow(self):
+        # Initial setup
+        participant = self._setup_participant()
+        block_json = self._get_block_info("rhdis")
+        session_id = block_json["session_id"]
+
+        # Test practice rounds (first 4 rounds)
+        self._validate_practice_round(session_id, 1, participant, actions=["EXPLAINER", "EXPLAINER", "TRIAL_VIEW"])
+        self._validate_practice_round(session_id, 2, participant)
+        self._validate_practice_round(session_id, 3, participant)
+        self._validate_practice_round(session_id, 4, participant)
+
+        # Test real rounds (should be 36 rounds)
+        for i in range(0, 36):
+            real_round_number = i + 5  # Real rounds start from 5th round
+
+            # The first real round has ["EXPLAINER", "EXPLAINER", "TRIAL_VIEW"] views
+            if i == 0:
+                self._validate_real_round(
+                    session_id, real_round_number, participant, actions=["EXPLAINER", "EXPLAINER", "TRIAL_VIEW"]
+                )
+                continue
+
+            self._validate_real_round(session_id, real_round_number, participant)
+
+        # Debriefing (one single 'FINAL' view)
+        next_round = self._get_next_round(session_id)
+        self.assertEqual(len(next_round), 1)
+        self.assertEqual(next_round[0]["view"], "FINAL")
+
+    def _setup_participant(self):
+        """Setup participant and session data"""
         participant_response = self.client.get("/participant/")
         participant = self.load_json_or_fail(participant_response)
+
         self.assertTrue("id" in participant)
         self.assertTrue(participant["id"])
-        csrf_token = participant["csrf_token"]
 
         session = self.client.session
         session.update({"participant_id": participant["id"]})
         session.save()
 
-        block_response = self.client.get("/experiment/block/rhdis/")
+        return participant
 
+    def _validate_practice_round(self, session_id, round_number, participant, actions=["EXPLAINER", "TRIAL_VIEW"]):
+        next_round = self._get_next_round(session_id)
+
+        # Check practice round structure
+        for i, action in enumerate(actions):
+            self.assertEqual(next_round[i]["view"], action, f"Round {round_number} action {i} is not {action}")
+
+        # Trial view index
+        trial_view_index = actions.index("TRIAL_VIEW")
+        trial_view = next_round[trial_view_index]
+
+        # Check title requirements for practice round - should contain "practice" or "oefenen"
+        trial_title = trial_view["title"].lower()
+        self.assertTrue(
+            "practice" in trial_title or "oefenen" in trial_title, f"Round {round_number} title is not practice"
+        )
+
+        # Submit score for practice round
+        self._submit_score(
+            session_id=session_id,
+            result_id=trial_view["feedback_form"]["form"][0]["result_id"],
+            expected_response=trial_view["feedback_form"]["form"][0]["expected_response"],
+            csrf_token=participant["csrf_token"],
+        )
+
+        return next_round
+
+    def _validate_real_round(self, session_id, round_number, participant, actions=["TRIAL_VIEW"]):
+        next_round = self._get_next_round(session_id)
+
+        # Check real round structure
+        for i, action in enumerate(actions):
+            self.assertEqual(next_round[i]["view"], action, f"Round {round_number} action {i} is not {action}")
+
+        # Check title requirements for real round
+        trial_view_index = actions.index("TRIAL_VIEW")
+        trial_view = next_round[trial_view_index]
+        trial_title = trial_view["title"].lower()
+        title_round_number = round_number - 4  # Real rounds start from 5th round
+        self.assertNotIn("practice", trial_title, f"Round {round_number} title contains practice")
+        self.assertNotIn("oefenen", trial_title, f"Round {round_number} title contains oefenen")
+        self.assertTrue(
+            f"{title_round_number} van " in trial_title or f"{title_round_number} of " in trial_title,
+            f"Round {round_number} title is not {title_round_number} van",
+        )
+
+        # Submit score for real round
+        self._submit_score(
+            session_id=session_id,
+            result_id=trial_view["feedback_form"]["form"][0]["result_id"],
+            expected_response=trial_view["feedback_form"]["form"][0]["expected_response"],
+            csrf_token=participant["csrf_token"],
+        )
+
+        return next_round
+
+    def _get_block_info(self, block_slug):
+        """Get block information"""
+        block_response = self.client.get(f"/experiment/block/{block_slug}/")
         block_json = self.load_json_or_fail(block_response)
+
         self.assertTrue(
             {
                 "slug",
@@ -52,115 +143,28 @@ class RhythmDiscriminationTest(TestCase):
             <= block_json.keys()
         )
 
-        session_id = block_json["session_id"]
+        return block_json
 
-        # go to the next round (1st round | practice)
+    def _get_next_round(self, session_id):
+        """Get next round data"""
         next_round_response = self.client.post(f"/session/{session_id}/next_round/")
-        next_round = self.load_json_or_fail(next_round_response).get("next_round")
+        return self.load_json_or_fail(next_round_response).get("next_round")
 
-        # first two actions should be 'EXPLAINER', then one 'TRIAL_VIEW'
-        self.assertEqual(next_round[0]["view"], "EXPLAINER")
-        self.assertEqual(next_round[1]["view"], "EXPLAINER")
-        self.assertEqual(next_round[2]["view"], "TRIAL_VIEW")
-
-        feedback_form_result_id = next_round[2]["feedback_form"]["form"][0]["result_id"]
-        expected_response = next_round[2]["feedback_form"]["form"][0]["expected_response"]
-
-        # post score
+    def _submit_score(self, session_id, result_id, expected_response, csrf_token):
+        """Submit score for a round"""
         score_response = self.client.post(
             "/result/score/",
             {
                 "session_id": session_id,
                 "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
-                % (expected_response, feedback_form_result_id),
+                % (expected_response, result_id),
                 "csrfmiddlewaretoken": csrf_token,
             },
         )
         self.load_json_or_fail(score_response)
-
-        # go to the next round (2nd round | practice)
-        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
-        next_round = self.load_json_or_fail(next_round_response).get("next_round")
-
-        # check that 1st action is 'EXPLAINER' and 2nd is 'TRIAL_VIEW'
-        self.assertEqual(next_round[0]["view"], "EXPLAINER")
-        self.assertEqual(next_round[1]["view"], "TRIAL_VIEW")
-
-        # post score
-        feedback_form_result_id = next_round[1]["feedback_form"]["form"][0]["result_id"]
-        expected_response = next_round[1]["feedback_form"]["form"][0]["expected_response"]
-        score_response = self.client.post(
-            "/result/score/",
-            {
-                "session_id": session_id,
-                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
-                % (expected_response, feedback_form_result_id),
-                "csrfmiddlewaretoken": csrf_token,
-            },
-        )
-
-        self.load_json_or_fail(score_response)
-
-        # go to the next round (3rd round | practice)
-        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
-        next_round = self.load_json_or_fail(next_round_response).get("next_round")
-
-        # check that 1st action is 'EXPLAINER' and 2nd is 'TRIAL_VIEW'
-        self.assertEqual(next_round[0]["view"], "EXPLAINER")
-        self.assertEqual(next_round[1]["view"], "TRIAL_VIEW")
-
-        # post score
-        feedback_form_result_id = next_round[1]["feedback_form"]["form"][0]["result_id"]
-        expected_response = next_round[1]["feedback_form"]["form"][0]["expected_response"]
-        score_response = self.client.post(
-            "/result/score/",
-            {
-                "session_id": session_id,
-                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
-                % (expected_response, feedback_form_result_id),
-                "csrfmiddlewaretoken": csrf_token,
-            },
-        )
-
-        self.load_json_or_fail(score_response)
-
-        # go to the next round (4th round | practice)
-        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
-        next_round = self.load_json_or_fail(next_round_response).get("next_round")
-
-        # check that 1st action is 'EXPLAINER' and 2nd is 'TRIAL_VIEW'
-        self.assertEqual(next_round[0]["view"], "EXPLAINER")
-        self.assertEqual(next_round[1]["view"], "TRIAL_VIEW")
-
-        # post score
-        feedback_form_result_id = next_round[1]["feedback_form"]["form"][0]["result_id"]
-        expected_response = next_round[1]["feedback_form"]["form"][0]["expected_response"]
-        score_response = self.client.post(
-            "/result/score/",
-            {
-                "session_id": session_id,
-                "json_data": '{"decision_time":2,"form":[{"key":"same","value":"%s","result_id":%s}]}'
-                % (expected_response, feedback_form_result_id),
-                "csrfmiddlewaretoken": csrf_token,
-            },
-        )
-
-        self.load_json_or_fail(score_response)
-
-        # go to the next round (5th round | real)
-        next_round_response = self.client.post(f"/session/{session_id}/next_round/")
-        next_round = self.load_json_or_fail(next_round_response).get("next_round")
-
-        # check that 1st & 2nd action is 'EXPLAINER' and 3nd is 'TRIAL_VIEW'
-        self.assertEqual(next_round[0]["view"], "EXPLAINER")
-        self.assertEqual(next_round[1]["view"], "EXPLAINER")
-        self.assertEqual(next_round[2]["view"], "TRIAL_VIEW")
-
-        # check that the title of the TRIAL_VIEW does not contain 'practice' or 'oefenen'
-        self.assertNotIn("practice", next_round[2]["title"].lower())
-        self.assertNotIn("oefenen", next_round[2]["title"].lower())
 
     def load_json_or_fail(self, response):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["content-type"], "application/json")
+
         return response.json()


### PR DESCRIPTION
Additional to fixing the title issues, I've added tests that validates the titles of the rounds, along with the rest of the block flow.

Related to #1325