### PR TITLE
Add timestamp for start of turn

### DIFF
--- a/frontend/src/components/MatchingPairs/MatchingPairs.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.tsx
@@ -62,6 +62,8 @@ const MatchingPairs = ({
         yPosition.current = posY;
     }
 
+    let startOfTurn = performance.now();
+
     // Show (animated) feedback after second click on second card or finished playing
     const showFeedback = (score: number) => {
 
@@ -142,6 +144,7 @@ const MatchingPairs = ({
                 currentCard.noevents = true;
                 currentCard.boardposition = index + 1;
                 currentCard.timestamp = performance.now();
+                currentCard.start_of_turn = startOfTurn;
                 // reset response interval in case this card has a value from a previous turn
                 currentCard.response_interval_ms = '';
                 // clear feedback text
@@ -152,6 +155,7 @@ const MatchingPairs = ({
     };
 
     const finishTurn = () => {
+        startOfTurn = performance.now();
         finishedPlaying();
         // remove matched cards from the board
         if (score === 10 || score === 20) {

--- a/frontend/src/components/MatchingPairs/MatchingPairs.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.tsx
@@ -50,6 +50,7 @@ const MatchingPairs = ({
     const [inBetweenTurns, setInBetweenTurns] = useState(false);
     const [score, setScore] = useState<number | null>(null);
     const [total, setTotal] = useState(bonusPoints);
+    const [startOfTurn, setStartOfTurn] = useState(performance.now());
 
     const columnCount = sections.length > 6 ? 4 : 3;
 
@@ -61,8 +62,6 @@ const MatchingPairs = ({
         xPosition.current = posX;
         yPosition.current = posY;
     }
-
-    let startOfTurn = performance.now();
 
     // Show (animated) feedback after second click on second card or finished playing
     const showFeedback = (score: number) => {
@@ -126,7 +125,7 @@ const MatchingPairs = ({
                 const first_card = firstCard;
                 const second_card = currentCard;
                 try {
-                    const scoreResponse = await scoreIntermediateResult({ session, participant, result: { first_card, second_card } });
+                    const scoreResponse = await scoreIntermediateResult({ session, participant, result: { "start_timestamp": StartOfTurn, first_card, second_card } });
                     if (!scoreResponse) {
                         throw new Error('We cannot currently proceed with the game. Try again later');
                     }
@@ -143,7 +142,7 @@ const MatchingPairs = ({
                 currentCard.turned = true;
                 currentCard.noevents = true;
                 currentCard.boardposition = index + 1;
-                currentCard.timestamp = performance.now();
+                setStartOfTurn(performance.now());
                 currentCard.start_of_turn = startOfTurn;
                 // reset response interval in case this card has a value from a previous turn
                 currentCard.response_interval_ms = '';

--- a/frontend/src/components/MatchingPairs/MatchingPairs.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.tsx
@@ -125,7 +125,7 @@ const MatchingPairs = ({
                 const first_card = firstCard;
                 const second_card = currentCard;
                 try {
-                    const scoreResponse = await scoreIntermediateResult({ session, participant, result: { "start_timestamp": StartOfTurn, first_card, second_card } });
+                    const scoreResponse = await scoreIntermediateResult({ session, participant, result: { "start_timestamp": startOfTurn, first_card, second_card } });
                     if (!scoreResponse) {
                         throw new Error('We cannot currently proceed with the game. Try again later');
                     }
@@ -154,7 +154,7 @@ const MatchingPairs = ({
     };
 
     const finishTurn = () => {
-        startOfTurn = performance.now();
+        setStartOfTurn(performance.now());
         finishedPlaying();
         // remove matched cards from the board
         if (score === 10 || score === 20) {

--- a/frontend/src/components/MatchingPairs/MatchingPairs.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.tsx
@@ -118,14 +118,11 @@ const MatchingPairs = ({
                 currentCard.boardposition = index + 1;
                 currentCard.timestamp = performance.now();
 
-                const firstCardTimestamp = firstCard?.timestamp ?? 0;
-                currentCard.response_interval_ms = Math.round(currentCard.timestamp - firstCardTimestamp);
-
                 // check for match
                 const first_card = firstCard;
                 const second_card = currentCard;
                 try {
-                    const scoreResponse = await scoreIntermediateResult({ session, participant, result: { "start_timestamp": startOfTurn, first_card, second_card } });
+                    const scoreResponse = await scoreIntermediateResult({ session, participant, result: { "start_of_turn": startOfTurn, first_card, second_card } });
                     if (!scoreResponse) {
                         throw new Error('We cannot currently proceed with the game. Try again later');
                     }
@@ -142,10 +139,7 @@ const MatchingPairs = ({
                 currentCard.turned = true;
                 currentCard.noevents = true;
                 currentCard.boardposition = index + 1;
-                setStartOfTurn(performance.now());
                 currentCard.start_of_turn = startOfTurn;
-                // reset response interval in case this card has a value from a previous turn
-                currentCard.response_interval_ms = '';
                 // clear feedback text
                 setFeedbackText('');
             }

--- a/frontend/src/components/MatchingPairs/MatchingPairs.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.tsx
@@ -139,6 +139,7 @@ const MatchingPairs = ({
                 currentCard.turned = true;
                 currentCard.noevents = true;
                 currentCard.boardposition = index + 1;
+                currentCard.timestamp = performance.now();
                 // clear feedback text
                 setFeedbackText('');
             }

--- a/frontend/src/components/MatchingPairs/MatchingPairs.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.tsx
@@ -139,7 +139,6 @@ const MatchingPairs = ({
                 currentCard.turned = true;
                 currentCard.noevents = true;
                 currentCard.boardposition = index + 1;
-                currentCard.start_of_turn = startOfTurn;
                 // clear feedback text
                 setFeedbackText('');
             }


### PR DESCRIPTION
This PR sets a timestamp `start_of_turn` in the result of the first card.
First when the board has been loaded, then on every third click of a turn. 

Closes: #1298  