### PR TITLE
Fixed: Add phase model and associate with blocks in experiment fixtures

### DIFF
--- a/backend/experiment/fixtures/experiment.json
+++ b/backend/experiment/fixtures/experiment.json
@@ -7,6 +7,14 @@
         }
     },
     {
+        "model": "experiment.Phase",
+        "pk": 1,
+        "fields": {
+            "experiment": 1,
+            "index": 0
+        }
+    },
+    {
         "model": "experiment.Block",
         "pk": 1,
         "fields": {
@@ -101,6 +109,7 @@
         "model": "experiment.Block",
         "pk": 8,
         "fields": {
+            "phase": 1,
             "slug": "rhdis",
             "rounds": 40,
             "bonus_points": 0,


### PR DESCRIPTION
Introduce a phase model and link it to existing blocks in the experiment.json fixtures.

Fixes #1357