### PR TITLE
Fixed: Add `random` and `interval` props to `Histogram` component

### DIFF
--- a/frontend/src/components/Histogram/Histogram.test.tsx
+++ b/frontend/src/components/Histogram/Histogram.test.tsx
@@ -154,4 +154,51 @@ describe('Histogram', () => {
         expect(initialHeights).to.deep.equal(updatedHeights);
         expect(mockAnalyser.getByteFrequencyData).not.toHaveBeenCalled();
     });
+
+    it('updates bar heights based on random data when random is true and running is true', async () => {
+        const bars = 5;
+
+        // Ensure the analyser does not provide data
+        mockAnalyser.getByteFrequencyData.mockImplementation(() => { });
+
+        const { container, rerender } = render(
+            <Histogram running={true} bars={bars} random={true} />
+        );
+
+        const getHeights = () =>
+            Array.from(container.querySelectorAll('.aha__histogram > div')).map(
+                (bar) => bar.style.height
+            );
+
+        const initialHeights = getHeights();
+
+        // Advance timers and trigger animation frame
+        await act(async () => {
+            vi.advanceTimersByTime(100);
+        });
+
+        rerender(<Histogram running={true} bars={bars} random={true} />);
+
+        const updatedHeights = getHeights();
+
+        expect(initialHeights).not.to.deep.equal(updatedHeights);
+        expect(mockAnalyser.getByteFrequencyData).not.toHaveBeenCalled();
+    });
+
+    it('does not call getByteFrequencyData when random is true', async () => {
+        const bars = 5;
+
+        const { rerender } = render(
+            <Histogram running={true} bars={bars} random={true} />
+        );
+
+        // Advance timers and trigger animation frame
+        await act(async () => {
+            vi.advanceTimersByTime(100);
+        });
+
+        rerender(<Histogram running={true} bars={bars} random={true} />);
+
+        expect(mockAnalyser.getByteFrequencyData).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -9,6 +9,7 @@ interface HistogramProps {
     marginTop?: number;
     backgroundColor?: string;
     borderRadius?: string;
+    random?: boolean; // Added the 'random' prop
 }
 
 const Histogram: React.FC<HistogramProps> = ({
@@ -19,6 +20,7 @@ const Histogram: React.FC<HistogramProps> = ({
     marginTop = 0,
     backgroundColor = undefined,
     borderRadius = '0.15rem',
+    random = false, // Default value set to false
 }) => {
     const [frequencyData, setFrequencyData] = useState<Uint8Array>(new Uint8Array(bars));
 
@@ -35,13 +37,24 @@ const Histogram: React.FC<HistogramProps> = ({
         }
 
         const updateFrequencyData = () => {
-            if (window.audioContext && window.analyzer) {
+            let dataWithoutExtremes: Uint8Array;
+
+            if (random) {
+                // Generate random frequency data
+                dataWithoutExtremes = new Uint8Array(bars);
+                for (let i = 0; i < bars; i++) {
+                    dataWithoutExtremes[i] = Math.floor(Math.random() * 256);
+                }
+            } else if (window.audioContext && window.analyzer) {
                 const data = new Uint8Array(bars + 3);
                 window.analyzer.getByteFrequencyData(data);
                 // Remove the lower end of the frequency data
-                const dataWithoutExtremes = data.slice(3, bars + 3);
-                setFrequencyData(dataWithoutExtremes);
+                dataWithoutExtremes = data.slice(3, bars + 3);
+            } else {
+                dataWithoutExtremes = new Uint8Array(bars);
             }
+
+            setFrequencyData(dataWithoutExtremes);
             requestRef.current = requestAnimationFrame(updateFrequencyData);
         };
 
@@ -52,7 +65,7 @@ const Histogram: React.FC<HistogramProps> = ({
                 cancelAnimationFrame(requestRef.current);
             }
         };
-    }, [running, bars]);
+    }, [running, bars, random]); // Added 'random' to dependency array
 
     const barWidth = `calc((100% - ${(bars - 1) * spacing}px) / ${bars})`;
 

--- a/frontend/src/components/MatchingPairs/PlayCard.tsx
+++ b/frontend/src/components/MatchingPairs/PlayCard.tsx
@@ -56,6 +56,7 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view, showAni
                         bars={histogramBars}
                         backgroundColor="purple"
                         borderRadius=".5rem"
+                        random={true}
                     />
                 :
                 <div

--- a/frontend/src/components/MatchingPairs/PlayCard.tsx
+++ b/frontend/src/components/MatchingPairs/PlayCard.tsx
@@ -57,7 +57,7 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view, showAni
                         backgroundColor="purple"
                         borderRadius=".5rem"
                         random={true}
-                        interval={100}
+                        interval={200}
                     />
                 :
                 <div

--- a/frontend/src/components/MatchingPairs/PlayCard.tsx
+++ b/frontend/src/components/MatchingPairs/PlayCard.tsx
@@ -57,6 +57,7 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section, view, showAni
                         backgroundColor="purple"
                         borderRadius=".5rem"
                         random={true}
+                        interval={100}
                     />
                 :
                 <div

--- a/frontend/src/stories/Histogram.stories.jsx
+++ b/frontend/src/stories/Histogram.stories.jsx
@@ -35,3 +35,33 @@ export const Default = {
         ),
     ],
 };
+
+export const Random = {
+    args: {
+        bars: 7,
+        spacing: 6,
+        interval: 100,
+        running: true,
+        marginLeft: 0,
+        marginTop: 0,
+        backgroundColor: undefined,
+        borderRadius: "0.15rem",
+        random: true,
+        interval: 150,
+    },
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    width: "128px",
+                    height: "128px",
+                    margin: "1rem auto",
+                    backgroundColor: "purple",
+                    padding: "1rem",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/frontend/src/stories/Histogram.stories.tsx
+++ b/frontend/src/stories/Histogram.stories.tsx
@@ -1,11 +1,13 @@
+import type { Meta } from '@storybook/react';
 import Histogram from "../components/Histogram/Histogram";
 
-export default {
+const meta: Meta<typeof Histogram> = {
     title: "Histogram",
     component: Histogram,
     parameters: {
         layout: "fullscreen",
     },
+    tags: ["autodocs"],
 };
 
 export const Default = {
@@ -65,3 +67,5 @@ export const Random = {
         ),
     ],
 };
+
+export default meta;


### PR DESCRIPTION
Re-added the random histogram bar changes as not to "help" the participant in the matching pairs experiment.

This PR adds the `random` prop (`false` by default) that makes the `Histogram` show random bar changes again. Additionally, the `interval` prop has been re-instated, which is used as the interval for random bar changes.

The `PlayCard` component then uses the `random` feature of the `Histogram` as it is used by the Matching Pairs game.

Fixes #1362