### PR TITLE
Fixed: Refactor Django template to avoid method calls and set placeholders consistently

### DIFF
--- a/backend/experiment/templates/edit-sections.html
+++ b/backend/experiment/templates/edit-sections.html
@@ -57,11 +57,11 @@
             </td>
             <td>
                 <input type="text" name="{{section.id}}_artist" maxlength="128" id="{{section.id}}_artist"
-                    value="{{ section.artist_name('*')}}" >
+                    value="{{ section.artist_name}}" placeholder="*">
             </td>
             <td>
                 <input type="text" name="{{section.id}}_name" maxlength="128" id="{{section.id}}_name"
-                    value="{{ section.song_name('*')}}" >
+                    value="{{ section.song_name}}" placeholder="*">
             </td>
             <td>
                 <input type="number" name="{{section.id}}_start_time" maxlength="128" required=""


### PR DESCRIPTION
Consistently set placeholders to "*" and refrain from calling methods directly in the Django template. Django does not allow you to call methods in templates. Originally, the placeholder attribute was only set to "*" when there was no song / artist name. I think it's better to just always set it. It will appear only whenever there is no value anyway.

Resolves #1327 