### PR TITLE
add experiment about page as Router option

### DIFF
--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -86,7 +86,7 @@ const App = () => {
                         <Route path={URLS.experiment} element={<Experiment />} />
 
                         {/* ExperimentAbout */}
-                        <Route path={URLS.experiment} element={<ExperimentAbout />} />
+                        <Route path={URLS.experimentAbout} element={<ExperimentAbout />} />
 
                         {/* Store profile */}
                         <Route

--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -11,6 +11,7 @@ import { URLS as API_URLS } from "../../API";
 import useBoundStore from "../../util/stores";
 import Block from "../Block/Block";
 import Experiment from "../Experiment/Experiment";
+import ExperimentAbout from "../Experiment/ExperimentAbout/ExperimentAbout";
 import LoaderContainer from "../LoaderContainer/LoaderContainer";
 import ConditionalRender from "../ConditionalRender/ConditionalRender";
 import Profile from "../Profile/Profile";
@@ -83,6 +84,9 @@ const App = () => {
 
                         {/* Experiment */}
                         <Route path={URLS.experiment} element={<Experiment />} />
+
+                        {/* ExperimentAbout */}
+                        <Route path={URLS.experiment} element={<ExperimentAbout />} />
 
                         {/* Store profile */}
                         <Route


### PR DESCRIPTION
This would be an option towards #1337 : the about page can also function as a landing page.