### PR TITLE
Fix serialization error for returning participants

### DIFF
--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -104,8 +104,8 @@ def serialize_phase(phase: Phase, participant: Participant, times_played: int) -
     blocks = list(phase.blocks.order_by("index").all())
 
     next_block = get_upcoming_block(phase, participant, times_played)
-    if isinstance(next_block, int):
-        return next_block
+    if not next_block:
+        return None
 
     total_score = get_total_score(blocks, participant)
     if phase.randomize:
@@ -139,7 +139,7 @@ def serialize_block(block_object: Block, language: str = "en") -> dict:
 
 def get_upcoming_block(
     phase: Phase, participant: Participant, times_played: int
-) -> Union[dict, int]:
+) -> dict:
     """return next block with minimum finished sessions for this participant
     if all blocks have been played an equal number of times, return None
 
@@ -157,7 +157,7 @@ def get_upcoming_block(
     min_session_count = min(finished_session_counts)
     if not phase.dashboard:
         if times_played != min_session_count:
-            return min_session_count
+            return None
     next_block_index = finished_session_counts.index(min_session_count)
     return serialize_block(blocks[next_block_index])
 

--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -1,5 +1,5 @@
 from random import shuffle
-from typing import Optional
+from typing import Optional, Union
 
 from django_markup.markup import formatter
 from django.utils.translation import activate, get_language
@@ -104,8 +104,8 @@ def serialize_phase(phase: Phase, participant: Participant, times_played: int) -
     blocks = list(phase.blocks.order_by("index").all())
 
     next_block = get_upcoming_block(phase, participant, times_played)
-    if not next_block:
-        return None
+    if isinstance(next_block, int):
+        return next_block
 
     total_score = get_total_score(blocks, participant)
     if phase.randomize:
@@ -137,7 +137,9 @@ def serialize_block(block_object: Block, language: str = "en") -> dict:
     }
 
 
-def get_upcoming_block(phase: Phase, participant: Participant, times_played: int):
+def get_upcoming_block(
+    phase: Phase, participant: Participant, times_played: int
+) -> Union[dict, int]:
     """return next block with minimum finished sessions for this participant
     if all blocks have been played an equal number of times, return None
 
@@ -155,7 +157,7 @@ def get_upcoming_block(phase: Phase, participant: Participant, times_played: int
     min_session_count = min(finished_session_counts)
     if not phase.dashboard:
         if times_played != min_session_count:
-            return None
+            return min_session_count
     next_block_index = finished_session_counts.index(min_session_count)
     return serialize_block(blocks[next_block_index])
 

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -87,6 +87,32 @@ class TestExperimentViews(TestCase):
         self.assertIsNotNone(response_json)
         self.assertIn(response_json.get("nextBlock").get("slug"), ("block2", "block3"))
 
+    def test_get_experiment_returning_participant(self):
+        Session.objects.bulk_create(
+            self._get_session_objects(
+                [
+                    self.block1,
+                    self.block2,
+                    self.block3,
+                    self.block4,
+                    self.block1,
+                    self.block2,
+                    self.block3,
+                    self.block4,
+                ]
+            )
+        )
+        response = self.client.get("/experiment/test_series/")
+        self.assertEqual(response.json().get("nextBlock").get("slug"), "block1")
+
+    def _get_session_objects(self, block_list: list[Block]) -> list[Session]:
+        return [
+            Session(
+                block=block, participant=self.participant, finished_at=timezone.now()
+            )
+            for block in block_list
+        ]
+
     def test_experiment_not_found(self):
         # if Experiment does not exist, return 404
         response = self.client.get("/experiment/not_found/")

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -119,14 +119,18 @@ def get_experiment(
     times_played_key = 'f"{slug}-xplayed"'
     times_played = request.session.get(times_played_key, 0)
     for phase in phases:
-        serialized_phase = serialize_phase(phase, participant, times_played)
-        if serialized_phase:
+        serialized_phase_or_min_session_count = serialize_phase(
+            phase, participant, times_played
+        )
+        if isinstance(serialized_phase_or_min_session_count, dict):
             return JsonResponse(
-                {**serialize_experiment(experiment), **serialized_phase}
+                {
+                    **serialize_experiment(experiment),
+                    **serialized_phase_or_min_session_count,
+                }
             )
-    # if no phase was found, start from scratch by incrementing times_played
-    times_played += 1
-    request.session[times_played_key] = times_played
+    # if no phase was found, start from scratch with the minimum session count
+    request.session[times_played_key] = serialized_phase_or_min_session_count
     return get_experiment(request, slug)
 
 

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -124,11 +124,10 @@ def get_experiment(
             return JsonResponse(
                 {**serialize_experiment(experiment), **serialized_phase}
             )
-    # if no phase was found, start from scratch by incrementing times_pleyd
+    # if no phase was found, start from scratch by incrementing times_played
     times_played += 1
     request.session[times_played_key] = times_played
-    serialized_phase = serialize_phase(phases[0], participant, times_played)
-    return JsonResponse({**serialize_experiment(experiment), **serialized_phase})
+    return get_experiment(request, slug)
 
 
 def get_associated_blocks(pk_list):


### PR DESCRIPTION
Close #1371: the bug was caused by an old session cookie, in which the active participant already had finished sessions. Going in from this branch will assume the participant hasn't played the experiments yet, and set `times_played` to 0. This means that after the `for` loop, `serialize_phase` would still return `None`. A bit of an edge case, but it's not unrealistic to assume that it would affect participants of active experiments after release.

This branch checks the minimum session count and then sets `times_played` accordingly. It also reintroduces the previous implementation with recursion: this means that the participant can resume a later phase, instead of just the first one.