### PR TITLE
Refactor: refactor toggle button indicators for collapsible forms

### DIFF
--- a/backend/experiment/static/experiment_form.js
+++ b/backend/experiment/static/experiment_form.js
@@ -18,8 +18,10 @@ function initCollapsibleInlineForms() {
             // create text element in button to show that the form is collapsed
             collapsedInfo = document.createElement('small');
             collapsedInfo.id = 'collapsed-info';
-            collapsedInfo.innerText = ' (-)';
+
+            collapsedInfo.innerText = ' \u25b2';
             collapsedInfo.style.color = '#fff';
+            collapsedInfo.style.fontSize = '.75rem';
             toggleButton.appendChild(collapsedInfo);
         }
 
@@ -31,10 +33,10 @@ function initCollapsibleInlineForms() {
 
             if (currentlyHidden) {
                 // create text element in button to show that the form is collapsed
-                collapsedInfo.innerText = ' (+)';
+                collapsedInfo.innerText = ' \u25bc';
             } else {
                 // remove the text element in button to show that the form is expanded
-                collapsedInfo.innerText = ' (-)';
+                collapsedInfo.innerText = ' \u25b2';
             }
         });
     });


### PR DESCRIPTION
Update the indicators for the toggle buttons in collapsible forms to use arrow symbols for better visual clarity.

<img width="465" alt="image" src="https://github.com/user-attachments/assets/4b14137d-7281-4848-a600-4b6f223f32ad">

Related to #1382