### PR TITLE
Added: Add collapsible functionality to block forms with expand/collapse all buttons

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -148,7 +148,6 @@ class BlockAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
                 data=str(serializers.serialize("json", all_feedback.order_by("pk"))),
             )
 
-
         # create forced download response
         response = HttpResponse(zip_buffer.getbuffer())
         response["Content-Type"] = "application/x-zip-compressed"
@@ -287,7 +286,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
         content = obj.get_fallback_content()
 
         return content.name if content else "No name"
-    
+
     def redirect_to_overview(self):
         return redirect(reverse("admin:experiment_experiment_changelist"))
 
@@ -313,25 +312,33 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
 
             # Validate slug
             if not extension.isalnum():
-                messages.add_message(request,
-                                     messages.ERROR,
-                                     f"{extension} is nog a valid slug extension. Only alphanumeric characters are allowed.")
+                messages.add_message(
+                    request,
+                    messages.ERROR,
+                    f"{extension} is nog a valid slug extension. Only alphanumeric characters are allowed.",
+                )
             if extension.lower() != extension:
-                messages.add_message(request,
-                                     messages.ERROR,
-                                     f"{extension} is nog a valid slug extension. Only lowercase characters are allowed.")
+                messages.add_message(
+                    request,
+                    messages.ERROR,
+                    f"{extension} is nog a valid slug extension. Only lowercase characters are allowed.",
+                )
             # Check for duplicate slugs
             for exp in Experiment.objects.all():
                 if exp.slug == f"{obj.slug}{slug_extension}":
-                    messages.add_message(request,
-                                     messages.ERROR,
-                                     f"An experiment with slug: {obj.slug}{slug_extension} already exists. Please choose a different slug extension.")
+                    messages.add_message(
+                        request,
+                        messages.ERROR,
+                        f"An experiment with slug: {obj.slug}{slug_extension} already exists. Please choose a different slug extension.",
+                    )
             for as_block in obj.associated_blocks():
                 for block in Block.objects.all():
                     if f"{as_block.slug}{slug_extension}" == block.slug:
-                        messages.add_message(request,
-                                        messages.ERROR,
-                                        f"A block with slug: {block.slug}{slug_extension} already exists. Please choose a different slug extension.")
+                        messages.add_message(
+                            request,
+                            messages.ERROR,
+                            f"A block with slug: {block.slug}{slug_extension} already exists. Please choose a different slug extension.",
+                        )
             # Return to form with error messages
             if len(messages.get_messages(request)) != 0:
                 return render(
@@ -341,9 +348,9 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                 )
 
             # order_by is inserted here to prevent a query error
-            exp_contents = obj.translated_content.order_by('name').all()
+            exp_contents = obj.translated_content.order_by("name").all()
             # order_by is inserted here to prevent a query error
-            exp_phases = obj.phases.order_by('index').all()
+            exp_phases = obj.phases.order_by("index").all()
 
             # Duplicate Experiment object
             exp_copy = obj
@@ -372,7 +379,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                 # Duplicate blocks in this phase
                 for block in these_blocks:
                     # order_by is inserted here to prevent a query error
-                    block_contents = block.translated_contents.order_by('name').all()                    
+                    block_contents = block.translated_contents.order_by("name").all()
                     these_playlists = block.playlists.all()
                     question_series = QuestionSeries.objects.filter(block=block)
 
@@ -385,7 +392,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                     block_copy.playlists.set(these_playlists)
 
                     # Duplicate Block translated content objects
-                    for content in block_contents:          
+                    for content in block_contents:
                         block_content_copy = content
                         block_content_copy.pk = None
                         block_content_copy._state.adding = True
@@ -413,7 +420,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                         series_copy.questions.set(these_questions)
 
             return self.redirect_to_overview()
-        
+
         # Go back to experiment overview
         if "_back" in request.POST:
             return self.redirect_to_overview()
@@ -463,7 +470,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                 "blocks": blocks,
                 "sessions": all_sessions,
                 "participants": all_participants,
-                'feedback': all_feedback,
+                "feedback": all_feedback,
                 "collect_data": collect_data,
             },
         )
@@ -541,6 +548,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                     level=messages.WARNING,
                 )
 
+
 class PhaseAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "name_link",
@@ -572,6 +580,7 @@ class PhaseAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
 
         return format_html(", ".join([block.slug for block in blocks]))
 
+
 class BlockTranslatedContentAdmin(admin.ModelAdmin):
     list_display = ["name", "block", "language"]
     list_filter = ["language"]
@@ -590,6 +599,7 @@ class BlockTranslatedContentAdmin(admin.ModelAdmin):
         return format_html(
             ", ".join([f'<a href="/admin/experiment/block/{block.id}/change/">{block.name}</a>' for block in blocks])
         )
+
 
 admin.site.register(Block, BlockAdmin)
 admin.site.register(Experiment, ExperimentAdmin)

--- a/backend/experiment/forms.py
+++ b/backend/experiment/forms.py
@@ -280,8 +280,8 @@ class BlockForm(ModelForm):
         }
 
     class Media:
-        js = ["block_admin.js"]
-        css = {"all": ["block_admin.css"]}
+        js = ["block_admin.js", "collapsible_blocks.js"]
+        css = {"all": ["block_admin.css", "collapsible_blocks.css"]}
 
 
 class ExportForm(Form):

--- a/backend/experiment/static/collapsible_blocks.css
+++ b/backend/experiment/static/collapsible_blocks.css
@@ -3,8 +3,8 @@
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"] {
   border: none;
   border-radius: 0px;
-  margin-bottom: 1rem;
-  border: 1px solid #ccc;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3 {
@@ -15,8 +15,7 @@
   border-radius: 0;
   background: #f8f9fa;
   transition: background-color 0.2s;
-  '
-
+  color: #495057;
 }
 
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3:hover {
@@ -25,7 +24,6 @@
 
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"].collapsed {
   border: none;
-  margin-bottom: 10px;
 }
 
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3>b {
@@ -33,14 +31,13 @@
 }
 
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"] .collapse-toggle {
-  color: #666;
   transition: transform 0.2s;
-  font-size: 1rem;
+  font-size: .75rem;
+  color: #495057;
 }
 
 .djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3 .inline_label {
   font-weight: bold;
-  color: #666;
   font-size: .75rem;
 }
 
@@ -53,19 +50,21 @@
 
 /* Style for expand/collapse all buttons */
 .collapse-buttons-container {
-  margin-top: .5rem;
-  margin-bottom: .5rem;
-  text-align: right;
+  display: inline-block;
+  margin-top: 0rem;
+  margin-bottom: 0rem;
+  margin-left: auto;
+  align-self: flex-end;
 }
 
 .collapse-buttons-container button {
-  margin-left: 10px;
-  padding: 5px 10px;
-  border: 1px solid #ccc;
+  margin-left: .5rem;
+  padding: .25rem;
   border-radius: 4px;
   background: #fff;
   cursor: pointer;
-  font-size: 12px;
+  font-size: .75rem;
+  border: 0px solid #ccc;
 }
 
 .collapse-buttons-container button:hover {

--- a/backend/experiment/static/collapsible_blocks.css
+++ b/backend/experiment/static/collapsible_blocks.css
@@ -1,0 +1,63 @@
+/* collapsible_blocks.css */
+
+.djn-inline-form[data-inline-model="experiment-block"]>h3 {
+  cursor: pointer;
+  user-select: none;
+  padding: 10px;
+  margin: 0;
+  border-radius: 4px 4px 0 0;
+  background: #f8f9fa;
+  transition: background-color 0.2s;
+}
+
+.djn-inline-form[data-inline-model="experiment-block"]>h3:hover {
+  background: #e9ecef;
+}
+
+.djn-inline-form[data-inline-model="experiment-block"].collapsed {
+  margin-bottom: 10px;
+}
+
+.djn-inline-form[data-inline-model="experiment-block"] .collapse-toggle {
+  color: #666;
+  transition: transform 0.2s;
+}
+
+.djn-inline-form[data-inline-model="experiment-block"]>h3 .inline_label {
+  font-weight: normal;
+  color: #666;
+}
+
+/* Style adjustments for the block form when collapsed */
+.djn-inline-form[data-inline-model="experiment-block"].collapsed>h3 {
+  border-radius: 4px;
+  margin-bottom: 5px;
+}
+
+/* Style for expand/collapse all buttons */
+.collapse-buttons-container {
+  margin-top: .5rem;
+  text-align: right;
+}
+
+.collapse-buttons-container button {
+  margin-left: 10px;
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.collapse-buttons-container button:hover {
+  background: #f8f9fa;
+}
+
+.expand-all-btn {
+  color: #28a745;
+}
+
+.collapse-all-btn {
+  color: #dc3545;
+}

--- a/backend/experiment/static/collapsible_blocks.css
+++ b/backend/experiment/static/collapsible_blocks.css
@@ -1,42 +1,60 @@
 /* collapsible_blocks.css */
 
-.djn-inline-form[data-inline-model="experiment-block"]>h3 {
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"] {
+  border: none;
+  border-radius: 0px;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+}
+
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3 {
   cursor: pointer;
   user-select: none;
   padding: 10px;
   margin: 0;
-  border-radius: 4px 4px 0 0;
+  border-radius: 0;
   background: #f8f9fa;
   transition: background-color 0.2s;
+  '
+
 }
 
-.djn-inline-form[data-inline-model="experiment-block"]>h3:hover {
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3:hover {
   background: #e9ecef;
 }
 
-.djn-inline-form[data-inline-model="experiment-block"].collapsed {
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"].collapsed {
+  border: none;
   margin-bottom: 10px;
 }
 
-.djn-inline-form[data-inline-model="experiment-block"] .collapse-toggle {
-  color: #666;
-  transition: transform 0.2s;
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3>b {
+  display: none;
 }
 
-.djn-inline-form[data-inline-model="experiment-block"]>h3 .inline_label {
-  font-weight: normal;
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"] .collapse-toggle {
   color: #666;
+  transition: transform 0.2s;
+  font-size: 1rem;
+}
+
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"]>h3 .inline_label {
+  font-weight: bold;
+  color: #666;
+  font-size: .75rem;
 }
 
 /* Style adjustments for the block form when collapsed */
-.djn-inline-form[data-inline-model="experiment-block"].collapsed>h3 {
-  border-radius: 4px;
-  margin-bottom: 5px;
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"].collapsed>h3 {}
+
+.djn-group-nested .djn-inline-form[data-inline-model="experiment-block"].collapsed .inline_label {
+  font-weight: normal;
 }
 
 /* Style for expand/collapse all buttons */
 .collapse-buttons-container {
   margin-top: .5rem;
+  margin-bottom: .5rem;
   text-align: right;
 }
 

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -1,0 +1,123 @@
+// collapsible_blocks.js
+
+function initializeBlockForm(blockForm) {
+  const header = blockForm.querySelector('h3');
+
+  // Only add toggle button if it doesn't exist
+  if (header && !header.querySelector('.collapse-toggle')) {
+    const toggleBtn = document.createElement('span');
+    toggleBtn.className = 'collapse-toggle';
+    toggleBtn.innerHTML = '►';  // Start collapsed
+    toggleBtn.style.marginLeft = '10px';
+    toggleBtn.style.cursor = 'pointer';
+    header.appendChild(toggleBtn);
+
+    // Add click handler to header
+    header.addEventListener('click', function (e) {
+      // Don't trigger if clicking on other buttons in the header
+      if (e.target.classList.contains('djn-remove-handler') ||
+        e.target.classList.contains('inline-deletelink')) {
+        return;
+      }
+
+      toggleBlockVisibility(blockForm);
+    });
+  }
+
+  // Initialize as collapsed by default
+  const contentSections = [
+    blockForm.querySelector('fieldset'),                                            // Main block form
+    blockForm.querySelector('.djn-group-nested[data-inline-model="experiment-blocktranslatedcontent"]')  // Translated content form
+  ];
+
+  contentSections.forEach(section => {
+    if (section) {
+      section.style.display = 'none';
+    }
+  });
+
+  blockForm.classList.add('collapsed');
+}
+
+function toggleBlockVisibility(blockForm) {
+  const contentSections = [
+    blockForm.querySelector('fieldset'),                                            // Main block form
+    blockForm.querySelector('.djn-group-nested[data-inline-model="experiment-blocktranslatedcontent"]')  // Translated content form
+  ];
+
+  const toggleBtn = blockForm.querySelector('.collapse-toggle');
+  const isCollapsed = blockForm.classList.contains('collapsed');
+
+  contentSections.forEach(section => {
+    if (section) {
+      section.style.display = isCollapsed ? 'block' : 'none';
+    }
+  });
+
+  if (isCollapsed) {
+    toggleBtn.innerHTML = '▼';
+    blockForm.classList.remove('collapsed');
+  } else {
+    toggleBtn.innerHTML = '►';
+    blockForm.classList.add('collapsed');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Initialize all existing blocks
+  document.querySelectorAll('.djn-inline-form[data-inline-model="experiment-block"]').forEach(blockForm => {
+    initializeBlockForm(blockForm);
+  });
+
+  // Add expand/collapse all buttons at the top
+  const firstBlock = document.querySelector('.djn-inline-form[data-inline-model="experiment-block"]');
+  if (firstBlock) {
+    const buttonsContainer = document.createElement('div');
+    buttonsContainer.className = 'collapse-buttons-container';
+    buttonsContainer.style.marginBottom = '10px';
+
+    const expandAllBtn = document.createElement('button');
+    expandAllBtn.type = 'button';
+    expandAllBtn.innerText = 'Expand All Blocks';
+    expandAllBtn.className = 'expand-all-btn';
+    expandAllBtn.onclick = function () {
+      document.querySelectorAll('.djn-inline-form[data-inline-model="experiment-block"]').forEach(blockForm => {
+        if (blockForm.classList.contains('collapsed')) {
+          toggleBlockVisibility(blockForm);
+        }
+      });
+    };
+
+    const collapseAllBtn = document.createElement('button');
+    collapseAllBtn.type = 'button';
+    collapseAllBtn.innerText = 'Collapse All Blocks';
+    collapseAllBtn.className = 'collapse-all-btn';
+    collapseAllBtn.onclick = function () {
+      document.querySelectorAll('.djn-inline-form[data-inline-model="experiment-block"]').forEach(blockForm => {
+        if (!blockForm.classList.contains('collapsed')) {
+          toggleBlockVisibility(blockForm);
+        }
+      });
+    };
+
+    buttonsContainer.appendChild(expandAllBtn);
+    buttonsContainer.appendChild(collapseAllBtn);
+    firstBlock.parentNode.insertBefore(buttonsContainer, firstBlock);
+  }
+});
+
+// Add observer for dynamically added blocks
+const observer = new MutationObserver(function (mutations) {
+  mutations.forEach(function (mutation) {
+    mutation.addedNodes.forEach(function (node) {
+      if (node.nodeType === 1 && node.matches('.djn-inline-form[data-inline-model="experiment-block"]')) {
+        initializeBlockForm(node);
+      }
+    });
+  });
+});
+
+observer.observe(document.body, {
+  childList: true,
+  subtree: true
+});

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -1,5 +1,9 @@
-// collapsible_blocks.js
-
+/**
+ * Initializes an (inline) block form by adding a collapsible toggle button to the header
+ * and setting up the initial collapsed state of the form.
+ *
+ * @param {HTMLElement} blockForm - The block form element to initialize.
+ */
 function initializeBlockForm(blockForm) {
   let header = blockForm.querySelector('h3');
 
@@ -116,7 +120,7 @@ document.addEventListener('DOMContentLoaded', function () {
     firstBlock.parentNode.parentNode.querySelector('h2').appendChild(buttonsContainer);
   }
 
-  // Add observer for dynamically added blocks
+  // Add observer for dynamically added blocks (e.g. when adding a new block)
   const observer = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
       mutation.addedNodes.forEach(function (node) {

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -7,7 +7,7 @@ function initializeBlockForm(blockForm) {
   if (header && !header.querySelector('.collapse-toggle')) {
     const toggleBtn = document.createElement('span');
     toggleBtn.className = 'collapse-toggle';
-    toggleBtn.innerHTML = '▲';
+    toggleBtn.innerHTML = '▼';
     toggleBtn.style.marginLeft = '10px';
     toggleBtn.style.cursor = 'pointer';
     header.appendChild(toggleBtn);
@@ -55,10 +55,10 @@ function toggleBlockVisibility(blockForm) {
   });
 
   if (isCollapsed) {
-    toggleBtn.innerHTML = '▼';
+    toggleBtn.innerHTML = '▲';
     blockForm.classList.remove('collapsed');
   } else {
-    toggleBtn.innerHTML = '▲';
+    toggleBtn.innerHTML = '▼';
     blockForm.classList.add('collapsed');
   }
 }
@@ -74,7 +74,6 @@ document.addEventListener('DOMContentLoaded', function () {
   if (firstBlock) {
     const buttonsContainer = document.createElement('div');
     buttonsContainer.className = 'collapse-buttons-container';
-    buttonsContainer.style.marginBottom = '10px';
 
     const expandAllBtn = document.createElement('button');
     expandAllBtn.type = 'button';
@@ -103,6 +102,7 @@ document.addEventListener('DOMContentLoaded', function () {
     buttonsContainer.appendChild(expandAllBtn);
     buttonsContainer.appendChild(collapseAllBtn);
     firstBlock.parentNode.insertBefore(buttonsContainer, firstBlock);
+    firstBlock.parentNode.parentNode.querySelector('h2').appendChild(buttonsContainer);
   }
 });
 

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -1,7 +1,7 @@
 // collapsible_blocks.js
 
 function initializeBlockForm(blockForm) {
-  const header = blockForm.querySelector('h3');
+  let header = blockForm.querySelector('h3');
 
   // Only add toggle button if it doesn't exist
   if (header && !header.querySelector('.collapse-toggle')) {
@@ -11,7 +11,14 @@ function initializeBlockForm(blockForm) {
     toggleBtn.style.marginLeft = '10px';
     toggleBtn.style.cursor = 'pointer';
     header.appendChild(toggleBtn);
+  }
 
+  header = blockForm.querySelector('h3');
+
+  // If collapse-toggle does not have a click handler yet, add one
+  const toggleBtn = blockForm.querySelector('.collapse-toggle');
+
+  if (toggleBtn && !toggleBtn.onclick) {
     // Add click handler to header
     header.addEventListener('click', function (e) {
       // Don't trigger if clicking on other buttons in the header
@@ -40,6 +47,7 @@ function initializeBlockForm(blockForm) {
 }
 
 function toggleBlockVisibility(blockForm) {
+
   const contentSections = [
     blockForm.querySelector('fieldset'),                                            // Main block form
     blockForm.querySelector('.djn-group-nested[data-inline-model="experiment-blocktranslatedcontent"]')  // Translated content form
@@ -71,6 +79,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Add expand/collapse all buttons at the top
   const firstBlock = document.querySelector('.djn-inline-form[data-inline-model="experiment-block"]');
+
   if (firstBlock) {
     const buttonsContainer = document.createElement('div');
     buttonsContainer.className = 'collapse-buttons-container';
@@ -79,6 +88,7 @@ document.addEventListener('DOMContentLoaded', function () {
     expandAllBtn.type = 'button';
     expandAllBtn.innerText = 'Expand All Blocks';
     expandAllBtn.className = 'expand-all-btn';
+
     expandAllBtn.onclick = function () {
       document.querySelectorAll('.djn-inline-form[data-inline-model="experiment-block"]').forEach(blockForm => {
         if (blockForm.classList.contains('collapsed')) {
@@ -91,6 +101,7 @@ document.addEventListener('DOMContentLoaded', function () {
     collapseAllBtn.type = 'button';
     collapseAllBtn.innerText = 'Collapse All Blocks';
     collapseAllBtn.className = 'collapse-all-btn';
+
     collapseAllBtn.onclick = function () {
       document.querySelectorAll('.djn-inline-form[data-inline-model="experiment-block"]').forEach(blockForm => {
         if (!blockForm.classList.contains('collapsed')) {
@@ -104,20 +115,26 @@ document.addEventListener('DOMContentLoaded', function () {
     firstBlock.parentNode.insertBefore(buttonsContainer, firstBlock);
     firstBlock.parentNode.parentNode.querySelector('h2').appendChild(buttonsContainer);
   }
-});
 
-// Add observer for dynamically added blocks
-const observer = new MutationObserver(function (mutations) {
-  mutations.forEach(function (mutation) {
-    mutation.addedNodes.forEach(function (node) {
-      if (node.nodeType === 1 && node.matches('.djn-inline-form[data-inline-model="experiment-block"]')) {
-        initializeBlockForm(node);
-      }
+  // Add observer for dynamically added blocks
+  const observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      mutation.addedNodes.forEach(function (node) {
+        if (node.nodeType === 1 && node.matches('.djn-inline-form[data-inline-model="experiment-block"]')) {
+
+          // Initialize newly added block by adding toggle button, etc.
+          initializeBlockForm(node);
+
+          // Expand every newly added inline block form
+          toggleBlockVisibility(node);
+        }
+      });
     });
   });
-});
 
-observer.observe(document.body, {
-  childList: true,
-  subtree: true
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
+
 });

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -23,16 +23,21 @@ function initializeBlockForm(blockForm) {
   const toggleBtn = blockForm.querySelector('.collapse-toggle');
 
   if (toggleBtn && !toggleBtn.onclick) {
-    // Add click handler to header
-    header.addEventListener('click', function (e) {
-      // Don't trigger if clicking on other buttons in the header
-      if (e.target.classList.contains('djn-remove-handler') ||
-        e.target.classList.contains('inline-deletelink')) {
-        return;
-      }
+    // Remove click handler from header if it exists to prevent multiple click handlers on the same element
+    header.removeEventListener('click', toggleVisibilityClickHandler);
 
-      toggleBlockVisibility(blockForm);
-    });
+    // Add click handler to header
+    header.addEventListener('click', toggleVisibilityClickHandler);
+  }
+
+  function toggleVisibilityClickHandler(e) {
+    // Don't trigger if clicking on other buttons in the header
+    if (e.target.classList.contains('djn-remove-handler') ||
+      e.target.classList.contains('inline-deletelink')) {
+      return;
+    }
+
+    toggleBlockVisibility(blockForm);
   }
 
   // Initialize as collapsed by default

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -7,7 +7,7 @@ function initializeBlockForm(blockForm) {
   if (header && !header.querySelector('.collapse-toggle')) {
     const toggleBtn = document.createElement('span');
     toggleBtn.className = 'collapse-toggle';
-    toggleBtn.innerHTML = '►';  // Start collapsed
+    toggleBtn.innerHTML = '▲';
     toggleBtn.style.marginLeft = '10px';
     toggleBtn.style.cursor = 'pointer';
     header.appendChild(toggleBtn);
@@ -58,7 +58,7 @@ function toggleBlockVisibility(blockForm) {
     toggleBtn.innerHTML = '▼';
     blockForm.classList.remove('collapsed');
   } else {
-    toggleBtn.innerHTML = '►';
+    toggleBtn.innerHTML = '▲';
     blockForm.classList.add('collapsed');
   }
 }

--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -79,6 +79,11 @@ document.addEventListener('DOMContentLoaded', function () {
   // Initialize all existing blocks
   document.querySelectorAll('.djn-inline-form[data-inline-model="experiment-block"]').forEach(blockForm => {
     initializeBlockForm(blockForm);
+
+    // Expand block form if there are errors in it (i.e. .errors or .errorlist)
+    if (blockForm.querySelector('.errors, .errorlist')) {
+      toggleBlockVisibility(blockForm);
+    }
   });
 
   // Add expand/collapse all buttons at the top

--- a/backend/experiment/static/experiment_form.css
+++ b/backend/experiment/static/experiment_form.css
@@ -1,5 +1,8 @@
 /* Add cursor pointer to inline group headings as they are clickable to toggle the form underneath */
 .inline-group .inline-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Introduce collapsible functionality to block forms, enhancing user experience with improved visibility and layout. Update styles and documentation to support the new features.

Resolves #1380

## Screenshots

### Collapsed state

![image](https://github.com/user-attachments/assets/72b1f387-7d4e-4ab1-a76e-e33fd3b1fd80)

### One inline block form expanded

![image](https://github.com/user-attachments/assets/25413593-518e-47f9-92ac-bb60b240385b)

