### PR TITLE
Fixed: Temporarily enable random bars in Histogram for audio playback animation

### DIFF
--- a/frontend/src/components/ListenCircle/ListenCircle.tsx
+++ b/frontend/src/components/ListenCircle/ListenCircle.tsx
@@ -16,7 +16,15 @@ const ListenCircle = ({
         <>
             <CountDown duration={duration} running={countDownRunning} />
             <div className="aha__histogram-container">
-                <Histogram running={histogramRunning} />
+                <Histogram
+                    running={histogramRunning}
+
+                    // Set random to true (and interval to 200) temporarily to see the animation
+                    // TODO: Remove random and interval props and fix Histogram to always use
+                    // random bars when the audio play_method is not "BUFFER"
+                    random={true}
+                    interval={200}
+                />
             </div>
         </>
     );


### PR DESCRIPTION
Enable random bars in the Histogram component during audio playback to visualize animation. This change is temporary and will be revisited for a more permanent solution.

Related to #1379