### PR TITLE
Refactor: Integrate Round management and enhance Histogram component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,103 +1,103 @@
 {
-  "name": "aml-frontend",
-  "description": "The React Frontend for the MUSCLE platform",
-  "type": "module",
-  "license": "MIT",
-  "dependencies": {
-    "@sentry/react": "^8.40.0",
-    "@vitejs/plugin-react": "^4.2.1",
-    "axios": ">=1.7.4",
-    "classnames": "^2.2.6",
-    "email-validator": "^2.0.4",
-    "file-saver": "^2.0.5",
-    "qs": "^6.10.3",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-helmet": "^6.1.0",
-    "react-rangeslider": "^2.2.0",
-    "react-router": "^6.25.1",
-    "react-router-dom": "^6.25.1",
-    "react-select": "^5.4.0",
-    "react-share": "^5.1.1",
-    "react-transition-group": "^4.4.5",
-    "sass": "^1.69.5",
-    "typescript": "^5.3.3",
-    "vite": "^5.2.14",
-    "vite-tsconfig-paths": "^4.3.2",
-    "zustand": "^4.4.7"
-  },
-  "scripts": {
-    "start": "vite --host",
-    "build": "vite build",
-    "preview": "vite preview",
-    "test": "vitest",
-    "test:ci": "vitest --watch=false --coverage",
-    "generate-badge": "coverage-badges -s coverage/coverage-summary.json -o coverage-frontend-badge-new.svg --label 'Frontend Code Coverage'",
-    "storybook": "storybook dev -p 6006 --no-open",
-    "storybook:build": "storybook build",
-    "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
-    "lint:fix": "eslint --fix src/**/*.js",
-    "build-storybook": "storybook build"
-  },
-  "eslintConfig": {
-    "plugins": [
-      "chai-friendly"
-    ],
-    "extends": [
-      "react-app",
-      "plugin:storybook/recommended"
-    ],
-    "rules": {
-      "no-unused-expressions": 0,
-      "chai-friendly/no-unused-expressions": [
-        "error",
-        {
-          "allowShortCircuit": true
+    "name": "aml-frontend",
+    "description": "The React Frontend for the MUSCLE platform",
+    "type": "module",
+    "license": "MIT",
+    "dependencies": {
+        "@sentry/react": "^8.40.0",
+        "@vitejs/plugin-react": "^4.2.1",
+        "axios": ">=1.7.4",
+        "classnames": "^2.2.6",
+        "email-validator": "^2.0.4",
+        "file-saver": "^2.0.5",
+        "qs": "^6.10.3",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "react-helmet": "^6.1.0",
+        "react-rangeslider": "^2.2.0",
+        "react-router": "^6.25.1",
+        "react-router-dom": "^6.25.1",
+        "react-select": "^5.4.0",
+        "react-share": "^5.1.1",
+        "react-transition-group": "^4.4.5",
+        "sass": "^1.69.5",
+        "typescript": "^5.3.3",
+        "vite": "^5.2.14",
+        "vite-tsconfig-paths": "^4.3.2",
+        "zustand": "^4.4.7"
+    },
+    "scripts": {
+        "start": "vite --host",
+        "build": "vite build",
+        "preview": "vite preview",
+        "test": "vitest",
+        "test:ci": "vitest --watch=false --coverage",
+        "generate-badge": "coverage-badges -s coverage/coverage-summary.json -o coverage-frontend-badge-new.svg --label 'Frontend Code Coverage'",
+        "storybook": "storybook dev -p 6006 --no-open",
+        "storybook:build": "storybook build",
+        "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
+        "lint:fix": "eslint --fix src/**/*.{js,jsx,ts,tsx}",
+        "build-storybook": "storybook build"
+    },
+    "eslintConfig": {
+        "plugins": [
+            "chai-friendly"
+        ],
+        "extends": [
+            "react-app",
+            "plugin:storybook/recommended"
+        ],
+        "rules": {
+            "no-unused-expressions": 0,
+            "chai-friendly/no-unused-expressions": [
+                "error",
+                {
+                    "allowShortCircuit": true
+                }
+            ]
         }
-      ]
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    },
+    "devDependencies": {
+        "@chromatic-com/storybook": "^3.2.2",
+        "@storybook/addon-essentials": "^8.4.6",
+        "@storybook/addon-interactions": "^8.4.6",
+        "@storybook/addon-links": "^8.4.6",
+        "@storybook/addon-onboarding": "^8.4.6",
+        "@storybook/blocks": "^8.4.6",
+        "@storybook/react": "^8.4.6",
+        "@storybook/react-vite": "^8.4.6",
+        "@storybook/test": "^8.4.6",
+        "@testing-library/dom": "^10.2.0",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.1",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@types/react-helmet": "^6",
+        "@types/react-router-dom": "^5.3.3",
+        "@vitest/coverage-istanbul": "^2.1.4",
+        "@vitest/coverage-v8": "^2.1.4",
+        "axios-mock-adapter": "^1.22.0",
+        "coverage-badges-cli": "^1.2.5",
+        "eslint": "^8.54.0",
+        "eslint-config-react-app": "^7.0.1",
+        "eslint-plugin-chai-friendly": "^0.7.2",
+        "eslint-plugin-storybook": "^0.11.1",
+        "happy-dom": "^15.10.2",
+        "history": "^5.3.0",
+        "prop-types": "15.8.1",
+        "storybook": "^8.4.6",
+        "vitest": "^2.1.4"
     }
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "devDependencies": {
-    "@chromatic-com/storybook": "^3.2.2",
-    "@storybook/addon-essentials": "^8.4.6",
-    "@storybook/addon-interactions": "^8.4.6",
-    "@storybook/addon-links": "^8.4.6",
-    "@storybook/addon-onboarding": "^8.4.6",
-    "@storybook/blocks": "^8.4.6",
-    "@storybook/react": "^8.4.6",
-    "@storybook/react-vite": "^8.4.6",
-    "@storybook/test": "^8.4.6",
-    "@testing-library/dom": "^10.2.0",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.1",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@types/react-helmet": "^6",
-    "@types/react-router-dom": "^5.3.3",
-    "@vitest/coverage-istanbul": "^2.1.4",
-    "@vitest/coverage-v8": "^2.1.4",
-    "axios-mock-adapter": "^1.22.0",
-    "coverage-badges-cli": "^1.2.5",
-    "eslint": "^8.54.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-chai-friendly": "^0.7.2",
-    "eslint-plugin-storybook": "^0.11.1",
-    "happy-dom": "^15.10.2",
-    "history": "^5.3.0",
-    "prop-types": "15.8.1",
-    "storybook": "^8.4.6",
-    "vitest": "^2.1.4"
-  }
 }

--- a/frontend/src/API.ts
+++ b/frontend/src/API.ts
@@ -7,6 +7,7 @@ import IExperiment from "@/types/Experiment";
 import Participant, { ParticipantLink } from "./types/Participant";
 import Session from "./types/Session";
 import Experiment from "@/types/Experiment";
+import { RoundResponse } from "./types/Round";
 
 // API handles the calls to the Hooked-server api
 
@@ -173,7 +174,7 @@ interface GetNextRoundParams {
 
 
 // Get next_round from server
-export const getNextRound = async ({ session }: GetNextRoundParams) => {
+export const getNextRound = async ({ session }: GetNextRoundParams): Promise<RoundResponse | null> => {
 
     const sessionId = session.id.toString();
 

--- a/frontend/src/components/AppBar/AppBar.test.tsx
+++ b/frontend/src/components/AppBar/AppBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import AppBar from './AppBar';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { vi, describe, beforeEach, it, expect } from 'vitest';

--- a/frontend/src/components/Block/Block.test.tsx
+++ b/frontend/src/components/Block/Block.test.tsx
@@ -51,7 +51,6 @@ vi.mock('../../util/stores', () => ({
             setHeadData: vi.fn(),
             resetHeadData: vi.fn(),
             setBlock: vi.fn(),
-            setRound: vi.fn(),
             setCurrentAction: vi.fn(),
         };
 

--- a/frontend/src/components/Block/Block.test.tsx
+++ b/frontend/src/components/Block/Block.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../API', () => ({
 
 vi.mock('../../util/stores', () => ({
     __esModule: true,
-    default: (fn) => {
+    default: (fn: any) => {
         const state = {
             session: mockSessionStore,
             participant: mockParticipantStore,
@@ -51,6 +51,8 @@ vi.mock('../../util/stores', () => ({
             setHeadData: vi.fn(),
             resetHeadData: vi.fn(),
             setBlock: vi.fn(),
+            setRound: vi.fn(),
+            setCurrentAction: vi.fn(),
         };
 
         return fn(state);

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -71,7 +71,7 @@ const Block = () => {
         const currentAction = newState ? newState : null;
         setCurrentAction({ ...currentAction });
         updateState(newState);
-    }, [updateState]);
+    }, [updateState, setCurrentAction]);
 
     const continueToNextRound = async (activeSession: Session) => {
         // Try to get next_round data from server

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -56,6 +56,9 @@ const Block = () => {
     const setTheme = useBoundStore((state) => state.setTheme);
     const resetTheme = useBoundStore((state) => state.resetTheme);
     const setBlock = useBoundStore((state) => state.setBlock);
+    const setRound = useBoundStore((state) => state.setRound);
+    const setCurrentAction = useBoundStore((state) => state.setCurrentAction);
+    const currentActionIndex = useBoundStore((state) => state.currentActionIndex);
 
     const setHeadData = useBoundStore((state) => state.setHeadData);
     const resetHeadData = useBoundStore((state) => state.resetHeadData);
@@ -67,7 +70,7 @@ const Block = () => {
     const playlist = useRef(null);
 
     // API hooks
-    const [block, loadingBlock] = useBlock(slug);
+    const [block, loadingBlock] = useBlock(slug!);
 
     const loadingText = block ? block.loading_text : "";
     const className = block ? block.class_name : "";
@@ -83,6 +86,7 @@ const Block = () => {
     const updateActions = useCallback((currentActions: []) => {
         const newActions = currentActions;
         setActions(newActions);
+        setCurrentAction(0);
         const newState = newActions.shift();
         updateState(newState);
     }, [updateState]);
@@ -93,6 +97,7 @@ const Block = () => {
             session: activeSession
         });
         if (round) {
+            setRound({ ...round.next_round }); // Make a deep copy of the round as the 'round' object will be mutated by the updateActions
             updateActions(round.next_round);
         } else {
             setError(
@@ -106,6 +111,7 @@ const Block = () => {
     const onNext = async (doBreak = false) => {
         if (!doBreak && actions.length) {
             updateActions(actions);
+            setCurrentAction(currentActionIndex! + 1); // Increment current action index
         } else {
             continueToNextRound(session as Session);
         }

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -39,9 +39,7 @@ const Block = () => {
     const setTheme = useBoundStore((state) => state.setTheme);
     const resetTheme = useBoundStore((state) => state.resetTheme);
     const setBlock = useBoundStore((state) => state.setBlock);
-    const setRound = useBoundStore((state) => state.setRound);
     const setCurrentAction = useBoundStore((state) => state.setCurrentAction);
-    const currentActionIndex = useBoundStore((state) => state.currentActionIndex);
 
     const setHeadData = useBoundStore((state) => state.setHeadData);
     const resetHeadData = useBoundStore((state) => state.resetHeadData);
@@ -69,8 +67,9 @@ const Block = () => {
     const updateActions = useCallback((currentActions: Round) => {
         const newActions = currentActions;
         setActions(newActions);
-        setCurrentAction(0);
         const newState = newActions.shift();
+        const currentAction = newState ? newState : null;
+        setCurrentAction(currentAction);
         updateState(newState);
     }, [updateState]);
 
@@ -80,7 +79,6 @@ const Block = () => {
             session: activeSession
         });
         if (round) {
-            setRound({ ...round.next_round }); // Make a deep copy of the round as the 'round' object will be mutated by the updateActions
             updateActions(round.next_round);
         } else {
             setError(
@@ -94,7 +92,6 @@ const Block = () => {
     const onNext = async (doBreak = false) => {
         if (!doBreak && actions.length) {
             updateActions(actions);
-            setCurrentAction(currentActionIndex! + 1); // Increment current action index
         } else {
             continueToNextRound(session as Session);
         }

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -69,7 +69,7 @@ const Block = () => {
         setActions(newActions);
         const newState = newActions.shift();
         const currentAction = newState ? newState : null;
-        setCurrentAction(currentAction);
+        setCurrentAction({ ...currentAction });
         updateState(newState);
     }, [updateState]);
 
@@ -84,6 +84,7 @@ const Block = () => {
             setError(
                 "An error occured while loading the data, please try to reload the page. (Error: next_round data unavailable)"
             );
+            setCurrentAction(null);
             setState(null);
         }
     };

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -19,6 +19,7 @@ import FontLoader from "@/components/FontLoader/FontLoader";
 import useResultHandler from "@/hooks/useResultHandler";
 import Session from "@/types/Session";
 import { Action } from "@/types/Action";
+import { Round } from "@/types/Round";
 
 // Block handles the main (experiment) block flow:
 // - Loads the block and participant
@@ -46,7 +47,7 @@ const Block = () => {
     const resetHeadData = useBoundStore((state) => state.resetHeadData);
 
     // Current block state
-    const [actions, setActions] = useState([]);
+    const [actions, setActions] = useState<Round>([]);
     const [state, setState] = useState<Action | null>(startState);
     const [key, setKey] = useState<number>(Math.random());
     const playlist = useRef(null);
@@ -65,7 +66,7 @@ const Block = () => {
         setKey(Math.random());
     }, []);
 
-    const updateActions = useCallback((currentActions: []) => {
+    const updateActions = useCallback((currentActions: Round) => {
         const newActions = currentActions;
         setActions(newActions);
         setCurrentAction(0);

--- a/frontend/src/components/Block/Block.tsx
+++ b/frontend/src/components/Block/Block.tsx
@@ -6,37 +6,19 @@ import classNames from "classnames";
 import useBoundStore from "@/util/stores";
 import { getNextRound, useBlock } from "@/API";
 import DefaultPage from "@/components/Page/DefaultPage";
-import Explainer, { ExplainerProps } from "@/components/Explainer/Explainer";
-import Final, { FinalProps } from "@/components/Final/Final";
-import Loading, { LoadingProps } from "@/components/Loading/Loading";
-import Playlist, { PlaylistProps } from "@/components/Playlist/Playlist";
-import Score, { ScoreProps } from "@/components/Score/Score";
-import Trial, { TrialProps } from "@/components/Trial/Trial";
-import Info, { InfoProps } from "@/components/Info/Info";
+import Explainer from "@/components/Explainer/Explainer";
+import Final from "@/components/Final/Final";
+import Loading from "@/components/Loading/Loading";
+import Playlist from "@/components/Playlist/Playlist";
+import Score from "@/components/Score/Score";
+import Trial from "@/components/Trial/Trial";
+import Info from "@/components/Info/Info";
 import FloatingActionButton from "@/components/FloatingActionButton/FloatingActionButton";
 import UserFeedback from "@/components/UserFeedback/UserFeedback";
 import FontLoader from "@/components/FontLoader/FontLoader";
 import useResultHandler from "@/hooks/useResultHandler";
 import Session from "@/types/Session";
-import { RedirectProps } from "../Redirect/Redirect";
-
-interface SharedActionProps {
-    title?: string;
-    config?: object;
-    style?: object;
-}
-
-type ActionProps = SharedActionProps &
-    (
-        | { view: "EXPLAINER" } & ExplainerProps
-        | { view: "INFO" } & InfoProps
-        | { view: "TRIAL_VIEW" } & TrialProps
-        | { view: 'SCORE' } & ScoreProps
-        | { view: 'FINAL' } & FinalProps
-        | { view: 'PLAYLIST' } & PlaylistProps
-        | { view: 'REDIRECT' } & RedirectProps
-        | { view: "LOADING" } & LoadingProps
-    )
+import { Action } from "@/types/Action";
 
 // Block handles the main (experiment) block flow:
 // - Loads the block and participant
@@ -46,7 +28,7 @@ type ActionProps = SharedActionProps &
 //   Empty URL parameter "participant_id" is the same as no URL parameter at all
 const Block = () => {
     const { slug } = useParams();
-    const startState = { view: "LOADING" } as ActionProps;
+    const startState = { view: "LOADING" } as Action;
     // Stores
     const setError = useBoundStore(state => state.setError);
     const participant = useBoundStore((state) => state.participant);
@@ -65,7 +47,7 @@ const Block = () => {
 
     // Current block state
     const [actions, setActions] = useState([]);
-    const [state, setState] = useState<ActionProps | null>(startState);
+    const [state, setState] = useState<Action | null>(startState);
     const [key, setKey] = useState<number>(Math.random());
     const playlist = useRef(null);
 
@@ -76,7 +58,7 @@ const Block = () => {
     const className = block ? block.class_name : "";
 
     /** Set new state as spread of current state to force re-render */
-    const updateState = useCallback((state: ActionProps) => {
+    const updateState = useCallback((state: Action) => {
         if (!state) return;
 
         setState({ ...state });

--- a/frontend/src/components/Experiment/Header/Header.tsx
+++ b/frontend/src/components/Experiment/Header/Header.tsx
@@ -30,9 +30,6 @@ export const Header: React.FC<HeaderProps> = ({
     socialMediaConfig
 }) => {
 
-    // Get current URL minus the query string
-    const currentUrl = window.location.href.split('?')[0];
-
     return (
         <div className="hero">
             <div className="intro">

--- a/frontend/src/components/Explainer/Explainer.tsx
+++ b/frontend/src/components/Explainer/Explainer.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 import Button from "../Button/Button";
-import { Explainer } from "@/types/Action";
+import { Explainer as ExplainerAction } from "@/types/Action";
 
-export interface ExplainerProps extends Explainer {
+export interface ExplainerProps extends ExplainerAction {
     onNext: () => void;
 }
 

--- a/frontend/src/components/Explainer/Explainer.tsx
+++ b/frontend/src/components/Explainer/Explainer.tsx
@@ -1,16 +1,8 @@
 import { useEffect } from "react";
 import Button from "../Button/Button";
+import { Explainer } from "@/types/Action";
 
-interface ExplainerStep {
-    number: number;
-    description: string;
-}
-
-export interface ExplainerProps {
-    instruction: string;
-    button_label: string;
-    steps?: Array<ExplainerStep>;
-    timer: number | null;
+export interface ExplainerProps extends Explainer {
     onNext: () => void;
 }
 

--- a/frontend/src/components/Final/Final.tsx
+++ b/frontend/src/components/Final/Final.tsx
@@ -10,39 +10,10 @@ import useBoundStore from "../../util/stores";
 import ParticipantLink from "../ParticipantLink/ParticipantLink";
 import UserFeedback from "../UserFeedback/UserFeedback";
 import FinalButton from "./FinalButton";
-import ISocial from "@/types/Social";
-import Block, { FeedbackInfo } from "@/types/Block";
-import Participant from "@/types/Participant";
+import { Final } from "@/types/Action";
 
-export interface FinalProps {
-    block: Block;
-    participant: Participant;
-    score: number;
-    final_text: string | TrustedHTML;
-    action_texts: {
-        all_experiments: string;
-        profile: string;
-        play_again: string;
-    }
-    button: {
-        text: string;
-        link: string;
-    };
+export interface FinalProps extends Final {
     onNext: () => void;
-    show_participant_link: boolean;
-    participant_id_only: boolean;
-    show_profile_link: boolean;
-    social: ISocial;
-    feedback_info?: FeedbackInfo;
-    points: string;
-    rank: {
-        class: string;
-        text: string;
-    }
-    logo: {
-        image: string;
-        link: string;
-    };
 }
 
 /**

--- a/frontend/src/components/Final/Final.tsx
+++ b/frontend/src/components/Final/Final.tsx
@@ -10,9 +10,9 @@ import useBoundStore from "../../util/stores";
 import ParticipantLink from "../ParticipantLink/ParticipantLink";
 import UserFeedback from "../UserFeedback/UserFeedback";
 import FinalButton from "./FinalButton";
-import { Final } from "@/types/Action";
+import { Final as FinalAction } from "@/types/Action";
 
-export interface FinalProps extends Final {
+export interface FinalProps extends FinalAction {
     onNext: () => void;
 }
 

--- a/frontend/src/components/Histogram/Histogram.test.tsx
+++ b/frontend/src/components/Histogram/Histogram.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock, } from 'vitest';
+import { render, act } from '@testing-library/react';
 import Histogram from './Histogram';
 
 // Mock requestAnimationFrame and cancelAnimationFrame
@@ -14,9 +14,21 @@ vi.stubGlobal('cancelAnimationFrame', (handle: number): void => {
 // Mock setInterval and clearInterval
 vi.useFakeTimers();
 
+vi.mock('../../util/stores', () => ({
+    __esModule: true,
+    default: (fn: any) => {
+        const state = {
+            currentAction: vi.fn().mockReturnValue({ playback: { play_method: 'BUFFER' } }),
+        };
+
+        return fn(state);
+    },
+    useBoundStore: vi.fn()
+}));
+
 describe('Histogram', () => {
     let mockAnalyser: {
-        getByteFrequencyData: vi.Mock;
+        getByteFrequencyData: Mock
     };
 
     beforeEach(() => {
@@ -154,11 +166,8 @@ describe('Histogram', () => {
     it('updates bar heights based on random data when random is true and running is true', async () => {
         const bars = 5;
 
-        // Ensure the analyser does not provide data
-        mockAnalyser.getByteFrequencyData.mockImplementation(() => { });
-
         const { container, rerender } = render(
-            <Histogram running={true} bars={bars} random={true} />
+            <Histogram running={true} bars={bars} random={true} interval={200} />
         );
 
         const getHeights = () =>
@@ -168,9 +177,9 @@ describe('Histogram', () => {
 
         const initialHeights = getHeights();
 
-        // Advance timers and trigger animation frame
+        // Advance timers by at least one interval
         await act(async () => {
-            vi.advanceTimersByTime(100);
+            vi.advanceTimersByTime(200);
         });
 
         rerender(<Histogram running={true} bars={bars} random={true} />);
@@ -178,7 +187,6 @@ describe('Histogram', () => {
         const updatedHeights = getHeights();
 
         expect(initialHeights).not.to.deep.equal(updatedHeights);
-        expect(mockAnalyser.getByteFrequencyData).not.toHaveBeenCalled();
     });
 
     it('does not call getByteFrequencyData when random is true', async () => {
@@ -225,6 +233,7 @@ describe('Histogram', () => {
 
     it('updates bar heights based on frequency data using requestAnimationFrame', async () => {
         const bars = 5;
+
         mockAnalyser.getByteFrequencyData.mockImplementation((array) => {
             for (let i = 0; i < array.length; i++) {
                 array[i] = Math.floor(Math.random() * 256);

--- a/frontend/src/components/Histogram/Histogram.test.tsx
+++ b/frontend/src/components/Histogram/Histogram.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../../util/stores', () => ({
     __esModule: true,
     default: (fn: any) => {
         const state = {
-            currentAction: vi.fn().mockReturnValue({ playback: { play_method: 'BUFFER' } }),
+            currentAction: { playback: { play_method: 'BUFFER' } },
         };
 
         return fn(state);

--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
+import useBoundStore from '@/util/stores';
 
 interface HistogramProps {
     bars?: number;
@@ -27,9 +28,14 @@ const Histogram: React.FC<HistogramProps> = ({
     backgroundColor = undefined,
     borderRadius = '0.15rem',
     random = false,
-    interval = 100,
+    interval = 200,
 }) => {
     const [frequencyData, setFrequencyData] = useState<Uint8Array>(new Uint8Array(bars));
+
+    const currentAction = useBoundStore((state) => state.currentAction());
+    const isBuffer = currentAction?.playback?.play_method === 'BUFFER';
+
+    const shouldRandomize = random || !isBuffer;
 
     const animationFrameRef = useRef<number>();
     const intervalRef = useRef<number>();
@@ -50,7 +56,7 @@ const Histogram: React.FC<HistogramProps> = ({
         const updateFrequencyData = () => {
             let dataWithoutExtremes: Uint8Array;
 
-            if (random) {
+            if (shouldRandomize) {
                 // Generate random frequency data
                 dataWithoutExtremes = new Uint8Array(bars);
                 for (let i = 0; i < bars; i++) {
@@ -71,14 +77,14 @@ const Histogram: React.FC<HistogramProps> = ({
             }
         };
 
-        if (random) {
-            // Use setInterval when random is true
+        if (shouldRandomize) {
+            // Use setInterval when shouldRandomize is true
             if (intervalRef.current) {
                 clearInterval(intervalRef.current);
             }
             intervalRef.current = window.setInterval(updateFrequencyData, interval);
         } else {
-            // Use requestAnimationFrame when random is false
+            // Use requestAnimationFrame when shouldRandomize is false
             if (animationFrameRef.current) {
                 cancelAnimationFrame(animationFrameRef.current);
             }
@@ -93,7 +99,7 @@ const Histogram: React.FC<HistogramProps> = ({
                 clearInterval(intervalRef.current);
             }
         };
-    }, [running, bars, random, interval]);
+    }, [running, bars, shouldRandomize, interval]);
 
     const barWidth = `calc((100% - ${(bars - 1) * spacing}px) / ${bars})`;
 
@@ -120,7 +126,7 @@ const Histogram: React.FC<HistogramProps> = ({
                         height: `${(frequencyData[index] / 255) * 100}%`,
                         backgroundColor: 'currentColor',
                         marginRight: index < bars - 1 ? spacing : 0,
-                        transition: random
+                        transition: shouldRandomize
                             ? `height ${interval / 1000}s ease`
                             : 'height 0.05s ease',
                     }}

--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -32,7 +32,7 @@ const Histogram: React.FC<HistogramProps> = ({
 }) => {
     const [frequencyData, setFrequencyData] = useState<Uint8Array>(new Uint8Array(bars));
 
-    const currentAction = useBoundStore((state) => state.currentAction());
+    const currentAction = useBoundStore((state) => state.currentAction);
     const isBuffer = currentAction?.playback?.play_method === 'BUFFER';
 
     const shouldRandomize = random || !isBuffer;

--- a/frontend/src/components/Info/Info.tsx
+++ b/frontend/src/components/Info/Info.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 
 import Button from "../Button/Button";
-import { Info } from "@/types/Action";
+import { Info as InfoAction } from "@/types/Action";
 
-export interface InfoProps extends Info {
+export interface InfoProps extends InfoAction {
     onNext?: () => void;
 }
 

--- a/frontend/src/components/Info/Info.tsx
+++ b/frontend/src/components/Info/Info.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useState } from "react";
 
 import Button from "../Button/Button";
+import { Info } from "@/types/Action";
 
-export interface InfoProps {
-    heading?: string;
-    body: string | TrustedHTML;
-    button_label?: string;
-    button_link?: string;
+export interface InfoProps extends Info {
     onNext?: () => void;
 }
 

--- a/frontend/src/components/ListenCircle/ListenCircle.tsx
+++ b/frontend/src/components/ListenCircle/ListenCircle.tsx
@@ -16,15 +16,7 @@ const ListenCircle = ({
         <>
             <CountDown duration={duration} running={countDownRunning} />
             <div className="aha__histogram-container">
-                <Histogram
-                    running={histogramRunning}
-
-                    // Set random to true (and interval to 200) temporarily to see the animation
-                    // TODO: Remove random and interval props and fix Histogram to always use
-                    // random bars when the audio play_method is not "BUFFER"
-                    random={true}
-                    interval={200}
-                />
+                <Histogram running={histogramRunning} />
             </div>
         </>
     );

--- a/frontend/src/components/MatchingPairs/MatchingPairs.test.tsx
+++ b/frontend/src/components/MatchingPairs/MatchingPairs.test.tsx
@@ -10,17 +10,18 @@ import MatchingPairs, { SCORE_FEEDBACK_DISPLAY } from './MatchingPairs';
 let mock: MockAdapter;
 
 vi.mock("@/components/PlayButton/PlayCard", () => ({
-    default: props => <div data-testid="play-card" {...props} />
+    default: (props: any) => <div data-testid="play-card" {...props} />
 }));
 
 vi.mock("../../util/stores", () => ({
     __esModule: true,
-    default: (fn) => {
+    default: (fn: any) => {
         const state = {
             participant: 1,
             session: 1,
             setError: vi.fn(),
-            block: { bonus_points: 42 }
+            block: { bonus_points: 42 },
+            currentAction: () => ({ view: 'TRIAL_VIEW' }),
         };
         return fn(state);
     },

--- a/frontend/src/components/Playlist/Playlist.tsx
+++ b/frontend/src/components/Playlist/Playlist.tsx
@@ -1,11 +1,10 @@
+import { Playlist as PlaylistAction } from "@/types/Action";
 import Block from "@/types/Block";
-import { MutableRefObject, useEffect } from "react";
+import { useEffect } from "react";
 
-export interface PlaylistProps {
+export interface PlaylistProps extends PlaylistAction {
     block: Block;
-    instruction: string;
     onNext: () => void;
-    playlist: MutableRefObject<string>;
 }
 
 /**

--- a/frontend/src/components/Score/Score.tsx
+++ b/frontend/src/components/Score/Score.tsx
@@ -2,20 +2,9 @@ import { useState, useEffect, useRef } from "react";
 import classNames from "classnames";
 import Circle from "../Circle/Circle";
 import Button from "../Button/Button";
+import { Score } from "@/types/Action";
 
-export interface ScoreProps {
-    last_song?: string;
-    score: number;
-    score_message: string;
-    total_score?: number;
-    texts: {
-        score: string;
-        next: string;
-        listen_explainer: string;
-    };
-    icon?: string;
-    feedback?: string;
-    timer?: number;
+export interface ScoreProps extends Score {
     onNext: () => void;
 }
 

--- a/frontend/src/components/Score/Score.tsx
+++ b/frontend/src/components/Score/Score.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useRef } from "react";
 import classNames from "classnames";
 import Circle from "../Circle/Circle";
 import Button from "../Button/Button";
-import { Score } from "@/types/Action";
+import { Score as ScoreAction } from "@/types/Action";
 
-export interface ScoreProps extends Score {
+export interface ScoreProps extends ScoreAction {
     onNext: () => void;
 }
 

--- a/frontend/src/components/Trial/Trial.test.tsx
+++ b/frontend/src/components/Trial/Trial.test.tsx
@@ -43,7 +43,6 @@ const defaultConfig = {
 describe('Trial', () => {
     const mockOnNext = vi.fn();
     const mockOnResult = vi.fn();
-    const mockMakeResult = vi.fn();
 
     beforeEach(() => {
         vi.clearAllMocks();

--- a/frontend/src/components/Trial/Trial.tsx
+++ b/frontend/src/components/Trial/Trial.tsx
@@ -6,23 +6,11 @@ import FeedbackForm from "../FeedbackForm/FeedbackForm";
 import HTML from "../HTML/HTML";
 import Playback from "../Playback/Playback";
 import Button from "../Button/Button";
-import Question from "@/types/Question";
 import { OnResultType } from "@/hooks/useResultHandler";
 import { TrialConfig } from "@/types/Trial";
-import { PlaybackArgs } from "@/types/Playback";
+import { Trial } from "@/types/Action";
 
-export interface IFeedbackForm {
-    form: Question[];
-    submit_label: string;
-    skip_label: string;
-    is_skippable: boolean;
-}
-
-export interface TrialProps {
-    playback: PlaybackArgs;
-    html: { body: string | TrustedHTML };
-    feedback_form: IFeedbackForm;
-    config: TrialConfig;
+export interface TrialProps extends Trial {
     onNext: (breakRound?: boolean) => void;
     onResult: OnResultType;
 }

--- a/frontend/src/components/Trial/Trial.tsx
+++ b/frontend/src/components/Trial/Trial.tsx
@@ -8,9 +8,9 @@ import Playback from "../Playback/Playback";
 import Button from "../Button/Button";
 import { OnResultType } from "@/hooks/useResultHandler";
 import { TrialConfig } from "@/types/Trial";
-import { Trial } from "@/types/Action";
+import { Trial as TrialAction } from "@/types/Action";
 
-export interface TrialProps extends Trial {
+export interface TrialProps extends TrialAction {
     onNext: (breakRound?: boolean) => void;
     onResult: OnResultType;
 }

--- a/frontend/src/stories/Histogram.stories.tsx
+++ b/frontend/src/stories/Histogram.stories.tsx
@@ -22,7 +22,7 @@ export const Default = {
         borderRadius: "0.15rem",
     },
     decorators: [
-        (Story) => (
+        (Story: any) => (
             <div
                 style={{
                     width: "128px",

--- a/frontend/src/stories/Histogram.stories.tsx
+++ b/frontend/src/stories/Histogram.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import Histogram from "../components/Histogram/Histogram";
 
 const meta: Meta<typeof Histogram> = {
@@ -42,17 +42,16 @@ export const Random = {
     args: {
         bars: 7,
         spacing: 6,
-        interval: 100,
         running: true,
         marginLeft: 0,
         marginTop: 0,
         backgroundColor: undefined,
         borderRadius: "0.15rem",
         random: true,
-        interval: 150,
+        interval: 200,
     },
     decorators: [
-        (Story) => (
+        (Story: StoryFn) => (
             <div
                 style={{
                     width: "128px",

--- a/frontend/src/stories/Playback.stories.tsx
+++ b/frontend/src/stories/Playback.stories.tsx
@@ -18,9 +18,8 @@ export default {
 const createCommonDecorator = (play_method: "BUFFER" | "EXTERNAL") => (Story: StoryFn) => {
     const [initialized, setInitialized] = useState(false);
 
-    const setRound = useBoundStore((state) => state.setRound);
     const setCurrentAction = useBoundStore((state) => state.setCurrentAction);
-    setRound([{
+    setCurrentAction({
         view: "TRIAL_VIEW",
         playback: {
             view: AUTOPLAY,
@@ -32,8 +31,7 @@ const createCommonDecorator = (play_method: "BUFFER" | "EXTERNAL") => (Story: St
             play_from: 0.0,
             resume_play: false,
         }
-    }]);
-    setCurrentAction(0);
+    });
 
     if (!initialized) {
         return (

--- a/frontend/src/stories/Playback.stories.tsx
+++ b/frontend/src/stories/Playback.stories.tsx
@@ -3,6 +3,8 @@ import Playback, { PlaybackProps } from "../components/Playback/Playback";
 import { AUTOPLAY } from "../types/Playback";
 
 import audio from "./assets/music.ogg";
+import useBoundStore from "@/util/stores";
+import { StoryFn } from "@storybook/react";
 
 export default {
     title: "Playback",
@@ -12,55 +14,76 @@ export default {
     },
 };
 
-export const Button = {
-    args: {
-        playbackArgs: {
+// Create a decorator that dynamically accepts a play_method
+const createCommonDecorator = (play_method: "BUFFER" | "EXTERNAL") => (Story: StoryFn) => {
+    const [initialized, setInitialized] = useState(false);
+
+    const setRound = useBoundStore((state) => state.setRound);
+    const setCurrentAction = useBoundStore((state) => state.setCurrentAction);
+    setRound([{
+        view: "TRIAL_VIEW",
+        playback: {
             view: AUTOPLAY,
-            play_method: "BUFFER",
+            play_method,
             show_animation: true,
             preload_message: "Loading audio...",
             instruction: "Click the button to play the audio.",
-            sections: [
-                {
-                    id: 0,
-                    url: audio,
-                }
-            ],
+            sections: [{ id: 0, url: audio }],
             play_from: 0.0,
             resume_play: false,
-        },
-        onPreloadReady: () => { },
-        autoAdvance: false,
-        responseTime: 10,
-        submitResult: () => { },
-        finishedPlaying: () => { },
-    } as PlaybackProps,
-    decorators: [
-        (Story) => {
-
-            const [initialized, setInitialized] = useState(false);
-
-
-            if (!initialized) {
-                return (
-                    <>
-                        <button onClick={() => {
-                            setInitialized(true);
-                        }
-                        }>
-                            Initialize WebAudio
-                        </button>
-                    </>
-                )
-            }
-
-            return (
-                <div
-                    style={{ width: "100%", height: "100%", backgroundColor: "#ddd", padding: "1rem" }}
-                >
-                    <Story />
-                </div>
-            )
         }
-    ],
+    }]);
+    setCurrentAction(0);
+
+    if (!initialized) {
+        return (
+            <>
+                <button onClick={() => setInitialized(true)}>
+                    Initialize WebAudio
+                </button>
+            </>
+        );
+    }
+
+    return (
+        <div
+            style={{ width: "100%", height: "100%", backgroundColor: "#ddd", padding: "1rem" }}
+        >
+            <Story />
+        </div>
+    );
+};
+
+// Create playback arguments dynamically
+const createPlaybackArgs = (play_method: "BUFFER" | "EXTERNAL"): PlaybackProps => ({
+    playbackArgs: {
+        view: AUTOPLAY,
+        play_method,
+        show_animation: true,
+        preload_message: "Loading audio...",
+        instruction: "Click the button to play the audio.",
+        sections: [
+            {
+                id: 0,
+                url: audio,
+            }
+        ],
+        play_from: 0.0,
+        resume_play: false,
+    },
+    onPreloadReady: () => { },
+    autoAdvance: false,
+    responseTime: 10,
+    submitResult: () => { },
+    finishedPlaying: () => { },
+});
+
+export const PlaybackAutoplayBuffer = {
+    args: createPlaybackArgs("BUFFER"),
+    decorators: [createCommonDecorator("BUFFER")],
+};
+
+export const PlaybackAutoplayExternal = {
+    args: createPlaybackArgs("EXTERNAL"),
+    decorators: [createCommonDecorator("EXTERNAL")],
 };

--- a/frontend/src/types/Action.ts
+++ b/frontend/src/types/Action.ts
@@ -1,7 +1,3 @@
-import { LoadingProps } from "@/components/Loading/Loading";
-import { PlaylistProps } from "@/components/Playlist/Playlist";
-import { RedirectProps } from "@/components/Redirect/Redirect";
-import { ScoreProps } from "@/components/Score/Score";
 import Social from "@/types/Social";
 import Block, { FeedbackInfo } from "@/types/Block";
 import Participant from "@/types/Participant";

--- a/frontend/src/types/Action.ts
+++ b/frontend/src/types/Action.ts
@@ -1,11 +1,14 @@
-import { ExplainerProps } from "@/components/Explainer/Explainer";
-import { FinalProps } from "@/components/Final/Final";
-import { InfoProps } from "@/components/Info/Info";
 import { LoadingProps } from "@/components/Loading/Loading";
 import { PlaylistProps } from "@/components/Playlist/Playlist";
 import { RedirectProps } from "@/components/Redirect/Redirect";
 import { ScoreProps } from "@/components/Score/Score";
-import { TrialProps } from "@/components/Trial/Trial";
+import Social from "@/types/Social";
+import Block, { FeedbackInfo } from "@/types/Block";
+import Participant from "@/types/Participant";
+import { PlaybackArgs } from "./Playback";
+import Question from "./Question";
+import { TrialConfig } from "./Trial";
+import { MutableRefObject } from "react";
 
 interface SharedActionProps {
   title?: string;
@@ -13,14 +16,108 @@ interface SharedActionProps {
   style?: object;
 }
 
+interface ExplainerStep {
+  number: number;
+  description: string;
+}
+
+export interface Explainer {
+  instruction: string;
+  button_label: string;
+  steps?: Array<ExplainerStep>;
+  timer: number | null;
+}
+
+export interface Info {
+  heading?: string;
+  body: string | TrustedHTML;
+  button_label?: string;
+  button_link?: string;
+}
+
+export interface IFeedbackForm {
+  form: Question[];
+  submit_label: string;
+  skip_label: string;
+  is_skippable: boolean;
+}
+
+export interface Trial {
+  playback: PlaybackArgs;
+  html: { body: string | TrustedHTML };
+  feedback_form: IFeedbackForm;
+  config: TrialConfig;
+}
+
+export interface Score {
+  last_song?: string;
+  score: number;
+  score_message: string;
+  total_score?: number;
+  texts: {
+    score: string;
+    next: string;
+    listen_explainer: string;
+  };
+  icon?: string;
+  feedback?: string;
+  timer?: number;
+}
+
+export interface Final {
+  block: Block;
+  participant: Participant;
+  score: number;
+  final_text: string | TrustedHTML;
+  action_texts: {
+    all_experiments: string;
+    profile: string;
+    play_again: string;
+  }
+  button: {
+    text: string;
+    link: string;
+  };
+  show_participant_link: boolean;
+  participant_id_only: boolean;
+  show_profile_link: boolean;
+  social: Social;
+  feedback_info?: FeedbackInfo;
+  points: string;
+  rank: {
+    class: string;
+    text: string;
+  }
+  logo: {
+    image: string;
+    link: string;
+  };
+}
+
+export interface Playlist {
+  instruction: string;
+  playlist: MutableRefObject<string>;
+}
+
+export interface Redirect {
+  url: string;
+}
+
+export interface Loading {
+  duration?: number;
+  loadingText?: string;
+}
+
 export type Action = SharedActionProps &
   (
-    | { view: "EXPLAINER" } & ExplainerProps
-    | { view: "INFO" } & InfoProps
-    | { view: "TRIAL_VIEW" } & TrialProps
-    | { view: 'SCORE' } & ScoreProps
-    | { view: 'FINAL' } & FinalProps
-    | { view: 'PLAYLIST' } & PlaylistProps
-    | { view: 'REDIRECT' } & RedirectProps
-    | { view: "LOADING" } & LoadingProps
+    | { view: "EXPLAINER" } & Explainer
+    | { view: "INFO" } & Info
+    | { view: "TRIAL_VIEW" } & Trial
+    | { view: 'SCORE' } & Score
+    | { view: 'FINAL' } & Final
+    | { view: 'PLAYLIST' } & Playlist
+    | { view: 'REDIRECT' } & Redirect
+    | { view: "LOADING" } & Loading
   )
+
+export default Action;

--- a/frontend/src/types/Action.ts
+++ b/frontend/src/types/Action.ts
@@ -1,0 +1,26 @@
+import { ExplainerProps } from "@/components/Explainer/Explainer";
+import { FinalProps } from "@/components/Final/Final";
+import { InfoProps } from "@/components/Info/Info";
+import { LoadingProps } from "@/components/Loading/Loading";
+import { PlaylistProps } from "@/components/Playlist/Playlist";
+import { RedirectProps } from "@/components/Redirect/Redirect";
+import { ScoreProps } from "@/components/Score/Score";
+import { TrialProps } from "@/components/Trial/Trial";
+
+interface SharedActionProps {
+  title?: string;
+  config?: object;
+  style?: object;
+}
+
+export type Action = SharedActionProps &
+  (
+    | { view: "EXPLAINER" } & ExplainerProps
+    | { view: "INFO" } & InfoProps
+    | { view: "TRIAL_VIEW" } & TrialProps
+    | { view: 'SCORE' } & ScoreProps
+    | { view: 'FINAL' } & FinalProps
+    | { view: 'PLAYLIST' } & PlaylistProps
+    | { view: 'REDIRECT' } & RedirectProps
+    | { view: "LOADING" } & LoadingProps
+  )

--- a/frontend/src/types/Round.ts
+++ b/frontend/src/types/Round.ts
@@ -1,0 +1,30 @@
+import { IFeedbackForm } from "@/components/Trial/Trial";
+import { PlaybackArgs } from "./Playback";
+import { TrialConfig } from "./Trial";
+
+export interface Action {
+  view: string;
+
+  // Optional properties depending on the view
+  instruction?: string;
+  button_label?: string;
+  steps?: Array<{
+    number: number;
+    description: string;
+  }>;
+  timer?: number | null;
+  title?: string;
+  config?: TrialConfig;
+  style?: {
+    root: string;
+  };
+  playback?: PlaybackArgs;
+  html?: { body: string | TrustedHTML };
+  feedback_form?: IFeedbackForm;
+}
+
+export type Round = Action[];
+
+export interface RoundResponse {
+  next_round: Round;
+}

--- a/frontend/src/types/Round.ts
+++ b/frontend/src/types/Round.ts
@@ -1,27 +1,4 @@
-import { IFeedbackForm } from "@/components/Trial/Trial";
-import { PlaybackArgs } from "./Playback";
-import { TrialConfig } from "./Trial";
-
-export interface Action {
-  view: string;
-
-  // Optional properties depending on the view
-  instruction?: string;
-  button_label?: string;
-  steps?: Array<{
-    number: number;
-    description: string;
-  }>;
-  timer?: number | null;
-  title?: string;
-  config?: TrialConfig;
-  style?: {
-    root: string;
-  };
-  playback?: PlaybackArgs;
-  html?: { body: string | TrustedHTML };
-  feedback_form?: IFeedbackForm;
-}
+import { Action } from "./Action";
 
 export type Round = Action[];
 

--- a/frontend/src/util/stores.ts
+++ b/frontend/src/util/stores.ts
@@ -97,26 +97,14 @@ const createParticipantSlice: StateCreator<ParticipantSlice> = (set) => ({
     setParticipantLoading: (participantLoading: boolean) => set(() => ({ participantLoading }))
 });
 
-interface RoundSlice {
-    round: Round;
-    setRound: (round: Round) => void;
-    currentActionIndex: number | null;
-    setCurrentAction: (index: number) => void;
-    currentAction: () => Action | null;
+interface ActionSlice {
+    currentAction: Action | null;
+    setCurrentAction: (action: Action) => void;
 }
 
-const createRoundSlice: StateCreator<RoundSlice> = (set, get) => ({
-    round: [],
-    setRound: (round: Round) => set(() => ({ round })),
-    currentActionIndex: null,
-    setCurrentAction: (index: number) => set(() => ({ currentActionIndex: index })),
-    currentAction: () => {
-        const index = get().currentActionIndex;
-        if (index === null) {
-            return null;
-        }
-        return get().round[index];
-    },
+const createActionSlice: StateCreator<ActionSlice> = (set, get) => ({
+    setCurrentAction: (action: Action) => set(() => ({ currentAction: action })),
+    currentAction: null,
 });
 
 interface SessionSlice {
@@ -141,12 +129,12 @@ const createThemeSlice: StateCreator<ThemeSlice> = (set) => ({
     resetTheme: () => set(() => ({ theme: null })),
 });
 
-export const useBoundStore = create<BlockSlice & DocumentHeadSlice & ErrorSlice & ParticipantSlice & RoundSlice & SessionSlice & ThemeSlice>((...args) => ({
+export const useBoundStore = create<BlockSlice & DocumentHeadSlice & ErrorSlice & ParticipantSlice & ActionSlice & SessionSlice & ThemeSlice>((...args) => ({
     ...createBlockSlice(...args),
     ...createDocumentHeadSlice(...args),
     ...createErrorSlice(...args),
     ...createParticipantSlice(...args),
-    ...createRoundSlice(...args),
+    ...createActionSlice(...args),
     ...createSessionSlice(...args),
     ...createThemeSlice(...args),
 }));

--- a/frontend/src/util/stores.ts
+++ b/frontend/src/util/stores.ts
@@ -5,7 +5,7 @@ import IParticipant from "@/types/Participant";
 import ISession from "@/types/Session";
 import ITheme from "@/types/Theme";
 import IBlock from "@/types/Block";
-import { Action, Round } from '@/types/Round';
+import { Action } from '@/types/Action';
 
 interface BlockSlice {
     block?: IBlock;

--- a/frontend/src/util/stores.ts
+++ b/frontend/src/util/stores.ts
@@ -5,6 +5,7 @@ import IParticipant from "@/types/Participant";
 import ISession from "@/types/Session";
 import ITheme from "@/types/Theme";
 import IBlock from "@/types/Block";
+import { Action, Round } from '@/types/Round';
 
 interface BlockSlice {
     block?: IBlock;
@@ -96,6 +97,28 @@ const createParticipantSlice: StateCreator<ParticipantSlice> = (set) => ({
     setParticipantLoading: (participantLoading: boolean) => set(() => ({ participantLoading }))
 });
 
+interface RoundSlice {
+    round: Round;
+    setRound: (round: Round) => void;
+    currentActionIndex: number | null;
+    setCurrentAction: (index: number) => void;
+    currentAction: () => Action | null;
+}
+
+const createRoundSlice: StateCreator<RoundSlice> = (set, get) => ({
+    round: [],
+    setRound: (round: Round) => set(() => ({ round })),
+    currentActionIndex: null,
+    setCurrentAction: (index: number) => set(() => ({ currentActionIndex: index })),
+    currentAction: () => {
+        const index = get().currentActionIndex;
+        if (index === null) {
+            return null;
+        }
+        return get().round[index];
+    },
+});
+
 interface SessionSlice {
     session: ISession | null;
     setSession: (session: ISession) => void;
@@ -118,11 +141,12 @@ const createThemeSlice: StateCreator<ThemeSlice> = (set) => ({
     resetTheme: () => set(() => ({ theme: null })),
 });
 
-export const useBoundStore = create<BlockSlice & DocumentHeadSlice & ErrorSlice & ParticipantSlice & SessionSlice & ThemeSlice>((...args) => ({
+export const useBoundStore = create<BlockSlice & DocumentHeadSlice & ErrorSlice & ParticipantSlice & RoundSlice & SessionSlice & ThemeSlice>((...args) => ({
     ...createBlockSlice(...args),
     ...createDocumentHeadSlice(...args),
     ...createErrorSlice(...args),
     ...createParticipantSlice(...args),
+    ...createRoundSlice(...args),
     ...createSessionSlice(...args),
     ...createThemeSlice(...args),
 }));

--- a/frontend/src/util/stores.ts
+++ b/frontend/src/util/stores.ts
@@ -102,7 +102,7 @@ interface ActionSlice {
     setCurrentAction: (action: Action) => void;
 }
 
-const createActionSlice: StateCreator<ActionSlice> = (set, get) => ({
+const createActionSlice: StateCreator<ActionSlice> = (set) => ({
     setCurrentAction: (action: Action) => set(() => ({ currentAction: action })),
     currentAction: null,
 });

--- a/frontend/src/util/webAudio.ts
+++ b/frontend/src/util/webAudio.ts
@@ -4,7 +4,6 @@ let track: MediaElementAudioSourceNode;
 let source: AudioBufferSourceNode;
 let buffers: { [key: string]: AudioBuffer } = {};
 let audioContext: AudioContext;
-let previousSource: string;
 let analyzer: AnalyserNode;
 
 export let audioInitialized = false;
@@ -97,7 +96,6 @@ export const loadBuffer = async (id: number, src: string, canPlay: () => void) =
         // store buffer in buffers object
         .then(decodedData => {
             buffers[id] = decodedData;
-            previousSource = src;
             canPlay();
         });
 };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
     globals: true,
     environment: 'happy-dom',
+    allowOnly: true,
     coverage: {
       reportsDirectory: 'public/coverage',
       provider: 'v8',


### PR DESCRIPTION
Introduce a new `RoundResponse` type for round management in the Block component, streamline the Action type definition, and enhance the Histogram component with improved randomization logic. Fix various type annotations and update tests to ensure proper functionality.

## What does this PR do?

- It commits the `next_round` data to the `RoundSlice` in the zustand store every time a new round is received from a `next_round` http request.
- It also types the array of actions in `next_round` as "`Round`', which is basically an array of `Action`.
- It also keeps track of the "current action" by setting the index of the current action of the current round in the store.
- This store management of next round & action is currently done in parallel to the way the current round & action(s) are managed in the `Block` component. It has no effect on that functionality. Tracking said data in our zustand store is only used for the `Histogram` component to know whether the current action's section(s) are loaded into the buffer (`AudioContext`) or whether it is loaded externally through the "normal" `Audio` element/API.
- The `Histogram` then uses that information to determine whether it should display actual audio frequency data (only possible through buffer) or random bar data.
  - It will show random data whenever the `random` prop is true, or whenever the current action's section is _not_ played through buffer (aka `!isBuffer`)

## Questions

- Should we now or later convert the whole bookkeeping of round & (current) action(s) to use the zustand store?
- In the `Action` type I now import interfaces (used for different action types) from the components directly. Should I import those into the `Action` type file?
- Should we maybe rename the `next_round` prop in the next round request to `actions`? The http response would then become `{ "actions": [{...}, {...}, {...}] }`, which might make more sense.