### PR TITLE
Move feedback to experimenter dashboard

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -44,14 +44,6 @@ from participant.models import Participant
 from question.models import QuestionSeries, QuestionInSeries
 
 
-class FeedbackInline(admin.TabularInline):
-    """Inline to show results linked to given participant"""
-
-    model = Feedback
-    fields = ["text"]
-    extra = 0
-
-
 class BlockTranslatedContentInline(NestedTabularInline):
     model = BlockTranslatedContent
 
@@ -92,7 +84,7 @@ class BlockAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
         "bonus_points",
         "playlists",
     ]
-    inlines = [QuestionSeriesInline, FeedbackInline, BlockTranslatedContentInline]
+    inlines = [QuestionSeriesInline, BlockTranslatedContentInline]
     form = BlockForm
 
     # make playlists fields a list of checkboxes
@@ -432,9 +424,11 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
         all_blocks = obj.associated_blocks()
         all_participants = obj.current_participants()
         all_sessions = obj.export_sessions()
+        all_feedback = obj.export_feedback()
         collect_data = {
             "participant_count": len(all_participants),
             "session_count": len(all_sessions),
+            "feedback_count": len(all_feedback),
         }
 
         blocks = [
@@ -462,6 +456,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
                 "blocks": blocks,
                 "sessions": all_sessions,
                 "participants": all_participants,
+                'feedback': all_feedback,
                 "collect_data": collect_data,
             },
         )

--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -435,6 +435,7 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, NestedModelAdmin):
             {
                 "id": block.id,
                 "slug": block.slug,
+                "name": block,
                 "started": len(all_sessions.filter(block=block)),
                 "finished": len(
                     all_sessions.filter(

--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -46,6 +46,11 @@ class Experiment(models.Model):
         translated_content = self.get_fallback_content()
         return translated_content.name if translated_content else self.slug
 
+    @property
+    def name(self):
+        content = self.get_fallback_content()
+        return content.name if content and content.name else ""
+
     class Meta:
         verbose_name_plural = "Experiments"
 
@@ -82,6 +87,18 @@ class Experiment(models.Model):
         for session in self.export_sessions():
             participants[session.participant.id] = session.participant
         return participants.values()
+
+    def export_feedback(self) -> QuerySet[Session]:
+        """export feedback for the blocks in this experiment
+
+        Returns:
+            Associated block feedback
+        """
+
+        all_feedback = Feedback.objects.none()
+        for block in self.associated_blocks():
+            all_feedback |= Feedback.objects.filter(block=block)
+        return all_feedback
 
     def get_fallback_content(self) -> "ExperimentTranslatedContent":
         """Get fallback content for the experiment

--- a/backend/experiment/static/experiment_dashboard.js
+++ b/backend/experiment/static/experiment_dashboard.js
@@ -6,6 +6,14 @@ const closeSessions = () => {
     })
 }
 
+// Hide all feedback
+const closeFeedback = () => {
+    document.getElementById("all-feedback").close();
+    document.querySelectorAll(".feedback-row").forEach(function (element) {
+        element.classList.add("hide");
+    })
+}
+
 // Hide all participants
 const closeParticipants = () => {
     document.getElementById("all-participants").close();
@@ -41,6 +49,14 @@ document.getElementById("show-participants").addEventListener("click", () => {
 document.getElementById("show-sessions").addEventListener("click", () => {
     document.getElementById("all-sessions").showModal();
     document.querySelectorAll(".session-row").forEach(function (element) {
+        element.classList.remove("hide");
+    })
+})
+
+// Attach event to show all feedback button
+document.getElementById("show-feedback").addEventListener("click", () => {
+    document.getElementById("all-feedback").showModal();
+    document.querySelectorAll(".feedback-row").forEach(function (element) {
         element.classList.remove("hide");
     })
 })

--- a/backend/experiment/static/experiment_dashboard_feedback.js
+++ b/backend/experiment/static/experiment_dashboard_feedback.js
@@ -1,0 +1,9 @@
+// Show feedback for a specific experiment
+const showBlockFeedback = (id) => {
+    document.getElementById(`show-feedback-${id}`).addEventListener("click", function () {
+        document.querySelectorAll(`.block-${id}`).forEach(function (element) {
+            element.classList.remove("hide");
+        })
+        document.getElementById("all-feedback").showModal();
+    })
+}

--- a/backend/experiment/static/experiment_dashboard_sessions.js
+++ b/backend/experiment/static/experiment_dashboard_sessions.js
@@ -1,7 +1,7 @@
-// Show sessions for a specific experiment
+// Show sessions for a specific block
 const showBlockSessions = (id) => {
     document.getElementById(`show-sessions-${id}`).addEventListener("click", function () {
-        document.querySelectorAll(`.experiment-${id}`).forEach(function (element) {
+        document.querySelectorAll(`.block-${id}`).forEach(function (element) {
             element.classList.remove("hide");
         })
         document.getElementById("all-sessions").showModal();

--- a/backend/experiment/templates/experiment-dashboard-feedback.html
+++ b/backend/experiment/templates/experiment-dashboard-feedback.html
@@ -1,0 +1,19 @@
+<!-- session table -->
+<dialog id="all-feedback" class="pop-up pop-up-big">
+    <h1>Feedback in experiment: {{ experiment.name }}</h1>
+    <input type="button" value="close" onClick="closeFeedback()" autofocus />
+
+    <!-- List and hide all sessions in this experiment with a unique id per block -->
+    <div class="feedback-list">
+        <h2>Feedback</h2>
+        {% for item in feedback %}
+
+            <div class="feedback-row hide block-{{ item.block.id }}">
+                <h3>Feedback for block: {{ item.block.name }}</h3>
+                <p>{{ item.text }}</p>
+            </div>
+
+        {% endfor %}
+        </div>
+    <input type="button" value="close" onClick="closeFeedback()" />
+</dialog>

--- a/backend/experiment/templates/experiment-dashboard-feedback.html
+++ b/backend/experiment/templates/experiment-dashboard-feedback.html
@@ -1,15 +1,20 @@
 <!-- session table -->
 <dialog id="all-feedback" class="pop-up pop-up-big">
-    <h1>Feedback in experiment: {{ experiment.name }}</h1>
+    <h1>
+        Feedback for Experiment: <a href="{% url 'admin:experiment_experiment_change' experiment.id %}" target="_blank">{{ experiment }}</a>
+    </h1>
     <input type="button" value="close" onClick="closeFeedback()" autofocus />
 
     <!-- List and hide all sessions in this experiment with a unique id per block -->
     <div class="feedback-list">
-        <h2>Feedback</h2>
+
         {% for item in feedback %}
 
             <div class="feedback-row hide block-{{ item.block.id }}">
-                <h3>Feedback for block: {{ item.block.name }}</h3>
+                    <h3>
+                        Block: <a href="{% url 'admin:experiment_block_change' item.block.id %}" target="_blank" title="Block URL id">{{ item.block }}</a>
+                    </h3>
+                </a>
                 <p>{{ item.text }}</p>
             </div>
 

--- a/backend/experiment/templates/experiment-dashboard-participants.html
+++ b/backend/experiment/templates/experiment-dashboard-participants.html
@@ -1,6 +1,8 @@
 <!-- Participant table -->
 <dialog id="all-participants" class="pop-up pop-up-big">
-    <h1>All participants in experiment: {{ experiment.name }}</h1>
+    <h1>
+        All participants in Experiment: <a href="{% url 'admin:experiment_experiment_change' experiment.id %}" target="_blank">{{ experiment }}</a>
+    </h1>
     <input type="button" value="close" onClick="closeParticipants()" autofocus />
     <table>
         <caption class="dashboard-caption">Participants</caption>

--- a/backend/experiment/templates/experiment-dashboard-participants.html
+++ b/backend/experiment/templates/experiment-dashboard-participants.html
@@ -1,8 +1,9 @@
 <!-- Participant table -->
 <dialog id="all-participants" class="pop-up pop-up-big">
-    <h1>All Participants in experiment: {{ experiment.name }}</h1>
+    <h1>All participants in experiment: {{ experiment.name }}</h1>
     <input type="button" value="close" onClick="closeParticipants()" autofocus />
     <table>
+        <caption class="dashboard-caption">Participants</caption>
         <thead>
             <tr>
                 <th>Participant URL id *</th>

--- a/backend/experiment/templates/experiment-dashboard-sessions.html
+++ b/backend/experiment/templates/experiment-dashboard-sessions.html
@@ -1,6 +1,8 @@
 <!-- session table -->
 <dialog id="all-sessions" class="pop-up pop-up-big">
-    <h1>Sessions in experiment: {{ experiment.name }}</h1>
+    <h1>
+        Sessions in experiment: <a href="{% url 'admin:experiment_experiment_change' experiment.id %}" target="_blank">{{ experiment }}</a>
+    </h1>
     <input type="button" value="close" onClick="closeSessions()" autofocus />
     <table>
         <caption class="dashboard-caption">Sessions</caption>
@@ -25,13 +27,14 @@
                     <td>
                         <p>
                             <a href="{% url 'admin:session_session_change' session.id %}" target="_blank">
-                            {{ session.id }}</a>
+                                {{ session.id }}
+                            </a>
                         </p>
                     </td>
 
                     <td>
                         <p>
-                            {{ session.block.slug }}
+                            {{ session.block }}
                         </p>
                     </td>
 
@@ -95,7 +98,7 @@
                         <h3>
                             Session: <a href="{% url 'admin:session_session_change' session.id %}" target="_blank">{{ session.id }}</a><br>
                             Participant: <a href="{% url 'admin:participant_participant_change' session.participant.id %}" target="_blank">{{ session.participant.participant_id_url }}</a><br>
-                            Block: {{ session.block.slug }}
+                            Block: <a href="{% url 'admin:experiment_block_change' session.block.id %}" target="_blank" title="Block URL id">{{ session.block }}</a>
                         </h3>
 
                         <pre>

--- a/backend/experiment/templates/experiment-dashboard-sessions.html
+++ b/backend/experiment/templates/experiment-dashboard-sessions.html
@@ -1,5 +1,6 @@
 <!-- session table -->
 <dialog id="all-sessions" class="pop-up pop-up-big">
+    <h1>Sessions in experiment: {{ experiment.name }}</h1>
     <input type="button" value="close" onClick="closeSessions()" autofocus />
     <table>
         <caption class="dashboard-caption">Sessions</caption>
@@ -19,7 +20,7 @@
         <tbody>
             <!-- List and hide all sessions in this experiment with a unique id per block -->
             {% for session in sessions %}
-                <tr class="session-row hide experiment-{{ session.block.id }} participant-session-{{ session.participant.id }}">
+                <tr class="session-row hide block-{{ session.block.id }} participant-session-{{ session.participant.id }}">
 
                     <td>
                         <p>

--- a/backend/experiment/templates/experiment-dashboard.html
+++ b/backend/experiment/templates/experiment-dashboard.html
@@ -1,5 +1,6 @@
 {% extends "admin/base_site.html" %} {% block content %}{% load static %}
 <script src="{% static 'experiment_dashboard_sessions.js' %}"></script>
+<script src="{% static 'experiment_dashboard_feedback.js' %}"></script>
 <style>
     input {
         margin-right: 1rem;
@@ -14,6 +15,10 @@
     }
     #all-sessions tr {
         background-color: var(--body-bg)
+    }
+    #all-feedback p {
+        font-weight: 400;
+        background-color: var(--darkened-bg)
     }
     td, th {
         vertical-align: middle;
@@ -61,13 +66,11 @@
     }
     .pop-up-big {
         top: 4.2rem;
-        left: 10vw;
         width: calc(80vw - 34px);
         height: 80vh;
     }
     .pop-up-small {
         top: 6.2rem;
-        left: 12vw;
         width: calc(76vw - 51px);
         height: 70vh;
         z-index: 1;
@@ -89,6 +92,28 @@
         background: var(--button-fg);
         color: var(--button-bg);
     }
+    .feedback-list {
+        margin-top: 4rem;
+    }
+    .feedback-row {
+        width: 66%;
+        margin: 1rem auto 0px auto;
+        padding: 1rem;
+        border-radius: 1rem;
+        background-color: var(--darkened-bg);
+    }
+    .feedback-list h2 {
+        font-size: 0.875rem;
+        color: var(--body-fg);
+        font-weight: 600;
+        text-align: center;
+    }
+    .feedback-row h3 {
+        color: var(--body-fg);
+        font-weight: 600;
+        text-align: left;
+        margin-bottom: 1rem;
+    }
 </style>
 
 <h1>Blocks in Experiment: {{ experiment.name }}</h1>
@@ -97,6 +122,7 @@
         <!-- Show all participants and sessions -->
         <input type="button" value="{{ collect_data.participant_count }} participants" id="show-participants" />
         <input type="button" value="{{ collect_data.session_count }} sessions" id="show-sessions" />
+        <input type="button" value="{{ collect_data.feedback_count }} feedback" id="show-feedback" />
     </form>
 </p>
 
@@ -111,6 +137,7 @@
             <th>Participant count</th>
             <th>Participants *</th>
             <th>Sessions</th>
+            <th>Feedback</th>
         </tr>
     </thead>
 
@@ -163,6 +190,14 @@
                 </script>
             </td>
 
+            <td class="table=feedback">
+                <input type="button" value="Feedback" id="show-feedback-{{ block.id }}" />
+                <script>
+                    // Show all session for this block in popup
+                    showBlockFeedback({{ block.id }})
+                </script>
+            </td>
+
         </tr>
         {% endfor %}
     </tbody>
@@ -172,6 +207,8 @@
 {% include "experiment-dashboard-sessions.html" %}
 
 {% include "experiment-dashboard-participants.html" %}
+
+{% include "experiment-dashboard-feedback.html" %}
 
 <script src="{% static 'experiment_dashboard.js' %}"></script>
 {% endblock %}

--- a/backend/experiment/templates/experiment-dashboard.html
+++ b/backend/experiment/templates/experiment-dashboard.html
@@ -50,12 +50,11 @@
     }
     .pop-up {
         background-color: var(--body-bg);
-        box-shadow: 0px 0px 10px var(--primary);
+        box-shadow: 0px 0px 10px var(--body-quiet-color);
         position: fixed;
-
         padding: 2rem;
         border-style: solid;
-        border-color: var(--primary);
+        border-color: var(--body-quiet-color);
         border-width: 1px;
         border-radius: 1px;
         overflow-y: scroll;
@@ -116,7 +115,9 @@
     }
 </style>
 
-<h1>Blocks in Experiment: {{ experiment.name }}</h1>
+<h1>
+    Blocks in Experiment: <a href="{% url 'admin:experiment_experiment_change' experiment.id %}" target="_blank">{{ experiment }}</a>
+</h1>
 <p>
     <form action="" method="post">
         <!-- Show all participants and sessions -->
@@ -147,7 +148,9 @@
         <tr>
             <td>
                 <p>
-                    {{ block.slug }}
+                    <a href="{% url 'admin:experiment_block_change' block.id %}" target="_blank" title="Block URL id">
+                            {{ block.name }}
+                    </a>
                 </p>
             </td>
 


### PR DESCRIPTION
This PR moves the feedback from the Block admin, where it could be edited, to the Experimenter dashboard, where it's read only.

closes: #1381 