### PR TITLE
Use buffers object to check wether a section has already been loaded

### DIFF
--- a/frontend/src/components/Preload/Preload.tsx
+++ b/frontend/src/components/Preload/Preload.tsx
@@ -46,17 +46,15 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
 
                 sections.forEach((section, index) => {
 
+                    // skip Preload if the section has already been loaded in the previous action
+                    if (webAudio.checkSectionLoaded(section) && sections.length === 1) {
+                        setAudioAvailable(true);
+                        return;
+                    }
+
                     // Clear buffers if this is the first section
                     if (index === 0) {
                         webAudio.clearBuffers();
-                    }
-
-                    // skip Preload if the section has already been loaded in the previous action
-                    if (webAudio.checkSectionLoaded(section)) {
-                        if (index === (sections.length - 1)) {
-                            setAudioAvailable(true);
-                        }
-                        return;
                     }
 
                     // Load sections in buffer

--- a/frontend/src/components/Preload/Preload.tsx
+++ b/frontend/src/components/Preload/Preload.tsx
@@ -46,17 +46,17 @@ const Preload = ({ sections, playMethod, duration, preloadMessage, pageTitle, on
 
                 sections.forEach((section, index) => {
 
+                    // Clear buffers if this is the first section
+                    if (index === 0) {
+                        webAudio.clearBuffers();
+                    }
+
                     // skip Preload if the section has already been loaded in the previous action
                     if (webAudio.checkSectionLoaded(section)) {
                         if (index === (sections.length - 1)) {
                             setAudioAvailable(true);
                         }
                         return;
-                    }
-
-                    // Clear buffers if this is the first section
-                    if (index === 0) {
-                        webAudio.clearBuffers();
                     }
 
                     // Load sections in buffer

--- a/frontend/src/util/webAudio.ts
+++ b/frontend/src/util/webAudio.ts
@@ -103,7 +103,7 @@ export const loadBuffer = async (id: number, src: string, canPlay: () => void) =
 };
 
 export const checkSectionLoaded = (section: Section) => {
-    if (section.url === previousSource) {
+    if (buffers.hasOwnProperty(section.id)) {
         return true;
     };
 };


### PR DESCRIPTION
This PR fixes the bug that occurs when you play `matching_pairs_lite` for the second time (via the dashboard) with 8 originals.

When the sections are loaded the buffer list gets cleared before loading the first section.
we used `previousSource`  to determine wether a section had already been loaded. 
A section might still be loaded, but if it isn't added to the `buffers` object, it will not be passed on to matching pairs.

I now changed this it to checking the `buffers` object to check if a section has been loaded. 

Fixes: #1368 