### PR TITLE
Fixed(redirect): Update play again URL format to include '/block' prefix

### DIFF
--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -54,7 +54,7 @@ class Base(object):
             if session.participant.participant_id_url
             else ""
         )
-        return f"/{session.block.slug}{participant_id_url_param}"
+        return f"/block/{session.block.slug}{participant_id_url_param}"
 
     def calculate_intermediate_score(self, session, result):
         """process result data during a trial (i.e., between next_round calls)

--- a/backend/experiment/rules/tests/test_base.py
+++ b/backend/experiment/rules/tests/test_base.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
-from django.conf import settings
-from experiment.models import Experiment, Phase, Block, ExperimentTranslatedContent, SocialMediaConfig
+from experiment.models import Block
 from session.models import Session
 from participant.models import Participant
 from section.models import Playlist
@@ -8,7 +7,6 @@ from ..base import Base
 
 
 class BaseTest(TestCase):
-
     def test_get_play_again_url(self):
         block = Block.objects.create(
             slug="music-lab",
@@ -19,7 +17,7 @@ class BaseTest(TestCase):
         )
         base = Base()
         play_again_url = base.get_play_again_url(session)
-        self.assertEqual(play_again_url, "/music-lab")
+        self.assertEqual(play_again_url, "/block/music-lab")
 
     def test_get_play_again_url_with_participant_id(self):
         block = Block.objects.create(
@@ -34,7 +32,7 @@ class BaseTest(TestCase):
         )
         base = Base()
         play_again_url = base.get_play_again_url(session)
-        self.assertEqual(play_again_url, "/music-lab?participant_id=42")
+        self.assertEqual(play_again_url, "/block/music-lab?participant_id=42")
 
     def test_validate_playlist(self):
         base = Base()


### PR DESCRIPTION
Adjust the play again URL to ensure it includes the '/block' prefix for proper routing.

Resolves #1389 although we might want to discuss desired behavior in the nearby future