### PR TITLE
Docs: Update client references, add MkDocs build, and refactor social media serialization

### DIFF
--- a/backend/experiment/actions/consent.py
+++ b/backend/experiment/actions/consent.py
@@ -56,7 +56,7 @@ class Consent(BaseAction):  # pylint: disable=too-few-public-methods
                     MARKDOWN: Allowed tags: Markdown language
 
     Note:
-        Relates to client component: Consent.js
+        Relates to client component: Consent.tsx
     """
 
     # default consent text, that can be used for multiple blocks
@@ -73,7 +73,9 @@ class Consent(BaseAction):  # pylint: disable=too-few-public-methods
                 amet, nec te atqui scribentur. Diam molestie posidonium te sit, \
                 ea sea expetenda suscipiantur contentiones."
 
-    def __init__(self, text: File, title: str="Informed consent", confirm: str="I agree", deny: str="Stop", url: str="") -> dict:
+    def __init__(
+        self, text: File, title: str = "Informed consent", confirm: str = "I agree", deny: str = "Stop", url: str = ""
+    ) -> dict:
         # Determine which text to use
         if text != "":
             # Uploaded consent via file field: block.consent (High priority)

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -1,6 +1,5 @@
 from django.utils.translation import gettext_lazy as _
-from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Optional, Dict, TypedDict
 
 from experiment.serializers import serialize_social_media_config, SocialMediaConfigResponse
 from session.models import Session
@@ -8,8 +7,7 @@ from session.models import Session
 from .base_action import BaseAction
 
 
-@dataclass
-class ButtonResponse:
+class ButtonResponse(TypedDict):
     """
     Button configuration for an optional call-to-action button.
 
@@ -22,8 +20,7 @@ class ButtonResponse:
     link: str
 
 
-@dataclass
-class LogoResponse:
+class LogoResponse(TypedDict):
     """
     Logo configuration for branding or visual identification on the final screen.
 
@@ -36,8 +33,7 @@ class LogoResponse:
     link: str
 
 
-@dataclass
-class FinalActionResponse:
+class FinalActionResponse(TypedDict):
     """
     FinalActionResponse represents the structure of the final action data.
 
@@ -158,26 +154,26 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             self.points = points
 
     def action(self) -> FinalActionResponse:
-        return FinalActionResponse(
-            view=self.ID,
-            score=self.total_score,
-            rank=self.rank,
-            final_text=self.final_text,
-            button=self.button,
-            points=self.points,
-            action_texts={
+        return {
+            "view": self.ID,
+            "score": self.total_score,
+            "rank": self.rank,
+            "final_text": self.final_text,
+            "button": self.button,
+            "points": self.points,
+            "action_texts": {
                 "play_again": _("Play again"),
                 "profile": _("My profile"),
                 "all_experiments": _("All experiments"),
             },
-            title=self.title,
-            social=self.get_social_media_config(self.session),
-            show_profile_link=self.show_profile_link,
-            show_participant_link=self.show_participant_link,
-            feedback_info=self.feedback_info,
-            participant_id_only=self.show_participant_id_only,
-            logo=self.logo,
-        )
+            "title": self.title,
+            "social": self.get_social_media_config(self.session),
+            "show_profile_link": self.show_profile_link,
+            "show_participant_link": self.show_participant_link,
+            "feedback_info": self.feedback_info,
+            "participant_id_only": self.show_participant_id_only,
+            "logo": self.logo,
+        }
 
     def get_social_media_config(self, session: Session) -> Optional[SocialMediaConfigResponse]:
         experiment = session.block.phase.experiment

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -1,13 +1,13 @@
 from django.utils.translation import gettext_lazy as _
 from typing import Optional, Dict, TypedDict
 
-from experiment.serializers import serialize_social_media_config, SocialMediaConfigResponse
+from experiment.serializers import serialize_social_media_config, SocialMediaConfigConfiguration
 from session.models import Session
 
 from .base_action import BaseAction
 
 
-class ButtonResponse(TypedDict):
+class ButtonConfiguration(TypedDict):
     """
     Button configuration for an optional call-to-action button.
 
@@ -20,7 +20,7 @@ class ButtonResponse(TypedDict):
     link: str
 
 
-class LogoResponse(TypedDict):
+class LogoConfiguration(TypedDict):
     """
     Logo configuration for branding or visual identification on the final screen.
 
@@ -34,40 +34,20 @@ class LogoResponse(TypedDict):
 
 
 class FinalActionResponse(TypedDict):
-    """
-    FinalActionResponse represents the structure of the final action data.
-
-    Attributes:
-        view (str): A string identifying the view type, usually "FINAL".
-        score (float): The participant’s final numeric score at the end of the experiment or session.
-        rank (Optional[str]): The participant’s performance rank (e.g., "GOLD", "SILVER") or None if no rank is determined.
-        final_text (Optional[str]): A concluding message encouraging sharing, replaying, or reflecting on the results.
-        button (Optional[ButtonResponse]): Configuration for an optional call-to-action button.
-        points (str): The label for the scoring unit (e.g., "points"), typically localized.
-        action_texts (Dict[str, str]): A dictionary of localized strings for various interactive elements.
-        title (str): The title displayed prominently on the final screen, typically summarizing the result.
-        social (Optional[SocialMediaConfigResponse]): Configuration for social media sharing.
-        show_profile_link (bool): Whether to display a link to the participant's profile.
-        show_participant_link (bool): Whether to show a participant-related link or data.
-        feedback_info (Optional[Dict[str, str]]): Additional details enabling a feedback section.
-        participant_id_only (bool): If True, only display the participant ID without linking it.
-        logo (Optional[LogoResponse]): Optional logo configuration for branding.
-    """
-
     view: str
     score: float
     rank: Optional[str]
     final_text: Optional[str]
-    button: Optional[ButtonResponse]
+    button: Optional[ButtonConfiguration]
     points: str
     action_texts: Dict[str, str]
     title: str
-    social: Optional[SocialMediaConfigResponse]
+    social: Optional[SocialMediaConfigConfiguration]
     show_profile_link: bool
     show_participant_link: bool
     feedback_info: Optional[Dict[str, str]]
     participant_id_only: bool
-    logo: Optional[LogoResponse]
+    logo: Optional[LogoConfiguration]
 
 
 class Final(BaseAction):  # pylint: disable=too-few-public-methods
@@ -88,7 +68,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         session (Session): The current session object associated with the participant.
         title (str): The title displayed at the top of the final view. Defaults to a localized "Final score".
         final_text (Optional[str]): An optional concluding message (e.g., "Thanks for participating!").
-        button (Optional[ButtonResponse]): Optional call-to-action button configuration. For example:
+        button (Optional[ButtonConfiguration]): Optional call-to-action button configuration. For example:
                                             {"text": "Play again", "link": "/{experiment_slug}"}.
         points (Optional[str]): The label for the score units (e.g., "points"). Defaults to a localized "points".
         rank (Optional[str]): The participant's rank (e.g., "GOLD"). If not provided, no rank is displayed.
@@ -98,7 +78,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         feedback_info (Optional[Dict[str, str]]): Optional dictionary containing feedback-related data. For example:
                                                   {"header": "Feedback", "prompt": "Tell us what you think", "button_text": "Submit"}.
         total_score (Optional[float]): Explicit final score. If None, this is derived from the session.
-        logo (Optional[LogoResponse]): Optional logo configuration for branding. For example:
+        logo (Optional[LogoConfiguration]): Optional logo configuration for branding. For example:
                                         {"image": "/static/logo.png", "link": "https://example.com"}.
 
     Note:
@@ -122,7 +102,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         session: Session,
         title: str = _("Final score"),
         final_text: Optional[str] = None,
-        button: Optional[ButtonResponse] = None,
+        button: Optional[ButtonConfiguration] = None,
         points: Optional[str] = None,
         rank: Optional[str] = None,
         show_profile_link: bool = False,
@@ -130,7 +110,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         show_participant_id_only: bool = False,
         feedback_info: Optional[Dict[str, str]] = None,
         total_score: Optional[float] = None,
-        logo: Optional[LogoResponse] = None,
+        logo: Optional[LogoConfiguration] = None,
     ):
         self.session = session
         self.title = title
@@ -175,7 +155,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             "logo": self.logo,
         }
 
-    def get_social_media_config(self, session: Session) -> Optional[SocialMediaConfigResponse]:
+    def get_social_media_config(self, session: Session) -> Optional[SocialMediaConfigConfiguration]:
         experiment = session.block.phase.experiment
         if hasattr(experiment, "social_media_config") and experiment.social_media_config:
             return serialize_social_media_config(experiment.social_media_config, session.total_score())

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 from dataclasses import dataclass
 from typing import Optional, Dict
 
-from experiment.serializers import serialize_social_media_config, SocialMediaConfigDto
+from experiment.serializers import serialize_social_media_config, SocialMediaConfigResponse
 from session.models import Session
 
 from .base_action import BaseAction
@@ -50,7 +50,7 @@ class FinalActionResponse:
         points (str): The label for the scoring unit (e.g., "points"), typically localized.
         action_texts (Dict[str, str]): A dictionary of localized strings for various interactive elements.
         title (str): The title displayed prominently on the final screen, typically summarizing the result.
-        social (Optional[SocialMediaConfigDto]): Configuration for social media sharing.
+        social (Optional[SocialMediaConfigResponse]): Configuration for social media sharing.
         show_profile_link (bool): Whether to display a link to the participant's profile.
         show_participant_link (bool): Whether to show a participant-related link or data.
         feedback_info (Optional[Dict[str, str]]): Additional details enabling a feedback section.
@@ -66,7 +66,7 @@ class FinalActionResponse:
     points: str
     action_texts: Dict[str, str]
     title: str
-    social: Optional[SocialMediaConfigDto]
+    social: Optional[SocialMediaConfigResponse]
     show_profile_link: bool
     show_participant_link: bool
     feedback_info: Optional[Dict[str, str]]
@@ -179,17 +179,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             logo=self.logo,
         )
 
-    def get_social_media_config(self, session: Session) -> Optional[SocialMediaConfigDto]:
-        """
-        Retrieve social media configuration related to the experiment.
-
-        Args:
-            session (Session): The current participant's session object.
-
-        Returns:
-            Optional[SocialMediaConfigDto]: Social media configuration for sharing results.
-            Returns None if no configuration is available.
-        """
+    def get_social_media_config(self, session: Session) -> Optional[SocialMediaConfigResponse]:
         experiment = session.block.phase.experiment
         if hasattr(experiment, "social_media_config") and experiment.social_media_config:
             return serialize_social_media_config(experiment.social_media_config, session.total_score())

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -1,45 +1,174 @@
 from django.utils.translation import gettext_lazy as _
+from typing import TypedDict
 
-from experiment.serializers import serialize_social_media_config
+from experiment.serializers import serialize_social_media_config, SocialMediaConfigDto
 from session.models import Session
 
 from .base_action import BaseAction
 
 
+class ButtonDto(TypedDict):
+    """
+    Button configuration for an optional call-to-action button.
+
+    Attributes:
+        text (str): The text displayed on the button.
+        link (str): The URL or path to navigate to when the button is clicked.
+    """
+
+    text: str
+    link: str
+
+
+class LogoDto(TypedDict):
+    """
+    Logo configuration for branding or visual identification on the final screen.
+
+    Attributes:
+        image (str): The URL of the logo image to display.
+        link (str): The URL to navigate to when the logo is clicked.
+    """
+
+    image: str
+    link: str
+
+
+class FinalActionDto(TypedDict):
+    """
+    FinalActionDto represents the structure of the final action data transfer object.
+
+    Attributes:
+        view (str): A string identifying the view type, usually "FINAL".
+        score (float): The participant’s final numeric score at the end of the experiment or session.
+        rank (str | None): The participant’s performance rank (e.g., "GOLD", "SILVER") or None if no rank is determined.
+        final_text (str | None): A concluding message encouraging sharing, replaying, or reflecting on the results.
+        button (ButtonDto | None): Configuration for an optional call-to-action button.
+                                   For example: {"text": "Play again", "link": "/{experiment_slug}"}.
+        points (str): The label for the scoring unit (e.g., "points"), typically localized.
+        action_texts (dict): A dictionary of localized strings for various interactive elements. Typically includes:
+                             - "play_again": _("Play again")
+                             - "profile": _("My profile")
+                             - "all_experiments": _("All experiments")
+        title (str): The title displayed prominently on the final screen, typically summarizing the result (e.g., "Final score").
+        social (SocialMediaConfigDto | None): Configuration for social media sharing. If present, it specifies channels,
+                                              content, and links for participants to share their results.
+        show_profile_link (bool): Whether to display a link to the participant's profile.
+        show_participant_link (bool): Whether to show a participant-related link or data.
+        feedback_info (dict | None): Additional details enabling a feedback section where participants can leave remarks or questions.
+        participant_id_only (bool): If True, only display the participant ID without linking it, for a more anonymized final screen.
+        logo (LogoDto | None): Optional logo configuration for branding. For example:
+                               {"image": "/static/logo.png", "link": "https://example.com"}.
+    """
+
+    view: str
+    score: float
+    rank: str | None
+    final_text: str | None
+    button: ButtonDto | None
+    points: str
+    action_texts: dict
+    title: str
+    social: SocialMediaConfigDto | None
+    show_profile_link: bool
+    show_participant_link: bool
+    feedback_info: dict | None
+    participant_id_only: bool
+    logo: LogoDto | None
+
+
 class Final(BaseAction):  # pylint: disable=too-few-public-methods
     """
-    Provide data for a final view
+    Provide data for a "final" view, typically shown at the end of an experiment or session.
 
-    Relates to client component: Final.js
+    This view displays the participant's final score and, optionally, their rank or performance category.
+    It can also present navigation elements, such as a "Play again" button or links to other parts of the site.
+    Branding elements like a logo or social sharing options can be included to enhance user engagement.
+    A feedback section may also be provided if `feedback_info` is supplied.
+
+    The returned data aligns with `FinalActionDto`, ensuring type consistency and making the structure
+    clear for both developers and documentation readers. It can be consumed by a frontend component
+    (e.g.,
+    [Final.tsx](https://amsterdam-music-lab.github.io/MUSCLE/storybook/?path=/story/final--default)) to render the final screen.
+
+    Args:
+        session (Session): The current session object associated with the participant.
+        title (str): The title displayed at the top of the final view. Defaults to a localized "Final score".
+        final_text (str): An optional concluding message (e.g., "Thanks for participating!").
+        button (ButtonDto): Optional call-to-action button configuration. For example:
+                            {"text": "Play again", "link": "/{experiment_slug}"}.
+        points (str): The label for the score units (e.g., "points"). Defaults to a localized "points".
+        rank (str): The participant's rank (e.g., "GOLD"). If not provided, no rank is displayed.
+        show_profile_link (bool): If True, display a link to the participant's profile.
+        show_participant_link (bool): If True, display a participant-related link or information.
+        show_participant_id_only (bool): If True, only the participant ID is shown, without a link.
+        feedback_info (dict): Optional dictionary containing feedback-related data. For example:
+                              {"header": "Feedback", "prompt": "Tell us what you think", "button_text": "Submit"}.
+        total_score (float): Explicit final score. If None, this is derived from the session.
+        logo (LogoDto): Optional logo configuration for branding. For example:
+                        {"image": "/static/logo.png", "link": "https://example.com"}.
+
+    Attributes:
+        session (Session): The session object for the current participant.
+        title (str): The title for the final view.
+        final_text (str): A concluding message for the participant.
+        button (ButtonDto): Configuration for an optional CTA button.
+        rank (str): The participant's performance rank.
+        show_profile_link (bool): Whether to show a profile link.
+        show_participant_link (bool): Whether to show participant-related data.
+        show_participant_id_only (bool): Whether only to display the participant ID.
+        feedback_info (dict): Information for a feedback section.
+        logo (LogoDto): Configuration for a logo displayed in the final view.
+        total_score (float): The participant’s final score.
+        points (str): Label for the scoring unit.
+
+    Note:
+        The `action()` method returns a `FinalActionDto` that can be consumed by the frontend
+        to render the final screen.
     """
 
-    ID = 'FINAL'
+    ID = "FINAL"
 
     RANKS = {
-        'PLASTIC': {'text': _('plastic'), 'class': 'plastic'},
-        'BRONZE':  {'text': _('bronze'), 'class': 'bronze'},
-        'SILVER': {'text': _('silver'), 'class': 'silver'},
-        'GOLD': {'text': _('gold'), 'class': 'gold'},
-        'PLATINUM': {'text': _('platinum'), 'class': 'platinum'},
-        'DIAMOND': {'text': _('diamond'), 'class': 'diamond'}
+        "PLASTIC": {"text": _("plastic"), "class": "plastic"},
+        "BRONZE": {"text": _("bronze"), "class": "bronze"},
+        "SILVER": {"text": _("silver"), "class": "silver"},
+        "GOLD": {"text": _("gold"), "class": "gold"},
+        "PLATINUM": {"text": _("platinum"), "class": "platinum"},
+        "DIAMOND": {"text": _("diamond"), "class": "diamond"},
     }
 
     def __init__(
         self,
         session: Session,
         title: str = _("Final score"),
-        final_text: str = None,
-        button: dict = None,
-        points: str = None,
-        rank: str = None,
+        final_text: str | None = None,
+        button: ButtonDto | None = None,
+        points: str | None = None,
+        rank: str | None = None,
         show_profile_link: bool = False,
         show_participant_link: bool = False,
         show_participant_id_only: bool = False,
-        feedback_info: dict = None,
-        total_score: float = None,
-        logo: dict = None,
+        feedback_info: dict | None = None,
+        total_score: float | None = None,
+        logo: LogoDto | None = None,
     ):
+        """
+        Initialize the final action data.
 
+        Args:
+            session (Session): The current participant's session.
+            title (str, optional): The final view's title. Defaults to "Final score".
+            final_text (str, optional): Concluding message text. Defaults to None.
+            button (ButtonDto, optional): CTA button configuration. Defaults to None.
+            points (str, optional): Label for points. Defaults to "points".
+            rank (str, optional): Participant's rank (e.g., 'GOLD'). Defaults to None.
+            show_profile_link (bool, optional): Show profile link if True. Defaults to False.
+            show_participant_link (bool, optional): Show participant data link if True. Defaults to False.
+            show_participant_id_only (bool, optional): Show only participant ID if True. Defaults to False.
+            feedback_info (dict, optional): Feedback data. Defaults to None.
+            total_score (float, optional): Explicit score. If None, derived from session. Defaults to None.
+            logo (LogoDto, optional): Logo configuration. Defaults to None.
+        """
         self.session = session
         self.title = title
         self.final_text = final_text
@@ -50,17 +179,24 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         self.show_participant_id_only = show_participant_id_only
         self.feedback_info = feedback_info
         self.logo = logo
+
         if total_score is None:
             self.total_score = self.session.total_score()
         else:
             self.total_score = total_score
+
         if points is None:
             self.points = _("points")
         else:
             self.points = points
 
-    def action(self):
-        """Get data for final action"""
+    def action(self) -> FinalActionDto:
+        """
+        Get the final action data for rendering the final view.
+
+        Returns:
+            FinalActionDto: The final action data serialized for the client.
+        """
         return {
             "view": self.ID,
             "score": self.total_score,
@@ -82,12 +218,17 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             "logo": self.logo,
         }
 
-    def get_social_media_config(self, session: Session) -> dict:
+    def get_social_media_config(self, session: Session) -> SocialMediaConfigDto | None:
+        """
+        Retrieve social media configuration related to the experiment.
+
+        Args:
+            session (Session): The current participant's session object.
+
+        Returns:
+            SocialMediaConfigDto | None: Social media configuration for sharing results.
+            Returns None if no configuration is available.
+        """
         experiment = session.block.phase.experiment
-        if (
-            hasattr(experiment, "social_media_config")
-            and experiment.social_media_config
-        ):
-            return serialize_social_media_config(
-                experiment.social_media_config, session.total_score()
-            )
+        if hasattr(experiment, "social_media_config") and experiment.social_media_config:
+            return serialize_social_media_config(experiment.social_media_config, session.total_score())

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -107,20 +107,6 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         logo (LogoDto): Optional logo configuration for branding. For example:
                         {"image": "/static/logo.png", "link": "https://example.com"}.
 
-    Attributes:
-        session (Session): The session object for the current participant.
-        title (str): The title for the final view.
-        final_text (str): A concluding message for the participant.
-        button (ButtonDto): Configuration for an optional CTA button.
-        rank (str): The participant's performance rank.
-        show_profile_link (bool): Whether to show a profile link.
-        show_participant_link (bool): Whether to show participant-related data.
-        show_participant_id_only (bool): Whether only to display the participant ID.
-        feedback_info (dict): Information for a feedback section.
-        logo (LogoDto): Configuration for a logo displayed in the final view.
-        total_score (float): The participant’s final score.
-        points (str): Label for the scoring unit.
-
     Note:
         The `action()` method returns a `FinalActionDto` that can be consumed by the frontend
         to render the final screen.
@@ -152,23 +138,6 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         total_score: float | None = None,
         logo: LogoDto | None = None,
     ):
-        """
-        Initialize the final action data.
-
-        Args:
-            session (Session): The current participant's session.
-            title (str, optional): The final view's title. Defaults to "Final score".
-            final_text (str, optional): Concluding message text. Defaults to None.
-            button (ButtonDto, optional): CTA button configuration. Defaults to None.
-            points (str, optional): Label for points. Defaults to "points".
-            rank (str, optional): Participant's rank (e.g., 'GOLD'). Defaults to None.
-            show_profile_link (bool, optional): Show profile link if True. Defaults to False.
-            show_participant_link (bool, optional): Show participant data link if True. Defaults to False.
-            show_participant_id_only (bool, optional): Show only participant ID if True. Defaults to False.
-            feedback_info (dict, optional): Feedback data. Defaults to None.
-            total_score (float, optional): Explicit score. If None, derived from session. Defaults to None.
-            logo (LogoDto, optional): Logo configuration. Defaults to None.
-        """
         self.session = session
         self.title = title
         self.final_text = final_text
@@ -191,12 +160,6 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             self.points = points
 
     def action(self) -> FinalActionDto:
-        """
-        Get the final action data for rendering the final view.
-
-        Returns:
-            FinalActionDto: The final action data serialized for the client.
-        """
         return {
             "view": self.ID,
             "score": self.total_score,

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -1,5 +1,6 @@
 from django.utils.translation import gettext_lazy as _
-from typing import TypedDict
+from dataclasses import dataclass
+from typing import Optional, Dict
 
 from experiment.serializers import serialize_social_media_config, SocialMediaConfigDto
 from session.models import Session
@@ -7,7 +8,8 @@ from session.models import Session
 from .base_action import BaseAction
 
 
-class ButtonDto(TypedDict):
+@dataclass
+class ButtonResponse:
     """
     Button configuration for an optional call-to-action button.
 
@@ -20,7 +22,8 @@ class ButtonDto(TypedDict):
     link: str
 
 
-class LogoDto(TypedDict):
+@dataclass
+class LogoResponse:
     """
     Logo configuration for branding or visual identification on the final screen.
 
@@ -33,47 +36,42 @@ class LogoDto(TypedDict):
     link: str
 
 
-class FinalActionDto(TypedDict):
+@dataclass
+class FinalActionResponse:
     """
-    FinalActionDto represents the structure of the final action data transfer object.
+    FinalActionResponse represents the structure of the final action data.
 
     Attributes:
         view (str): A string identifying the view type, usually "FINAL".
         score (float): The participant’s final numeric score at the end of the experiment or session.
-        rank (str | None): The participant’s performance rank (e.g., "GOLD", "SILVER") or None if no rank is determined.
-        final_text (str | None): A concluding message encouraging sharing, replaying, or reflecting on the results.
-        button (ButtonDto | None): Configuration for an optional call-to-action button.
-                                   For example: {"text": "Play again", "link": "/{experiment_slug}"}.
+        rank (Optional[str]): The participant’s performance rank (e.g., "GOLD", "SILVER") or None if no rank is determined.
+        final_text (Optional[str]): A concluding message encouraging sharing, replaying, or reflecting on the results.
+        button (Optional[ButtonResponse]): Configuration for an optional call-to-action button.
         points (str): The label for the scoring unit (e.g., "points"), typically localized.
-        action_texts (dict): A dictionary of localized strings for various interactive elements. Typically includes:
-                             - "play_again": _("Play again")
-                             - "profile": _("My profile")
-                             - "all_experiments": _("All experiments")
-        title (str): The title displayed prominently on the final screen, typically summarizing the result (e.g., "Final score").
-        social (SocialMediaConfigDto | None): Configuration for social media sharing. If present, it specifies channels,
-                                              content, and links for participants to share their results.
+        action_texts (Dict[str, str]): A dictionary of localized strings for various interactive elements.
+        title (str): The title displayed prominently on the final screen, typically summarizing the result.
+        social (Optional[SocialMediaConfigDto]): Configuration for social media sharing.
         show_profile_link (bool): Whether to display a link to the participant's profile.
         show_participant_link (bool): Whether to show a participant-related link or data.
-        feedback_info (dict | None): Additional details enabling a feedback section where participants can leave remarks or questions.
-        participant_id_only (bool): If True, only display the participant ID without linking it, for a more anonymized final screen.
-        logo (LogoDto | None): Optional logo configuration for branding. For example:
-                               {"image": "/static/logo.png", "link": "https://example.com"}.
+        feedback_info (Optional[Dict[str, str]]): Additional details enabling a feedback section.
+        participant_id_only (bool): If True, only display the participant ID without linking it.
+        logo (Optional[LogoResponse]): Optional logo configuration for branding.
     """
 
     view: str
     score: float
-    rank: str | None
-    final_text: str | None
-    button: ButtonDto | None
+    rank: Optional[str]
+    final_text: Optional[str]
+    button: Optional[ButtonResponse]
     points: str
-    action_texts: dict
+    action_texts: Dict[str, str]
     title: str
-    social: SocialMediaConfigDto | None
+    social: Optional[SocialMediaConfigDto]
     show_profile_link: bool
     show_participant_link: bool
-    feedback_info: dict | None
+    feedback_info: Optional[Dict[str, str]]
     participant_id_only: bool
-    logo: LogoDto | None
+    logo: Optional[LogoResponse]
 
 
 class Final(BaseAction):  # pylint: disable=too-few-public-methods
@@ -85,7 +83,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
     Branding elements like a logo or social sharing options can be included to enhance user engagement.
     A feedback section may also be provided if `feedback_info` is supplied.
 
-    The returned data aligns with `FinalActionDto`, ensuring type consistency and making the structure
+    The returned data aligns with `FinalActionResponse`, ensuring type consistency and making the structure
     clear for both developers and documentation readers. It can be consumed by a frontend component
     (e.g.,
     [Final.tsx](https://amsterdam-music-lab.github.io/MUSCLE/storybook/?path=/story/final--default)) to render the final screen.
@@ -93,22 +91,22 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
     Args:
         session (Session): The current session object associated with the participant.
         title (str): The title displayed at the top of the final view. Defaults to a localized "Final score".
-        final_text (str): An optional concluding message (e.g., "Thanks for participating!").
-        button (ButtonDto): Optional call-to-action button configuration. For example:
-                            {"text": "Play again", "link": "/{experiment_slug}"}.
-        points (str): The label for the score units (e.g., "points"). Defaults to a localized "points".
-        rank (str): The participant's rank (e.g., "GOLD"). If not provided, no rank is displayed.
+        final_text (Optional[str]): An optional concluding message (e.g., "Thanks for participating!").
+        button (Optional[ButtonResponse]): Optional call-to-action button configuration. For example:
+                                            {"text": "Play again", "link": "/{experiment_slug}"}.
+        points (Optional[str]): The label for the score units (e.g., "points"). Defaults to a localized "points".
+        rank (Optional[str]): The participant's rank (e.g., "GOLD"). If not provided, no rank is displayed.
         show_profile_link (bool): If True, display a link to the participant's profile.
         show_participant_link (bool): If True, display a participant-related link or information.
         show_participant_id_only (bool): If True, only the participant ID is shown, without a link.
-        feedback_info (dict): Optional dictionary containing feedback-related data. For example:
-                              {"header": "Feedback", "prompt": "Tell us what you think", "button_text": "Submit"}.
-        total_score (float): Explicit final score. If None, this is derived from the session.
-        logo (LogoDto): Optional logo configuration for branding. For example:
-                        {"image": "/static/logo.png", "link": "https://example.com"}.
+        feedback_info (Optional[Dict[str, str]]): Optional dictionary containing feedback-related data. For example:
+                                                  {"header": "Feedback", "prompt": "Tell us what you think", "button_text": "Submit"}.
+        total_score (Optional[float]): Explicit final score. If None, this is derived from the session.
+        logo (Optional[LogoResponse]): Optional logo configuration for branding. For example:
+                                        {"image": "/static/logo.png", "link": "https://example.com"}.
 
     Note:
-        The `action()` method returns a `FinalActionDto` that can be consumed by the frontend
+        The `action()` method returns a `FinalActionResponse` that can be consumed by the frontend
         to render the final screen.
     """
 
@@ -127,16 +125,16 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         self,
         session: Session,
         title: str = _("Final score"),
-        final_text: str | None = None,
-        button: ButtonDto | None = None,
-        points: str | None = None,
-        rank: str | None = None,
+        final_text: Optional[str] = None,
+        button: Optional[ButtonResponse] = None,
+        points: Optional[str] = None,
+        rank: Optional[str] = None,
         show_profile_link: bool = False,
         show_participant_link: bool = False,
         show_participant_id_only: bool = False,
-        feedback_info: dict | None = None,
-        total_score: float | None = None,
-        logo: LogoDto | None = None,
+        feedback_info: Optional[Dict[str, str]] = None,
+        total_score: Optional[float] = None,
+        logo: Optional[LogoResponse] = None,
     ):
         self.session = session
         self.title = title
@@ -159,29 +157,29 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         else:
             self.points = points
 
-    def action(self) -> FinalActionDto:
-        return {
-            "view": self.ID,
-            "score": self.total_score,
-            "rank": self.rank,
-            "final_text": self.final_text,
-            "button": self.button,
-            "points": self.points,
-            "action_texts": {
+    def action(self) -> FinalActionResponse:
+        return FinalActionResponse(
+            view=self.ID,
+            score=self.total_score,
+            rank=self.rank,
+            final_text=self.final_text,
+            button=self.button,
+            points=self.points,
+            action_texts={
                 "play_again": _("Play again"),
                 "profile": _("My profile"),
                 "all_experiments": _("All experiments"),
             },
-            "title": self.title,
-            "social": self.get_social_media_config(self.session),
-            "show_profile_link": self.show_profile_link,
-            "show_participant_link": self.show_participant_link,
-            "feedback_info": self.feedback_info,
-            "participant_id_only": self.show_participant_id_only,
-            "logo": self.logo,
-        }
+            title=self.title,
+            social=self.get_social_media_config(self.session),
+            show_profile_link=self.show_profile_link,
+            show_participant_link=self.show_participant_link,
+            feedback_info=self.feedback_info,
+            participant_id_only=self.show_participant_id_only,
+            logo=self.logo,
+        )
 
-    def get_social_media_config(self, session: Session) -> SocialMediaConfigDto | None:
+    def get_social_media_config(self, session: Session) -> Optional[SocialMediaConfigDto]:
         """
         Retrieve social media configuration related to the experiment.
 
@@ -189,9 +187,10 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             session (Session): The current participant's session object.
 
         Returns:
-            SocialMediaConfigDto | None: Social media configuration for sharing results.
+            Optional[SocialMediaConfigDto]: Social media configuration for sharing results.
             Returns None if no configuration is available.
         """
         experiment = session.block.phase.experiment
         if hasattr(experiment, "social_media_config") and experiment.social_media_config:
             return serialize_social_media_config(experiment.social_media_config, session.total_score())
+        return None

--- a/backend/experiment/actions/utils.py
+++ b/backend/experiment/actions/utils.py
@@ -1,7 +1,6 @@
 from os.path import join
 import random
 
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django.template.loader import render_to_string
 

--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -1,6 +1,5 @@
 from random import shuffle
-from typing import Optional, Literal
-from dataclasses import dataclass
+from typing import Optional, TypedDict, Literal
 
 from django_markup.markup import formatter
 from django.utils.translation import activate, get_language
@@ -69,8 +68,7 @@ def serialize_experiment(experiment: Experiment) -> dict:
     return serialized
 
 
-@dataclass
-class SocialMediaConfigResponse:
+class SocialMediaConfigResponse(TypedDict):
     channels: list[Literal["facebook", "whatsapp", "twitter", "weibo", "share", "clipboard"]] | list[str]
     url: str
     content: str
@@ -79,14 +77,14 @@ class SocialMediaConfigResponse:
 
 def serialize_social_media_config(
     social_media_config: SocialMediaConfig,
-    score: float = 0.0,
-):
-    return SocialMediaConfigResponse(
-        tags=social_media_config.tags or ["amsterdammusiclab", "citizenscience"],
-        url=social_media_config.url,
-        content=social_media_config.get_content(score),
-        channels=social_media_config.channels or ["facebook", "twitter"],
-    )
+    score: Optional[float] = 0,
+) -> SocialMediaConfigResponse:
+    return {
+        "tags": social_media_config.tags or ["amsterdammusiclab", "citizenscience"],
+        "url": social_media_config.url,
+        "content": social_media_config.get_content(score),
+        "channels": social_media_config.channels or ["facebook", "twitter"],
+    }
 
 
 def serialize_phase(phase: Phase, participant: Participant, times_played: int) -> dict:

--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -1,5 +1,6 @@
 from random import shuffle
-from typing import Optional, TypedDict, Literal
+from typing import Optional, Literal
+from dataclasses import dataclass
 
 from django_markup.markup import formatter
 from django.utils.translation import activate, get_language
@@ -68,21 +69,8 @@ def serialize_experiment(experiment: Experiment) -> dict:
     return serialized
 
 
-class SocialMediaConfigDto(TypedDict):
-    """
-    SocialMediaConfigDto is a TypedDict that represents the configuration for social media sharing.
-
-    Attributes:
-        channels (list[Literal["facebook", "whatsapp", "twitter", "weibo", "share", "clipboard"]] | list[str]):
-            A list of social media channels or a list of strings representing the channels.
-        url (str):
-            The URL to be shared on social media.
-        content (str):
-            The content or message to be shared on social media, if applicable (does not work for facebook).
-        tags (list[str]):
-            A list of tags or hashtags to be included in the social media post, if applicable.
-    """
-
+@dataclass
+class SocialMediaConfigResponse:
     channels: list[Literal["facebook", "whatsapp", "twitter", "weibo", "share", "clipboard"]] | list[str]
     url: str
     content: str
@@ -91,23 +79,14 @@ class SocialMediaConfigDto(TypedDict):
 
 def serialize_social_media_config(
     social_media_config: SocialMediaConfig,
-    score: Optional[float] = 0,
-) -> SocialMediaConfigDto:
-    """Serialize social media config
-
-    Args:
-        social_media_config: SocialMediaConfig instance
-
-    returns:
-        Basic social media info
-    """
-
-    return {
-        "tags": social_media_config.tags or ["amsterdammusiclab", "citizenscience"],
-        "url": social_media_config.url,
-        "content": social_media_config.get_content(score),
-        "channels": social_media_config.channels or ["facebook", "twitter"],
-    }
+    score: float = 0.0,
+):
+    return SocialMediaConfigResponse(
+        tags=social_media_config.tags or ["amsterdammusiclab", "citizenscience"],
+        url=social_media_config.url,
+        content=social_media_config.get_content(score),
+        channels=social_media_config.channels or ["facebook", "twitter"],
+    )
 
 
 def serialize_phase(phase: Phase, participant: Participant, times_played: int) -> dict:

--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -68,7 +68,7 @@ def serialize_experiment(experiment: Experiment) -> dict:
     return serialized
 
 
-class SocialMediaConfigResponse(TypedDict):
+class SocialMediaConfigConfiguration(TypedDict):
     channels: list[Literal["facebook", "whatsapp", "twitter", "weibo", "share", "clipboard"]] | list[str]
     url: str
     content: str
@@ -78,7 +78,7 @@ class SocialMediaConfigResponse(TypedDict):
 def serialize_social_media_config(
     social_media_config: SocialMediaConfig,
     score: Optional[float] = 0,
-) -> SocialMediaConfigResponse:
+) -> SocialMediaConfigConfiguration:
     return {
         "tags": social_media_config.tags or ["amsterdammusiclab", "citizenscience"],
         "url": social_media_config.url,

--- a/scripts/mkdocs
+++ b/scripts/mkdocs
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This script builds the MkDocs documentation site.
+docker compose run --rm server mkdocs build -d ./docs-pages-build $@


### PR DESCRIPTION
Update the client component reference from `Consent.js` to `Consent.tsx`, introduce a MkDocs build script, and refactor social media serialization with a new `SocialMediaConfigDto` TypedDict. Clean up unused imports and enhance documentation with added docstrings.

I might have gone overboard a bit with the amount of documentation, so feel free to tell me where to cut down on. I do like the newly introduced Dto typing classes though, although I can imagine them to be in a separate file or something, just like we do in the frontend in the types directory. Lmk what you think. :-)