### PR TITLE
Docs: Add documentation for Redirect action and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ e2e/screenshots
 e2e/tests/__pycache__
 
 temp/
+
+docs-pages-build/

--- a/backend/experiment/actions/redirect.py
+++ b/backend/experiment/actions/redirect.py
@@ -7,10 +7,6 @@ class Redirect(BaseAction):
 
     This action is used to redirect the user to a specified URL.
 
-    Attributes:
-        ID (str): Identifier for the action, set to 'REDIRECT'.
-        url (str): The URL to which the redirection should occur.
-
     Args:
         url (str): The URL to redirect to.
 

--- a/backend/experiment/actions/redirect.py
+++ b/backend/experiment/actions/redirect.py
@@ -2,7 +2,23 @@ from .base_action import BaseAction
 
 
 class Redirect(BaseAction):
-    ID = 'REDIRECT'
+    """
+    Redirect Action
+
+    This action is used to redirect the user to a specified URL.
+
+    Attributes:
+        ID (str): Identifier for the action, set to 'REDIRECT'.
+        url (str): The URL to which the redirection should occur.
+
+    Args:
+        url (str): The URL to redirect to.
+
+    Example:
+        redirect_action = Redirect('https://example.com')
+    """
+
+    ID = "REDIRECT"
 
     def __init__(self, url):
         self.url = url


### PR DESCRIPTION
Include a docstring for the Redirect action class to clarify its purpose and usage. Also, add `docs-pages-build` to .gitignore to prevent a locally generated mkdocs site to clutter your changes in git.