### PR TITLE
Fix er/song duration configuration

### DIFF
--- a/backend/experiment/templates/edit-sections.html
+++ b/backend/experiment/templates/edit-sections.html
@@ -68,11 +68,11 @@
                     id="{{section.id}}_start_time" value="{{ section.start_time}}">
             </td>
             <td>
-                <input type="number" name="{{section.id}}_duration" maxlength="128" required=""
+                <input type="number" step="0.001" name="{{section.id}}_duration" maxlength="128" required=""
                     id="{{section.id}}_duration" value="{{ section.duration}}">
             </td>
             <td>
-                <input type="text" name="{{section.id}}_tag" maxlength="128" id="{{section.id}}_tag"
+                <input type="text" step="0.001" name="{{section.id}}_tag" maxlength="128" id="{{section.id}}_tag"
                     value="{{ section.tag}}">
             </td>
             <td>

--- a/backend/section/admin.py
+++ b/backend/section/admin.py
@@ -11,6 +11,7 @@ from django.urls import path, reverse
 from django.utils.translation import gettext_lazy as _
 
 import audioread
+import sys
 
 from .models import Section, Playlist, Song
 from .forms import AddSections, PlaylistAdminForm
@@ -152,7 +153,7 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
 
                 new_duration = float(request.POST.get(pre_fix + "_duration"))
                 # while running tests this would throw an error
-                try:
+                if "test" not in sys.argv:
                     # Check if the duration in the csv exceeds the actual duration of the audio file
                     file_path = join(settings.MEDIA_ROOT, str(section.filename))
 
@@ -166,7 +167,7 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
                         messages.error(request, f"Error: The duration of {section.filename} exceeds the actual duration of the audio file and has been set to {actual_duration} seconds.")
                     else:
                         section.duration = new_duration
-                except:
+                else:
                     section.duration = new_duration
 
                 section.tag = request.POST.get(pre_fix + "_tag")

--- a/backend/section/admin.py
+++ b/backend/section/admin.py
@@ -74,7 +74,8 @@ class PlaylistAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
 
             # create message based on csv_result (CSV_ERROR or CSV_OK)
             if csv_result["status"] == Playlist.CSV_ERROR:
-                messages.add_message(request, messages.ERROR, csv_result["message"])
+                for message in csv_result["messages"]:
+                    messages.add_message(request, messages.ERROR, message)
 
             elif csv_result["status"] == Playlist.CSV_OK:
                 messages.add_message(request, messages.INFO, csv_result["message"])

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -21,6 +21,7 @@ import random
 import csv
 from os.path import join
 import audioread
+import sys
 
 from django.db import models
 from django.utils import timezone
@@ -162,7 +163,7 @@ class Playlist(models.Model):
             # Check if the duration in the csv exceeds the actual duration of the audio file
             file_path = join(settings.MEDIA_ROOT, str(row['filename']))
 
-            try:
+            if "test" not in sys.argv:
                 # while running tests this would throw an error
                 with audioread.audio_open(file_path) as f:
                     actual_duration = f.duration
@@ -171,8 +172,7 @@ class Playlist(models.Model):
                     row['duration'] = actual_duration
                     global_errors += 1
                     csv_messages.append(f"Error: The duration of {row['filename']} exceeds the actual duration of the audio file and has been set to {actual_duration} seconds.")
-            except:
-                pass
+                    print('try')
                 
             # Make the changes if there are no global errors in this row
             if not iteration_error:

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -172,7 +172,6 @@ class Playlist(models.Model):
                     row['duration'] = actual_duration
                     global_errors += 1
                     csv_messages.append(f"Error: The duration of {row['filename']} exceeds the actual duration of the audio file and has been set to {actual_duration} seconds.")
-                    print('try')
                 
             # Make the changes if there are no global errors in this row
             if not iteration_error:

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -166,7 +166,7 @@ class Playlist(models.Model):
                 # while running tests this would throw an error
                 with audioread.audio_open(file_path) as f:
                     actual_duration = f.duration
-                if row['duration'] > actual_duration:
+                if float(row['duration']) > actual_duration:
                     # Add or edit this row, but show an error message containing the actual saved duration
                     row['duration'] = actual_duration
                     global_errors += 1

--- a/backend/section/models.py
+++ b/backend/section/models.py
@@ -139,7 +139,7 @@ class Playlist(models.Model):
         updated = 0
         lines = 0
         csv_messages = []
-        fatal_errors = 0
+        global_errors = 0
         for row in reader:
             lines += 1
             iteration_error = False
@@ -149,7 +149,7 @@ class Playlist(models.Model):
                 csv_messages.append(f"Error: Invalid row length, line: {str(lines)}")
                 # Skip adding or altering this row
                 iteration_error = True
-                fatal_errors += 1
+                global_errors += 1
 
             # check for valid numbers
             if not (is_number(row['start_time'])
@@ -157,23 +157,24 @@ class Playlist(models.Model):
                 csv_messages.append(f"Error: Expected number fields on line: {str(lines)}")
                 # Skip adding or altering this row
                 iteration_error = True
-                fatal_errors += 1
+                global_errors += 1
 
             # Check if the duration in the csv exceeds the actual duration of the audio file
             file_path = join(settings.MEDIA_ROOT, str(row['filename']))
+
             try:
                 # while running tests this would throw an error
                 with audioread.audio_open(file_path) as f:
                     actual_duration = f.duration
-                if float(row['duration']) > actual_duration:
+                if row['duration'] > actual_duration:
                     # Add or edit this row, but show an error message containing the actual saved duration
                     row['duration'] = actual_duration
-                    fatal_errors += 1                
+                    global_errors += 1
                     csv_messages.append(f"Error: The duration of {row['filename']} exceeds the actual duration of the audio file and has been set to {actual_duration} seconds.")
             except:
                 pass
                 
-            # Make the changes if there are no fatal errors in this row
+            # Make the changes if there are no global errors in this row
             if not iteration_error:
                 # Retrieve or create Song object
                 song = None
@@ -212,8 +213,8 @@ class Playlist(models.Model):
                 if section:
                     sections.append(section)
 
-        # No fatal errors 
-        if fatal_errors == 0:
+        # No global errors
+        if global_errors == 0:
 
             # Add sections
             Section.objects.bulk_create(sections)
@@ -231,7 +232,7 @@ class Playlist(models.Model):
                 'message':
                   f"Sections processed from CSV. Added: {str(len(sections))} - Updated: {str(updated)} - Removed: {str(len(delete_ids))}"
             }
-        
+
         return {
                     'status': self.CSV_ERROR,
                     'messages': csv_messages,


### PR DESCRIPTION
This PR:
- Adds a check to `_update_sections` and `edit_sections` that prevents users from entering a greater duration for an audio file than the actual duration.

- Refactors the `_update_sections` function:
When the `csv.DictReader` would find an error in a row it would return with an error message, but would only jump out of the `for` loop not out of the function, so that the sections it had already processed were still created, while the rest ignored. 
Now all the errors are first gathered and then shown in a list when returned to the admin
Row length errors as well as rows with invalid numbers will be shown in the admin, but will not be processed. 
Exceeding song duration errors will be shown in the admin but the setting will be corrected and saved.

While running tests the duration check will not be executed, because of the absence of actual audio files