### PR TITLE
Draft: Implement prototype of analytics dashboard that can be expanded upon

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -10,6 +10,7 @@ from django.core import serializers
 from django.shortcuts import render, redirect
 from django.forms import CheckboxSelectMultiple
 from django.http import HttpResponse
+from django.urls import path
 
 from inline_actions.admin import InlineActionsModelAdminMixin
 from django.urls import reverse
@@ -42,6 +43,27 @@ from section.models import Section, Song
 from result.models import Result
 from participant.models import Participant
 from question.models import QuestionSeries, QuestionInSeries
+
+
+original_admin_site = admin.site
+admin_urls = original_admin_site.get_urls
+
+
+def get_urls():
+    from experiment.views import admin_experimenter_analytics, block_export_data
+
+    urls = admin_urls()
+    custom_urls = [
+        path(
+            "api/block/<int:block_id>/export/",
+            original_admin_site.admin_view(block_export_data),
+            name="block_export_data",
+        ),
+    ]
+    return custom_urls + urls
+
+
+original_admin_site.get_urls = get_urls
 
 
 class BlockTranslatedContentInline(NestedTabularInline):

--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -55,6 +55,11 @@ def get_urls():
     urls = admin_urls()
     custom_urls = [
         path(
+            "experiment/analytics/block/<int:block_id>/",
+            original_admin_site.admin_view(admin_experimenter_analytics),
+            name="admin_experimenter_analytics",
+        ),
+        path(
             "api/block/<int:block_id>/export/",
             original_admin_site.admin_view(block_export_data),
             name="block_export_data",

--- a/backend/experiment/static/analytics/README.md
+++ b/backend/experiment/static/analytics/README.md
@@ -1,0 +1,43 @@
+# Experiment Analytics Project
+
+This project contains the code required to create the analytics dashboard for experiments, blocks, users, sessions, and so on. It consists of several typescript files that initialize charts for their respective analytics dashboard pages.
+
+## Getting started
+
+### Requirements
+
+- Node.js
+
+### Installation & running
+
+1. Navigate to the directory of the project
+
+```bash
+cd backend/experiment/static/analytics
+```
+
+2. Install dependencies
+
+This will install all the dependencies required to run the project. At the moment of writing, these dependencies are:
+- `nodemon`: A utility that will monitor for any changes in your source and automatically restart your server.
+- `typescript`: A language that builds on JavaScript by adding static type definitions.
+
+```bash
+npm install
+```
+
+3. Watch & rebuild the typescript files
+
+This will start a nodemon process that rebuilds the typescript files whenever they are changed.
+
+```bash
+npm run dev
+```
+
+4. Build the typescript files
+
+This will build the typescript files into javascript files.
+
+```bash
+npm run build
+```

--- a/backend/experiment/static/analytics/dist/experiment_analytics.js
+++ b/backend/experiment/static/analytics/dist/experiment_analytics.js
@@ -1,0 +1,301 @@
+// Helper function to format date strings (YYYY-MM-DD)
+function formatDate(dateStr) {
+    return dateStr.slice(0, 10);
+}
+// Process and transform data into structures used by charts
+function processData(sessions, participants, results) {
+    // Filter completed sessions
+    const completedSessions = sessions.filter(s => s.fields.finished_at !== null);
+    // SESSIONS BY DATE (For line chart)
+    const sessionsByDate = {};
+    completedSessions.forEach(session => {
+        const date = formatDate(session.fields.finished_at);
+        sessionsByDate[date] = (sessionsByDate[date] || 0) + 1;
+    });
+    const completionDates = Object.keys(sessionsByDate).sort();
+    const completionCounts = completionDates.map(d => sessionsByDate[d]);
+    // FINAL SCORES (For bar chart)
+    const finalScores = completedSessions.map(s => s.fields.final_score);
+    const scoreCounts = {};
+    finalScores.forEach(score => {
+        const scoreStr = String(score);
+        scoreCounts[scoreStr] = (scoreCounts[scoreStr] || 0) + 1;
+    });
+    const scoreLabels = Object.keys(scoreCounts);
+    const scoreData = Object.values(scoreCounts);
+    // COUNTRY DISTRIBUTION (For pie chart)
+    const countryCounts = {};
+    participants.forEach(p => {
+        const cc = p.fields.country_code || 'unknown';
+        countryCounts[cc] = (countryCounts[cc] || 0) + 1;
+    });
+    const countryLabels = Object.keys(countryCounts);
+    const countryData = Object.values(countryCounts);
+    // COMPLETION RATE BY PARTICIPANT
+    const participantIds = participants.map(p => p.pk);
+    const sessionsByParticipant = {};
+    participantIds.forEach(pid => sessionsByParticipant[pid] = { started: 0, completed: 0 });
+    sessions.forEach(s => {
+        const pid = s.fields.participant;
+        if (!sessionsByParticipant[pid]) {
+            sessionsByParticipant[pid] = { started: 0, completed: 0 };
+        }
+        sessionsByParticipant[pid].started += 1;
+        if (s.fields.finished_at !== null) {
+            sessionsByParticipant[pid].completed += 1;
+        }
+    });
+    const completionLabels = participantIds.map(pid => `P${pid}`);
+    const startedData = participantIds.map(pid => sessionsByParticipant[pid]?.started || 0);
+    const completedData = participantIds.map(pid => sessionsByParticipant[pid]?.completed || 0);
+    // DURATION DISTRIBUTION
+    function getDurationMinutes(start, end) {
+        const startDate = new Date(start);
+        const endDate = new Date(end);
+        const minutes = (endDate.getTime() - startDate.getTime()) / 60000;
+        return Math.max(minutes, 0);
+    }
+    const durations = completedSessions.map(s => getDurationMinutes(s.fields.started_at, s.fields.finished_at));
+    const binSize = 1; // 1-minute bins
+    const maxDuration = Math.ceil(Math.max(...durations, 0));
+    const durationBins = [];
+    for (let i = 0; i <= maxDuration; i += binSize) {
+        durationBins.push(i);
+    }
+    const durationCounts = Array(durationBins.length).fill(0);
+    durations.forEach(d => {
+        const binIndex = Math.min(Math.floor(d / binSize), durationBins.length - 1);
+        durationCounts[binIndex] += 1;
+    });
+    const durationLabels = durationBins.map(b => `${b}-${b + binSize}min`);
+    // ACCURACY OVER TIME
+    const dailyResults = {};
+    results.forEach(r => {
+        const date = formatDate(r.fields.created_at);
+        if (!dailyResults[date])
+            dailyResults[date] = { correct: 0, total: 0 };
+        const score = r.fields.score;
+        if (score !== null) {
+            dailyResults[date].total += 1;
+            if (score === 20.0) {
+                dailyResults[date].correct += 1;
+            }
+        }
+    });
+    const accuracyDates = Object.keys(dailyResults).sort();
+    const accuracyValues = accuracyDates.map(d => {
+        const dayData = dailyResults[d];
+        return dayData.total > 0 ? (dayData.correct / dayData.total) * 100.0 : 0;
+    });
+    return {
+        scoreLabels, scoreData,
+        completionDates, completionCounts,
+        countryLabels, countryData,
+        completionLabels, startedData, completedData,
+        durationLabels, durationCounts,
+        accuracyDates, accuracyValues
+    };
+}
+// Functions to create each chart
+function createScoreChart(labels, data) {
+    const scoreChartCanvas = document.getElementById('scoreChart');
+    const ctxScore = scoreChartCanvas.getContext('2d');
+    new Chart(ctxScore, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                    label: 'Count of Completed Sessions by Final Score',
+                    data: data,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1
+                }]
+        },
+        options: {
+            scales: {
+                y: { beginAtZero: true }
+            }
+        }
+    });
+}
+function createCompletionOverTimeChart(dates, counts) {
+    const completionChartCanvas = document.getElementById('completionChart');
+    const ctxCompletion = completionChartCanvas.getContext('2d');
+    new Chart(ctxCompletion, {
+        type: 'line',
+        data: {
+            labels: dates,
+            datasets: [{
+                    label: 'Sessions Completed Per Day',
+                    data: counts,
+                    fill: false,
+                    borderColor: 'rgba(255,99,132,1)',
+                    tension: 0.1
+                }]
+        },
+        options: {
+            scales: {
+                y: { beginAtZero: true }
+            }
+        }
+    });
+}
+function createCountryChart(labels, data) {
+    const countryChartCanvas = document.getElementById('countryChart');
+    const ctxCountry = countryChartCanvas.getContext('2d');
+    new Chart(ctxCountry, {
+        type: 'pie',
+        data: {
+            labels: labels,
+            datasets: [{
+                    data: data,
+                    backgroundColor: [
+                        'rgba(255, 99, 132, 0.5)',
+                        'rgba(54, 162, 235, 0.5)',
+                        'rgba(255, 206, 86, 0.5)',
+                        'rgba(75, 192, 192, 0.5)'
+                    ]
+                }]
+        },
+        options: {
+            responsive: true
+        }
+    });
+}
+function createParticipantCompletionChart(labels, started, completed) {
+    const completionChartCanvasTwo = document.getElementById('completionChartTwo');
+    const ctxCompletionTwo = completionChartCanvasTwo.getContext('2d');
+    new Chart(ctxCompletionTwo, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: 'Started',
+                    data: started,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)'
+                },
+                {
+                    label: 'Completed',
+                    data: completed,
+                    backgroundColor: 'rgba(75, 192, 192, 0.5)'
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: { beginAtZero: true }
+            }
+        }
+    });
+}
+function createDurationChart(labels, counts) {
+    const durationChartCanvas = document.getElementById('durationChart');
+    const ctxDuration = durationChartCanvas.getContext('2d');
+    new Chart(ctxDuration, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                    label: 'Session Count',
+                    data: counts,
+                    backgroundColor: 'rgba(153, 102, 255, 0.5)',
+                    borderWidth: 1
+                }]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: { beginAtZero: true }
+            },
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: function (context) {
+                            return `Count: ${context.parsed.y}`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+function createAccuracyChart(dates, values) {
+    const accuracyChartCanvas = document.getElementById('accuracyChart');
+    const ctxAccuracy = accuracyChartCanvas.getContext('2d');
+    new Chart(ctxAccuracy, {
+        type: 'line',
+        data: {
+            labels: dates,
+            datasets: [{
+                    label: 'Daily Accuracy (%)',
+                    data: values,
+                    borderColor: 'rgba(255,99,132,1)',
+                    fill: false,
+                    tension: 0.1
+                }]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    suggestedMax: 100
+                }
+            },
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: function (context) {
+                            return `Accuracy: ${context.parsed.y.toFixed(2)}%`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+// Initialize all charts
+function initializeCharts(data) {
+    const sessions = JSON.parse(data.sessions);
+    const participants = JSON.parse(data.participants);
+    const results = JSON.parse(data.results);
+    const { scoreLabels, scoreData, completionDates, completionCounts, countryLabels, countryData, completionLabels, startedData, completedData, durationLabels, durationCounts, accuracyDates, accuracyValues } = processData(sessions, participants, results);
+    createScoreChart(scoreLabels, scoreData);
+    createCompletionOverTimeChart(completionDates, completionCounts);
+    createCountryChart(countryLabels, countryData);
+    createParticipantCompletionChart(completionLabels, startedData, completedData);
+    createDurationChart(durationLabels, durationCounts);
+    createAccuracyChart(accuracyDates, accuracyValues);
+}
+async function fetchAnalyticsData() {
+    let data;
+    const errorElement = document.getElementById('error');
+    try {
+        const response = await fetch(BLOCK_EXPORT_DATA_URL);
+        if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+        }
+        data = await response.json();
+        initializeCharts(data);
+    }
+    catch (error) {
+        const statusCode = error.response ? error.response.status : 500;
+        const notFound = statusCode === 404;
+        const errorMessage = notFound ? 'The data for this block is not available.' : 'An error occurred while fetching data.';
+        if (errorElement) {
+            errorElement.textContent = errorMessage;
+            const refreshButton = document.createElement('button');
+            refreshButton.textContent = 'Refresh';
+            refreshButton.onclick = () => {
+                window.location.reload();
+            };
+            errorElement.appendChild(refreshButton);
+        }
+    }
+}
+document.addEventListener('DOMContentLoaded', () => {
+    fetchAnalyticsData();
+});

--- a/backend/experiment/static/analytics/package-lock.json
+++ b/backend/experiment/static/analytics/package-lock.json
@@ -1,0 +1,370 @@
+{
+  "name": "analytics",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "analytics",
+      "devDependencies": {
+        "nodemon": "^3.1.9",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    }
+  }
+}

--- a/backend/experiment/static/analytics/package.json
+++ b/backend/experiment/static/analytics/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "analytics",
+  "packageManager": "yarn@4.1.1",
+  "scripts": {
+    "build": "tsc",
+    "dev": "nodemon --watch src/experiment_analytics.ts --exec \"tsc -p tsconfig.json\""
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.9",
+    "typescript": "^5.7.2"
+  }
+}

--- a/backend/experiment/static/analytics/src/experiment_analytics.ts
+++ b/backend/experiment/static/analytics/src/experiment_analytics.ts
@@ -1,0 +1,391 @@
+declare const BLOCK_EXPORT_DATA_URL: string;
+declare const blockId: string;
+declare const Chart: any;
+
+interface SessionFields {
+  block: number;
+  participant: number;
+  playlist: number;
+  started_at: string;
+  finished_at: string | null;
+  json_data: any;
+  final_score: number;
+}
+
+interface Session {
+  model: string;
+  pk: number;
+  fields: SessionFields;
+}
+
+interface ParticipantFields {
+  unique_hash: string;
+  country_code: string | null;
+  access_info: string;
+  participant_id_url: string | null;
+}
+
+interface Participant {
+  model: string;
+  pk: number;
+  fields: ParticipantFields;
+}
+
+interface ResultFields {
+  session: number | null;
+  participant: number | null;
+  section: number | null;
+  created_at: string;
+  question_key: string;
+  expected_response: string | null;
+  given_response: string | null;
+  comment: string;
+  score: number | null;
+  scoring_rule: string;
+  json_data: any;
+}
+
+interface Result {
+  model: string;
+  pk: number;
+  fields: ResultFields;
+}
+
+interface BlockData {
+  sessions: string;
+  participants: string;
+  results: string;
+  // add other fields if necessary
+}
+
+// Helper function to format date strings (YYYY-MM-DD)
+function formatDate(dateStr: string): string {
+  return dateStr.slice(0, 10);
+}
+
+// Process and transform data into structures used by charts
+function processData(sessions: Session[], participants: Participant[], results: Result[]) {
+  // Filter completed sessions
+  const completedSessions = sessions.filter(s => s.fields.finished_at !== null);
+
+  // SESSIONS BY DATE (For line chart)
+  const sessionsByDate: Record<string, number> = {};
+  completedSessions.forEach(session => {
+    const date = formatDate(session.fields.finished_at!);
+    sessionsByDate[date] = (sessionsByDate[date] || 0) + 1;
+  });
+
+  const completionDates = Object.keys(sessionsByDate).sort();
+  const completionCounts = completionDates.map(d => sessionsByDate[d]);
+
+  // FINAL SCORES (For bar chart)
+  const finalScores = completedSessions.map(s => s.fields.final_score);
+  const scoreCounts: Record<string, number> = {};
+  finalScores.forEach(score => {
+    const scoreStr = String(score);
+    scoreCounts[scoreStr] = (scoreCounts[scoreStr] || 0) + 1;
+  });
+  const scoreLabels = Object.keys(scoreCounts);
+  const scoreData = Object.values(scoreCounts);
+
+  // COUNTRY DISTRIBUTION (For pie chart)
+  const countryCounts: Record<string, number> = {};
+  participants.forEach(p => {
+    const cc = p.fields.country_code || 'unknown';
+    countryCounts[cc] = (countryCounts[cc] || 0) + 1;
+  });
+  const countryLabels = Object.keys(countryCounts);
+  const countryData = Object.values(countryCounts);
+
+  // COMPLETION RATE BY PARTICIPANT
+  const participantIds = participants.map(p => p.pk);
+  const sessionsByParticipant: Record<number, { started: number; completed: number }> = {};
+  participantIds.forEach(pid => sessionsByParticipant[pid] = { started: 0, completed: 0 });
+
+  sessions.forEach(s => {
+    const pid = s.fields.participant;
+    if (!sessionsByParticipant[pid]) {
+      sessionsByParticipant[pid] = { started: 0, completed: 0 };
+    }
+    sessionsByParticipant[pid].started += 1;
+    if (s.fields.finished_at !== null) {
+      sessionsByParticipant[pid].completed += 1;
+    }
+  });
+
+  const completionLabels = participantIds.map(pid => `P${pid}`);
+  const startedData = participantIds.map(pid => sessionsByParticipant[pid]?.started || 0);
+  const completedData = participantIds.map(pid => sessionsByParticipant[pid]?.completed || 0);
+
+  // DURATION DISTRIBUTION
+  function getDurationMinutes(start: string, end: string): number {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    const minutes = (endDate.getTime() - startDate.getTime()) / 60000;
+    return Math.max(minutes, 0);
+  }
+
+  const durations = completedSessions.map(s => getDurationMinutes(s.fields.started_at, s.fields.finished_at!));
+  const binSize = 1; // 1-minute bins
+  const maxDuration = Math.ceil(Math.max(...durations, 0));
+  const durationBins: number[] = [];
+  for (let i = 0; i <= maxDuration; i += binSize) {
+    durationBins.push(i);
+  }
+  const durationCounts = Array(durationBins.length).fill(0);
+  durations.forEach(d => {
+    const binIndex = Math.min(Math.floor(d / binSize), durationBins.length - 1);
+    durationCounts[binIndex] += 1;
+  });
+  const durationLabels = durationBins.map(b => `${b}-${b + binSize}min`);
+
+  // ACCURACY OVER TIME
+  const dailyResults: Record<string, { correct: number; total: number }> = {};
+  results.forEach(r => {
+    const date = formatDate(r.fields.created_at);
+    if (!dailyResults[date]) dailyResults[date] = { correct: 0, total: 0 };
+    const score = r.fields.score;
+    if (score !== null) {
+      dailyResults[date].total += 1;
+      if (score === 20.0) {
+        dailyResults[date].correct += 1;
+      }
+    }
+  });
+
+  const accuracyDates = Object.keys(dailyResults).sort();
+  const accuracyValues = accuracyDates.map(d => {
+    const dayData = dailyResults[d];
+    return dayData.total > 0 ? (dayData.correct / dayData.total) * 100.0 : 0;
+  });
+
+  return {
+    scoreLabels, scoreData,
+    completionDates, completionCounts,
+    countryLabels, countryData,
+    completionLabels, startedData, completedData,
+    durationLabels, durationCounts,
+    accuracyDates, accuracyValues
+  };
+}
+
+// Functions to create each chart
+function createScoreChart(labels: string[], data: number[]) {
+  const scoreChartCanvas = document.getElementById('scoreChart') as HTMLCanvasElement;
+  const ctxScore = scoreChartCanvas.getContext('2d');
+  new Chart(ctxScore, {
+    type: 'bar',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: 'Count of Completed Sessions by Final Score',
+        data: data,
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+}
+
+function createCompletionOverTimeChart(dates: string[], counts: number[]) {
+  const completionChartCanvas = document.getElementById('completionChart') as HTMLCanvasElement;
+  const ctxCompletion = completionChartCanvas.getContext('2d');
+  new Chart(ctxCompletion, {
+    type: 'line',
+    data: {
+      labels: dates,
+      datasets: [{
+        label: 'Sessions Completed Per Day',
+        data: counts,
+        fill: false,
+        borderColor: 'rgba(255,99,132,1)',
+        tension: 0.1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+}
+
+function createCountryChart(labels: string[], data: number[]) {
+  const countryChartCanvas = document.getElementById('countryChart') as HTMLCanvasElement;
+  const ctxCountry = countryChartCanvas.getContext('2d');
+  new Chart(ctxCountry, {
+    type: 'pie',
+    data: {
+      labels: labels,
+      datasets: [{
+        data: data,
+        backgroundColor: [
+          'rgba(255, 99, 132, 0.5)',
+          'rgba(54, 162, 235, 0.5)',
+          'rgba(255, 206, 86, 0.5)',
+          'rgba(75, 192, 192, 0.5)'
+        ]
+      }]
+    },
+    options: {
+      responsive: true
+    }
+  });
+}
+
+function createParticipantCompletionChart(labels: string[], started: number[], completed: number[]) {
+  const completionChartCanvasTwo = document.getElementById('completionChartTwo') as HTMLCanvasElement;
+  const ctxCompletionTwo = completionChartCanvasTwo.getContext('2d');
+  new Chart(ctxCompletionTwo, {
+    type: 'bar',
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: 'Started',
+          data: started,
+          backgroundColor: 'rgba(54, 162, 235, 0.5)'
+        },
+        {
+          label: 'Completed',
+          data: completed,
+          backgroundColor: 'rgba(75, 192, 192, 0.5)'
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+}
+
+function createDurationChart(labels: string[], counts: number[]) {
+  const durationChartCanvas = document.getElementById('durationChart') as HTMLCanvasElement;
+  const ctxDuration = durationChartCanvas.getContext('2d');
+  new Chart(ctxDuration, {
+    type: 'bar',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: 'Session Count',
+        data: counts,
+        backgroundColor: 'rgba(153, 102, 255, 0.5)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: { beginAtZero: true }
+      },
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: function (context) {
+              return `Count: ${context.parsed.y}`;
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+function createAccuracyChart(dates: string[], values: number[]) {
+  const accuracyChartCanvas = document.getElementById('accuracyChart') as HTMLCanvasElement;
+  const ctxAccuracy = accuracyChartCanvas.getContext('2d');
+  new Chart(ctxAccuracy, {
+    type: 'line',
+    data: {
+      labels: dates,
+      datasets: [{
+        label: 'Daily Accuracy (%)',
+        data: values,
+        borderColor: 'rgba(255,99,132,1)',
+        fill: false,
+        tension: 0.1
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: {
+          beginAtZero: true,
+          suggestedMax: 100
+        }
+      },
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: function (context) {
+              return `Accuracy: ${context.parsed.y.toFixed(2)}%`;
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+// Initialize all charts
+function initializeCharts(data: BlockData) {
+  const sessions: Session[] = JSON.parse(data.sessions);
+  const participants: Participant[] = JSON.parse(data.participants);
+  const results: Result[] = JSON.parse(data.results);
+
+  const {
+    scoreLabels, scoreData,
+    completionDates, completionCounts,
+    countryLabels, countryData,
+    completionLabels, startedData, completedData,
+    durationLabels, durationCounts,
+    accuracyDates, accuracyValues
+  } = processData(sessions, participants, results);
+
+  createScoreChart(scoreLabels, scoreData);
+  createCompletionOverTimeChart(completionDates, completionCounts);
+  createCountryChart(countryLabels, countryData);
+  createParticipantCompletionChart(completionLabels, startedData, completedData);
+  createDurationChart(durationLabels, durationCounts);
+  createAccuracyChart(accuracyDates, accuracyValues);
+}
+
+async function fetchAnalyticsData() {
+  let data: BlockData;
+  const errorElement = document.getElementById('error');
+
+  try {
+    const response = await fetch(BLOCK_EXPORT_DATA_URL);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    data = await response.json();
+    initializeCharts(data);
+  } catch (error: any) {
+    const statusCode = error.response ? error.response.status : 500;
+    const notFound = statusCode === 404;
+    const errorMessage = notFound ? 'The data for this block is not available.' : 'An error occurred while fetching data.';
+    if (errorElement) {
+      errorElement.textContent = errorMessage;
+      const refreshButton = document.createElement('button');
+      refreshButton.textContent = 'Refresh';
+      refreshButton.onclick = () => {
+        window.location.reload();
+      };
+      errorElement.appendChild(refreshButton);
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchAnalyticsData();
+});

--- a/backend/experiment/static/analytics/tsconfig.json
+++ b/backend/experiment/static/analytics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "outFile": "dist/experiment_analytics.js",
+    // Cannot find module 'chart.js/auto'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?ts(2792)
+    "moduleResolution": "node",
+  },
+}

--- a/backend/experiment/templates/experiment-analytics.html
+++ b/backend/experiment/templates/experiment-analytics.html
@@ -1,0 +1,58 @@
+{% extends "admin/base_site.html" %}
+{% load inline_action_tags static %}
+{% block content %}
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<!-- api endpoint url -->
+<script type="text/javascript">
+  const BLOCK_EXPORT_DATA_URL = "{% url 'admin:block_export_data' block_id %}";
+  const blockId = "{{ block_id }}";
+</script>
+
+<script src="{% static 'analytics/dist/experiment_analytics.js' %}"></script>
+
+<style>
+  .analytics-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 20px;
+  }
+</style>
+
+<div id="error"></div>
+
+<div class="analytics-grid">
+  <div>
+    <h2>Final Score Distribution (Bar Chart)</h2>
+    <canvas id="scoreChart"></canvas>
+  </div>
+
+  <div>
+    <h2>Completed Sessions Over Time (Line Chart)</h2>
+    <canvas id="completionChart"></canvas>
+  </div>
+
+  <div>
+    <h2>Participants by Country (Pie Chart)</h2>
+    <canvas id="countryChart"></canvas>
+  </div>
+
+  <div>
+    <h2>Completion Rate by Participant (Grouped Bar)</h2>
+    <canvas id="completionChartTwo"></canvas>
+  </div>
+
+  <div>
+    <h2>Session Duration Distribution (Histogram)</h2>
+    <canvas id="durationChart"></canvas>
+  </div>
+
+  <div>
+    <h2>Daily Accuracy Over Time (Line Chart)</h2>
+    <canvas id="accuracyChart"></canvas>
+  </div>
+
+</div>
+
+{% endblock %}

--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -213,6 +213,17 @@ def validate_block_playlist(request: HttpRequest, rules_id: str) -> JsonResponse
 
 
 @staff_member_required
+def admin_experimenter_analytics(request: HttpRequest, block_id: int):
+    return render(
+        request,
+        "experiment-analytics.html",
+        context={
+            "block_id": block_id,
+        },
+    )
+
+
+@staff_member_required
 def block_export_data(request: HttpRequest, block_id: int):
     try:
         block = Block.objects.get(pk=block_id)


### PR DESCRIPTION
Introduce a prototype of an analytics dashboard using TypeScript and Chart.js, along with a new API endpoint for exporting block data in the admin interface that can be used to build the real analytics dashboard.

As this is a prototype, it is also an invitation to criticise this setup and / or ask questions about things that aren't clear yet.

## How to get this to work?

For the typescript project that contains the scripts for the charts, check https://github.com/Amsterdam-Music-Lab/MUSCLE/blob/76f5440707907f867bc4519f94fb3aa066f9a4b9/backend/experiment/static/analytics/README.md

The transpiled Javascript files are committed into the repository so they should work "out of the box". See also: https://github.com/Amsterdam-Music-Lab/MUSCLE/blob/76f5440707907f867bc4519f94fb3aa066f9a4b9/backend/experiment/static/analytics

Navigate to `http://localhost:8000/admin/experiment/analytics/block/{id}` to see the dashboard of a block in question. Be sure to use a block id of a block that has at least _some_ sessions and results.