### PR TITLE
Initialize playlist input for new block

### DIFF
--- a/backend/experiment/static/collapsible_blocks.js
+++ b/backend/experiment/static/collapsible_blocks.js
@@ -48,6 +48,9 @@ function initializeBlockForm(blockForm) {
   });
 
   blockForm.classList.add('collapsed');
+
+  // Initialize playlist input
+  django.jQuery('.django-select2').djangoSelect2();
 }
 
 function toggleBlockVisibility(blockForm) {


### PR DESCRIPTION
This PR initializes the playlist input `django-select2` when creating a new block, so that it appears in the right place.

closes: #1417 