### PR TITLE
Fixed: Update MSW initialization with relative service worker URL

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -9,7 +9,11 @@ initAudioListener();
 initWebAudioListener();
 
 // Initialize MSW
-initialize()
+initialize({
+    serviceWorker: {
+        url: './mockServiceWorker.js',
+    },
+});
 
 /** @type { import('@storybook/react').Preview } */
 const preview = {


### PR DESCRIPTION
Modify the MSW initialization to use a relative URL for the service worker, ensuring proper loading in various environments.

Related to #1440