### PR TITLE
Added: Add language support and enhance Experiment component

### DIFF
--- a/backend/experiment/serializers.py
+++ b/backend/experiment/serializers.py
@@ -60,6 +60,8 @@ def serialize_experiment(experiment: Experiment, language: str | None = None) ->
         content = Consent(translated_content.consent).action()
     elif experiment.get_fallback_content() and experiment.get_fallback_content().consent:
         content = Consent(experiment.get_fallback_content().consent).action()
+    else:
+        content = None
 
     theme = serialize_theme(experiment.theme_config) if experiment.theme_config else None
     about_content = translated_content.about_content if translated_content.about_content else None

--- a/backend/experiment/tests/test_views.py
+++ b/backend/experiment/tests/test_views.py
@@ -71,17 +71,13 @@ class TestExperimentViews(TestCase):
         self.assertEqual(response_json.get("socialMedia").get("content"), "Please play this Test experiment!")
         self.assertEqual(response_json.get("socialMedia").get("tags"), ["aml", "toontjehoger"])
         self.assertEqual(response_json.get("socialMedia").get("channels"), ["facebook", "twitter", "weibo"])
-        Session.objects.create(
-            block=self.block4, participant=self.participant, finished_at=timezone.now()
-        )
+        Session.objects.create(block=self.block4, participant=self.participant, finished_at=timezone.now())
         # starting second round of experiment
         response = self.client.get("/experiment/test_series/")
         response_json = response.json()
         self.assertIsNotNone(response_json)
         self.assertEqual(response_json.get("nextBlock").get("slug"), "block1")
-        Session.objects.create(
-            block=self.block1, participant=self.participant, finished_at=timezone.now()
-        )
+        Session.objects.create(block=self.block1, participant=self.participant, finished_at=timezone.now())
         response = self.client.get("/experiment/test_series/")
         response_json = response.json()
         self.assertIsNotNone(response_json)
@@ -106,12 +102,7 @@ class TestExperimentViews(TestCase):
         self.assertEqual(response.json().get("nextBlock").get("slug"), "block1")
 
     def _get_session_objects(self, block_list: list[Block]) -> list[Session]:
-        return [
-            Session(
-                block=block, participant=self.participant, finished_at=timezone.now()
-            )
-            for block in block_list
-        ]
+        return [Session(block=block, participant=self.participant, finished_at=timezone.now()) for block in block_list]
 
     def test_experiment_not_found(self):
         # if Experiment does not exist, return 404
@@ -146,7 +137,7 @@ class TestExperimentViews(TestCase):
         )
         response = self.client.get("/experiment/no_social_media/")
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("socialMedia", response.json())
+        self.assertIsNone(response.json().get("socialMedia"))
 
     def test_experiment_with_dashboard(self):
         # if Experiment has dashboard set True, return list of random blocks
@@ -164,17 +155,13 @@ class TestExperimentViews(TestCase):
         )
         self.intermediate_phase.dashboard = True
         self.intermediate_phase.save()
-        serialized_coll_1 = serialize_phase(
-            self.intermediate_phase, self.participant, 0
-        )
+        serialized_coll_1 = serialize_phase(self.intermediate_phase, self.participant, 0)
         total_score_1 = serialized_coll_1["totalScore"]
         self.assertEqual(total_score_1, 8)
         Session.objects.create(
             block=self.block3, participant=self.participant, finished_at=timezone.now(), final_score=8
         )
-        serialized_coll_2 = serialize_phase(
-            self.intermediate_phase, self.participant, 0
-        )
+        serialized_coll_2 = serialize_phase(self.intermediate_phase, self.participant, 0)
         total_score_2 = serialized_coll_2["totalScore"]
         self.assertEqual(total_score_2, 16)
 
@@ -227,9 +214,7 @@ class TestExperimentViews(TestCase):
         response = self.client.get("/experiment/test_experiment_translated_content/", headers={"Accept-Language": "nl"})
 
         # since no Dutch translation is available, the fallback content should be returned
-        self.assertEqual(
-            response.json().get("name"), "Test Experiment Fallback Content"
-        )
+        self.assertEqual(response.json().get("name"), "Test Experiment Fallback Content")
 
     def test_get_block(self):
         # Create a block

--- a/frontend/src/API.ts
+++ b/frontend/src/API.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from "@/config";
-import useGet, { Params } from "./util/useGet";
+import useGet from "./util/useGet";
 import axios from "axios";
 import qs from "qs";
 import IBlock from "@/types/Block";

--- a/frontend/src/API.ts
+++ b/frontend/src/API.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from "@/config";
-import useGet from "./util/useGet";
+import useGet, { Params } from "./util/useGet";
 import axios from "axios";
 import qs from "qs";
 import IBlock from "@/types/Block";
@@ -46,12 +46,11 @@ export const URLS = {
     }
 };
 
-export const useBlock = (slug: string): [IBlock | null, boolean] =>
+export const useBlock = (slug: string) =>
     useGet<IBlock>(API_BASE_URL + URLS.block.get(slug));
 
 export const useExperiment = (slug: string) => {
-    const data = useGet<Experiment>(API_BASE_URL + URLS.experiment.get(slug));
-    return data;
+    return useGet<Experiment>(API_BASE_URL + URLS.experiment.get(slug));
 }
 
 export const useParticipantScores = <T>() =>

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
     disabled?: boolean;
     value?: string;
     clickOnce?: boolean;
+    size?: "sm" | "md" | "lg";
 }
 
 // Button is a button that can only be clicked one time by default
@@ -23,8 +24,15 @@ const Button = ({
     disabled = false,
     value = "",
     clickOnce = true,
+    size = "lg",
 }: ButtonProps) => {
     const clicked = useRef(false);
+
+    const sizeClass = {
+        sm: "btn-sm",
+        md: "btn-md",
+        lg: "btn-lg",
+    }[size];
 
     // Only handle the first click
     const clickOnceGuard = () => {
@@ -55,7 +63,7 @@ const Button = ({
 
     return (
         <button
-            className={classNames({ disabled }, className, padding, "aha__button btn btn-lg")}
+            className={classNames({ disabled }, className, padding, "aha__button btn", sizeClass)}
             onClick={(e) => {
                 clickOnceGuard();
             }}

--- a/frontend/src/components/Consent/Consent.scss
+++ b/frontend/src/components/Consent/Consent.scss
@@ -6,7 +6,7 @@
 
     @media (min-width: 720px) {
         max-width: 500px;
-        margin: -15px auto;
+        margin: 0 auto;
     }
 
     h3 {
@@ -26,6 +26,7 @@
         max-height: calc(100vh - 250px);
         border-bottom: 1px solid $gray;
         margin-bottom: 0;
+
         @media (min-width: 720px) {
             max-height: calc(100vh - 300px);
         }

--- a/frontend/src/components/Experiment/Experiment.tsx
+++ b/frontend/src/components/Experiment/Experiment.tsx
@@ -57,7 +57,7 @@ const Experiment = () => {
         );
     }
 
-    if (!loadingExperiment && !experiment) {
+    if (!experiment) {
         return <p className="aha__error">Experiment not found</p>;
     }
 

--- a/frontend/src/components/Experiment/Experiment.tsx
+++ b/frontend/src/components/Experiment/Experiment.tsx
@@ -44,6 +44,7 @@ const Experiment = () => {
     }
 
     const onSwitchLanguage = (code: string) => {
+        if (code === experiment?.language) return;
         return fetchExperiment({ language: code })
     }
 

--- a/frontend/src/components/Experiment/Experiment.tsx
+++ b/frontend/src/components/Experiment/Experiment.tsx
@@ -8,19 +8,19 @@ import {
 import useBoundStore from "../../util/stores";
 import { useExperiment } from "@/API";
 import Consent from "../Consent/Consent";
+import LanguageSwitcher from "../LanguageSwitcher/LanguageSwitcher";
 import Footer from "../Footer/Footer";
 import DefaultPage from "../Page/DefaultPage";
 import Loading from "../Loading/Loading";
 import ExperimentAbout from "./ExperimentAbout/ExperimentAbout";
 import ExperimentDashboard from "./ExperimentDashboard/ExperimentDashboard";
-import IExperiment from "@/types/Experiment";
 import Redirect from "@/components/Redirect/Redirect";
 import useHeadDataFromExperiment from "@/hooks/useHeadDataFromExperiment";
 
 const Experiment = () => {
     const { slug } = useParams();
 
-    const [experiment, loadingExperiment] = useExperiment(slug!) as [IExperiment, boolean];
+    const [experiment, loadingExperiment, fetchExperiment] = useExperiment(slug!);
     const [hasShownConsent, setHasShownConsent] = useState(false);
     const participant = useBoundStore((state) => state.participant);
     const setTheme = useBoundStore((state) => state.setTheme);
@@ -31,6 +31,7 @@ const Experiment = () => {
     const displayDashboard = experiment?.dashboard.length;
     const showConsent = experiment?.consent;
     const totalScore = experiment?.totalScore;
+    const languages = experiment?.languages || [];
 
     useHeadDataFromExperiment(experiment, setHeadData, resetHeadData);
 
@@ -40,6 +41,10 @@ const Experiment = () => {
 
     const onNext = () => {
         setHasShownConsent(true);
+    }
+
+    const onSwitchLanguage = (code: string) => {
+        return fetchExperiment({ language: code })
     }
 
     const getBlockHref = (slug: string) => `/block/${slug}${participantIdUrl ? `?participant_id=${participantIdUrl}` : ""}`;
@@ -65,6 +70,9 @@ const Experiment = () => {
         }
         return (
             <DefaultPage className='aha__consent-wrapper' title={experiment.name}>
+                {languages.length > 1 && (
+                    <LanguageSwitcher languages={languages} onSwitchLanguage={onSwitchLanguage} currentLangCode={experiment?.language} />
+                )}
                 <Consent {...attrs} />
             </DefaultPage>
         )

--- a/frontend/src/components/LanguageSwitcher/LanguageSwitcher.scss
+++ b/frontend/src/components/LanguageSwitcher/LanguageSwitcher.scss
@@ -1,0 +1,11 @@
+.language-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  .language-switcher__label {
+    margin-bottom: 0rem;
+  }
+}

--- a/frontend/src/components/LanguageSwitcher/LanguageSwitcher.test.tsx
+++ b/frontend/src/components/LanguageSwitcher/LanguageSwitcher.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { it, expect, describe, vi } from 'vitest';
+import LanguageSwitcher from './LanguageSwitcher';
+
+describe('LanguageSwitcher Component', () => {
+  const languages = [
+    { code: 'en', label: 'English' },
+    { code: 'nl', label: 'Dutch' },
+  ];
+
+  it('renders language buttons', () => {
+    render(
+      <LanguageSwitcher
+        languages={languages}
+        currentLangCode="en"
+        onSwitchLanguage={() => { }}
+      />
+    );
+
+    expect(document.querySelector('.language-switcher')).not.toBeNull();
+    expect(screen.getByText('English')).not.toBeNull();
+  });
+
+  it('calls onSwitchLanguage when a language button is clicked', () => {
+    const onSwitchLanguage = vi.fn();
+    render(
+      <LanguageSwitcher
+        languages={languages}
+        currentLangCode="en"
+        onSwitchLanguage={onSwitchLanguage}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Dutch'));
+    expect(onSwitchLanguage).toHaveBeenCalledWith('nl');
+  });
+
+  it('highlights the current language', () => {
+    render(
+      <LanguageSwitcher
+        languages={languages}
+        currentLangCode="en"
+        onSwitchLanguage={() => { }}
+      />
+    );
+
+    const activeButton = screen.getByText('English');
+    expect(activeButton.classList.contains('btn-positive')).toBe(true);
+  });
+});

--- a/frontend/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,0 +1,25 @@
+import { Language } from '@/types/Experiment';
+import React from 'react';
+import Button from '../Button/Button';
+import './LanguageSwitcher.scss';
+
+interface LanguageSwitcherProps {
+  languages: Language[];
+  currentLangCode: string;
+  onSwitchLanguage: (langCode: string) => void;
+}
+
+const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ languages, onSwitchLanguage, currentLangCode }) => {
+
+  return (
+    <div className="language-switcher">
+      <label className='language-switcher__label'>Language:</label>
+      {languages.map((lang) => (
+        <Button key={lang.code} title={lang.label} onClick={() => onSwitchLanguage(lang.code)} clickOnce={false} className={lang.code === currentLangCode ? 'btn-positive' : 'btn-negative'} size='md'>
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/frontend/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -12,7 +12,7 @@ interface LanguageSwitcherProps {
 const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ languages, onSwitchLanguage, currentLangCode }) => {
 
   return (
-    <div className="language-switcher">
+    <div className="language-switcher" data-testid="language-switcher">
       <label className='language-switcher__label'>Language:</label>
       {languages.map((lang) => (
         <Button key={lang.code} title={lang.label} onClick={() => onSwitchLanguage(lang.code)} clickOnce={false} className={lang.code === currentLangCode ? 'btn-positive' : 'btn-negative'} size='md'>

--- a/frontend/src/scss/elements.scss
+++ b/frontend/src/scss/elements.scss
@@ -20,6 +20,10 @@ h3.title {
     font-size: 1.3em;
 }
 
+.btn-sm {
+    font-size: 0.8em;
+}
+
 @mixin btn-style($color) {
     background-color: $color;
     color: white;
@@ -29,7 +33,8 @@ h3.title {
         color: white;
     }
 
-    &:focus, &.checked {
+    &:focus,
+    &.checked {
         box-shadow: 0 0 0 0.2rem rgba($color, 0.5);
     }
 
@@ -51,6 +56,7 @@ h3.title {
 .btn-negative {
     @include btn-style($red);
 }
+
 .btn-yellow {
     @include btn-style($yellow);
 }

--- a/frontend/src/stories/PlayCard.stories.jsx
+++ b/frontend/src/stories/PlayCard.stories.jsx
@@ -1,8 +1,6 @@
 import PlayCard from "../components/MatchingPairs/PlayCard";
 import catImage from "./assets/images/cat-01.webp";
 
-console.log(catImage);
-
 export default {
     title: "PlayCard",
     component: PlayCard,

--- a/frontend/src/types/Experiment.ts
+++ b/frontend/src/types/Experiment.ts
@@ -16,6 +16,11 @@ export interface SocialMediaConfig {
     channels: Array<'facebook' | 'whatsapp' | 'twitter' | 'weibo' | 'share' | 'clipboard'>;
 }
 
+export interface Language {
+    code: string;
+    label: string;
+}
+
 export default interface Experiment {
     slug: string;
     name: string;
@@ -27,4 +32,6 @@ export default interface Experiment {
     theme?: Theme;
     totalScore: number;
     socialMediaConfig?: SocialMediaConfig;
+    languages?: Language[];
+    language: string;
 }

--- a/frontend/src/util/useGet.ts
+++ b/frontend/src/util/useGet.ts
@@ -1,36 +1,36 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 
+export type Params = Record<string, string | number | boolean>;
+
 // useGet is a react hook for getting data from a given url
-export const useGet = <T,>(url: string): [T | null, boolean] => {
+export const useGet = <T,>(url: string): [T | null, boolean, (params?: Params) => Promise<void>] => {
     const [data, setData] = useState<T | null>(null);
     const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        setData(null);
+    const fetchData = useCallback(async (params?: Params) => {
         setLoading(true);
+        try {
+            const response = await axios.get(url, { params });
+            console.log({ response })
+            setData(response.data);
+        } catch (err) {
+            setData(null);
+        } finally {
+            setLoading(false);
+        }
+    }, [url]);
 
+    useEffect(() => {
         const source = axios.CancelToken.source();
-        const fetchData = async () => {
-            try {
-                const response = await axios.get(url);
-                setData(response.data);
-                setLoading(false);
-            } catch (err) {
-                setData(null);
-                setLoading(false);
-            }
-        };
         fetchData();
 
         return () => {
-            setData(null);
-            setLoading(false);
             source.cancel();
         };
-    }, [url]);
+    }, [url, fetchData]);
 
-    return [data, loading];
+    return [data, loading, fetchData];
 };
 
 export default useGet;

--- a/frontend/src/util/useGet.ts
+++ b/frontend/src/util/useGet.ts
@@ -12,7 +12,6 @@ export const useGet = <T,>(url: string): [T | null, boolean, (params?: Params) =
         setLoading(true);
         try {
             const response = await axios.get(url, { params });
-            console.log({ response })
             setData(response.data);
         } catch (err) {
             setData(null);


### PR DESCRIPTION
This PR adds language switch buttons above the `Content` component on the `Experiment` page component. When clicking the language switcher button, the experiment will be re-fetched with a language parameter and subsequently uses the `activate` function to set the language cookie.

This PR can be considered a draft/prototype as we haven't really planned, specified, and designed this feature but is intended to start a conversation.

## Screencap



## Summary

Introduce a LanguageSwitcher for selecting languages, enhance the Experiment model to support multiple languages, and improve data fetching logic in the useGet hook. Additionally, implement customizable button sizes and enhance tests for the new functionality.