### PR TITLE
Docs: Enhance documentation and markdown support for Consent class

### DIFF
--- a/backend/experiment/actions/consent.py
+++ b/backend/experiment/actions/consent.py
@@ -5,10 +5,14 @@ from django.template import Template, Context
 from django_markup.markup import formatter
 from django.core.files import File
 
+from typing import Literal
+
 from .base_action import BaseAction
 
+RenderFormat = Literal["HTML", "MARKDOWN"]
 
-def get_render_format(url: str) -> str:
+
+def get_render_format(url: str) -> RenderFormat:
     """
     Detect markdown file based on file extension
 
@@ -16,7 +20,7 @@ def get_render_format(url: str) -> str:
         url: Url of the consent file
 
     Returns:
-        File format
+        File format of the consent file (HTML or MARKDOWN)
 
     """
     if splitext(url)[1] == ".md":
@@ -24,15 +28,15 @@ def get_render_format(url: str) -> str:
     return "HTML"
 
 
-def render_html_or_markdown(dry_text: str, render_format: str) -> str:
+def render_html_or_markdown(dry_text: str, render_format: RenderFormat) -> str:
     """render html or markdown
 
     Args:
-        dry_text: contents of a markdown or html file
-        render_format: type of contents, either 'HTML' or 'MARKDOWN'
+        dry_text (str): contents of a markdown or html file
+        render_format (RenderFormat): type of contents, either 'HTML' or 'MARKDOWN'
 
     Returns:
-        Content rendered to html
+        Content rendered to html.
     """
 
     if render_format == "HTML":
@@ -42,21 +46,42 @@ def render_html_or_markdown(dry_text: str, render_format: str) -> str:
     if render_format == "MARKDOWN":
         return formatter(dry_text, filter_name="markdown")
 
+    raise ValueError("Invalid render format. Must be either 'HTML' or 'MARKDOWN'.")
+
 
 class Consent(BaseAction):  # pylint: disable=too-few-public-methods
-    """Provide data for a view that ask consent for using the experiment data
+    """Handles experiment consent form generation and rendering and provides the consent form data to the frontend.
+
+    This class manages the display and processing of informed consent forms for experiments.
+    It can handle consent text from multiple sources (file upload, URL template, or default text)
+    and supports both HTML and Markdown formats.
 
     Args:
-        text: Uploaded file via an experiment's translated content's consent (fileField)
-        title: The title to be displayed
-        confirm: The text on the confirm button
-        deny: The text on the deny button
-        url:  If no text is provided the url will be used to load a template (HTML or MARKDOWN)
-                    HTML: (default) Allowed tags: html, django template language
-                    MARKDOWN: Allowed tags: Markdown language
+        text (File): A Django File object containing the consent form content. If provided,
+            this takes precedence over the URL parameter.
+        title (Optional[str]): The heading displayed above the consent form.
+            Defaults to "Informed consent".
+        confirm (Optional[str]): Text for the confirmation button. Defaults to "I agree".
+        deny (Optional[str]): Text for the rejection button. Defaults to "Stop".
+        url (Optional[str]): Template path to load consent content if no text file is provided.
+            Supports both HTML (default) and Markdown files.
+
+    Example:
+        ```python
+        consent = Consent(
+            text=File(open("path/to/consent.md")),
+            title="Informed consent",
+            confirm="I agree",
+            deny="Stop",
+        )
+        ```
 
     Note:
-        Relates to client component: Consent.tsx
+        - The text file is normally uploaded via the admin interface for the experiment, so most of the time (and by default) you will use an experiment's `translated_content.consent` file.
+        - This component is used in conjunction with the frontend Consent.tsx component
+        - HTML templates can use Django template language
+        - Markdown files are automatically converted to HTML
+        - Priority order for content: 1) uploaded file, 2) template URL, 3) default text
     """
 
     # default consent text, that can be used for multiple blocks
@@ -75,7 +100,7 @@ class Consent(BaseAction):  # pylint: disable=too-few-public-methods
 
     def __init__(
         self, text: File, title: str = "Informed consent", confirm: str = "I agree", deny: str = "Stop", url: str = ""
-    ) -> dict:
+    ) -> None:
         # Determine which text to use
         if text != "":
             # Uploaded consent via file field: block.consent (High priority)

--- a/backend/experiment/actions/consent.py
+++ b/backend/experiment/actions/consent.py
@@ -9,10 +9,8 @@ from typing import Literal
 
 from .base_action import BaseAction
 
-RenderFormat = Literal["HTML", "MARKDOWN"]
 
-
-def get_render_format(url: str) -> RenderFormat:
+def get_render_format(url: str) -> Literal["HTML", "MARKDOWN"]:
     """
     Detect markdown file based on file extension
 
@@ -28,12 +26,12 @@ def get_render_format(url: str) -> RenderFormat:
     return "HTML"
 
 
-def render_html_or_markdown(dry_text: str, render_format: RenderFormat) -> str:
+def render_html_or_markdown(dry_text: str, render_format: Literal["HTML", "MARKDOWN"]) -> str:
     """render html or markdown
 
     Args:
         dry_text (str): contents of a markdown or html file
-        render_format (RenderFormat): type of contents, either 'HTML' or 'MARKDOWN'
+        render_format (Literal["HTML", "MARKDOWN"]): type of contents, either 'HTML' or 'MARKDOWN'
 
     Returns:
         Content rendered to html.

--- a/backend/mkdocs.yml
+++ b/backend/mkdocs.yml
@@ -8,6 +8,13 @@ dev_addr: '127.0.0.1:8080'
 markdown_extensions:
   - smarty
   - toc
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
 
 theme:
   name: "material"


### PR DESCRIPTION
**NB:** [Add pymdownx extensions](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-blocks) for improved markdown rendering with syntax highlighting. See also screenshot below for a before & after:

## Screenshots

**Before**

<img width="732" alt="image" src="https://github.com/user-attachments/assets/09353fb7-8d90-4f27-bf25-3a742cc4040a" />


**After**

<img width="731" alt="image" src="https://github.com/user-attachments/assets/daf79c91-c97a-4bef-bfc9-94b0fc247c18" />


Related to #1428

