### PR TITLE
Fixed: Fix deletion of blocks related to translated content

### DIFF
--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -227,6 +227,12 @@ class Block(models.Model):
     theme_config = models.ForeignKey(ThemeConfig, on_delete=models.SET_NULL, blank=True, null=True)
 
     def __str__(self):
+        # If this block is unsaved or being deleted (has no PK),
+        # avoid calling get_fallback_content() (which does a DB query).
+        if not self.pk:
+            # Provide a fallback label or just return self.slug if present.
+            return self.slug or "Deleted/Unsaved Block"
+
         content = self.get_fallback_content()
         return content.name if content and content.name else self.slug
 
@@ -449,10 +455,6 @@ class Block(models.Model):
         Returns:
             Fallback content
         """
-
-        # If the block is not saved yet or is being deleted, there is no fallback content
-        if not self.pk:
-            return None
 
         if not self.phase or self.phase.experiment:
             return self.translated_contents.first()

--- a/backend/experiment/models.py
+++ b/backend/experiment/models.py
@@ -6,12 +6,12 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, get_language
 from django.contrib.postgres.fields import ArrayField
 from django.db.models.query import QuerySet
-from typing import List, Dict, Tuple, Any
+from typing import List, Any
 from experiment.standards.iso_languages import ISO_LANGUAGES
 from theme.models import ThemeConfig
 from image.models import Image
 from session.models import Session
-from typing import Optional, Union
+from typing import Optional
 
 from .validators import markdown_html_validator, block_slug_validator, experiment_slug_validator
 
@@ -31,11 +31,9 @@ class Experiment(models.Model):
         phases (Queryset[Phase]): Queryset of Phase instances
     """
 
-    slug = models.SlugField(db_index=True,
-                                 max_length=64,
-                                 unique=True,
-                                 null=True,
-                                 validators=[experiment_slug_validator])
+    slug = models.SlugField(
+        db_index=True, max_length=64, unique=True, null=True, validators=[experiment_slug_validator]
+    )
     translated_content = models.QuerySet["ExperimentTranslatedContent"]
     theme_config = models.ForeignKey("theme.ThemeConfig", blank=True, null=True, on_delete=models.SET_NULL)
     active = models.BooleanField(default=True)
@@ -288,13 +286,8 @@ class Block(models.Model):
             "block": {
                 "id": self.id,
                 "name": self.name,
-                "sessions": [
-                    session._export_admin() for session in self.session_set.all()
-                ],
-                "participants": [
-                    participant._export_admin()
-                    for participant in self.current_participants()
-                ],
+                "sessions": [session._export_admin() for session in self.session_set.all()],
+                "participants": [participant._export_admin() for participant in self.current_participants()],
             },
         }
 
@@ -388,18 +381,12 @@ class Block(models.Model):
                         # convert result json data to csv columns if selected
                         if "convert_result_json" in export_options:
                             if "decision_time" in export_options:
-                                result_data[result_prefix + "decision_time"] = (
-                                    result.json_data.get("decision_time", "")
-                                )
+                                result_data[result_prefix + "decision_time"] = result.json_data.get("decision_time", "")
                             if "result_config" in export_options:
-                                result_data[result_prefix + "result_config"] = (
-                                    result.json_data.get("config", "")
-                                )
+                                result_data[result_prefix + "result_config"] = result.json_data.get("config", "")
                         else:
                             if "result_config" in export_options:
-                                result_data[result_prefix + "result_data"] = (
-                                    result.json_data
-                                )
+                                result_data[result_prefix + "result_data"] = result.json_data
                     this_row.update(result_data)
                     fieldnames.update(result_data.keys())
                     result_counter += 1
@@ -456,12 +443,16 @@ class Block(models.Model):
                         question_series=qs, question=Question.objects.get(pk=question), index=i + 1
                     )
 
-    def get_fallback_content(self) -> "BlockTranslatedContent":
+    def get_fallback_content(self) -> "BlockTranslatedContent | None":
         """Get fallback content for the block
 
         Returns:
             Fallback content
         """
+
+        # If the block is not saved yet or is being deleted, there is no fallback content
+        if not self.pk:
+            return None
 
         if not self.phase or self.phase.experiment:
             return self.translated_contents.first()
@@ -623,9 +614,7 @@ class SocialMediaConfig(models.Model):
         experiment_name = translated_content.name
 
         if social_message:
-            has_placeholders = (
-                "{points}" in social_message and "{experiment_name}" in social_message
-            )
+            has_placeholders = "{points}" in social_message and "{experiment_name}" in social_message
 
             if not has_placeholders:
                 return social_message
@@ -636,9 +625,7 @@ class SocialMediaConfig(models.Model):
             return social_message.format(points=score, experiment_name=experiment_name)
 
         if score is None or experiment_name is None:
-            raise ValueError(
-                "score and name are required when no social media message is provided"
-            )
+            raise ValueError("score and name are required when no social media message is provided")
 
         return _("I scored %(score)d points in %(experiment_name)s") % {
             "score": score,

--- a/backend/experiment/tests/test_model.py
+++ b/backend/experiment/tests/test_model.py
@@ -44,6 +44,22 @@ class BlockModelTest(TestCase):
         block = Block.objects.get(slug="test-block")
         self.assertEqual(str(block), "Test Block")
 
+    def test_block_str_without_content(self):
+        block_no_content = Block.objects.create(slug="test-block-no-content")
+        self.assertEqual(str(block_no_content), "test-block-no-content")
+
+    def test_block_str_without_pk(self):
+        block_no_pk = Block.objects.create()
+        BlockTranslatedContent.objects.create(
+            block=block_no_pk,
+            language="en",
+            name="Not yet deleted test block",
+            description="Deleted test block description",
+        )
+        self.assertEqual(str(block_no_pk), "Not yet deleted test block")
+        block_no_pk.delete()
+        self.assertEqual(str(block_no_pk), "Deleted/Unsaved Block")
+
     def test_block_session_count(self):
         block = Block.objects.get(slug="test-block")
         self.assertEqual(block.session_count(), 0)


### PR DESCRIPTION
Address an issue preventing the deletion of blocks due to a block without a primary key being unable to relate to translated content.

Fixes #1436