### PR TITLE
Docs(Trial): Enhance Trial action configuration with type annotations and examples

### DIFF
--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -9,14 +9,14 @@ from .frontend_style import FrontendStyle
 
 class Config(TypedDict):
     """
-    Configuration for the Trial action
+    Configuration for the Trial action.
 
     Args:
-        response_time: how long to wait until stopping the player / proceeding to the next view
-        auto_advance: proceed to next view after player has stopped
-        listen_first: whether participant can submit before end of sound
-        show_continue_button: whether to show a button to proceed to the next view
-        continue_label: label for the continue button
+      - response_time (int): how long to wait until stopping the player
+      - auto_advance (bool): proceed automatically after stopping
+      - listen_first (bool): block form submission until playback ends
+      - show_continue_button (bool): display a 'Continue' button
+      - continue_label (str): label for the continue button
     """
 
     response_time: int

--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -42,6 +42,30 @@ class Trial(BaseAction):  # pylint: disable=too-few-public-methods
             boolean: first element is green, second is red
             boolean-negative-first: first element is red, second is green
 
+    Example:
+        ```python
+        key = 'test_trial'
+        section = session.playlist.get_section()
+        question = BooleanQuestion(
+            question=_(
+                "Do you like this song?"),
+            key=key,
+            result_id=prepare_result(key, session, section=section),
+            submits=True
+        )
+        form = Form([question])
+        playback = Autoplay([section])
+        view = Trial(
+            playback=playback,
+            feedback_form=form,
+            title=_('Test block'),
+            config={
+                'response_time': section.duration,
+                'listen_first': True
+            }
+        )
+        ```
+
     Note:
         Relates to client component: Trial.tsx
     """

--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -1,4 +1,5 @@
 from django.utils.translation import gettext_lazy as _
+from typing import Optional, TypedDict
 
 from .base_action import BaseAction
 from experiment.actions.form import Form
@@ -6,45 +7,56 @@ from experiment.actions.playback import Playback
 from .frontend_style import FrontendStyle
 
 
+class Config(TypedDict):
+    """
+    Configuration for the Trial action
+
+    Args:
+        response_time: how long to wait until stopping the player / proceeding to the next view
+        auto_advance: proceed to next view after player has stopped
+        listen_first: whether participant can submit before end of sound
+        show_continue_button: whether to show a button to proceed to the next view
+        continue_label: label for the continue button
+    """
+
+    response_time: int
+    auto_advance: bool
+    listen_first: bool
+    show_continue_button: bool
+    continue_label: str
+
+
 class Trial(BaseAction):  # pylint: disable=too-few-public-methods
     """
-    A view that may include Playback and/or a Form
-    Relates to client component: Trial.js
+    A view that may include Playback and/or a Form to be displayed to the participant.
 
-    Parameters:
-    - playback: player(s) to be displayed in this view
-    - feedback_form: array of form elements
-    - title: page title - defaults to empty
+    Args:
+        playback (Optional[Playback]): Player(s) to be displayed in this view (e.g. audio, video, image)
+        html (Optional[str]): HTML to be displayed in this view
+        feedback_form (Optional[Form]): array of form elements
+        title (Optional(str)): page title - defaults to empty
+        config (Optional[Config]): dictionary with following settings
+        style (FrontendStyle): style class to add to elements in form and playback
+            neutral: first element is blue, second is yellow, third is teal
+            neutral-inverted: first element is yellow, second is blue, third is teal
+            boolean: first element is green, second is red
+            boolean-negative-first: first element is red, second is green
+
+    Note:
+        Relates to client component: Trial.tsx
     """
 
     ID = "TRIAL_VIEW"
 
     def __init__(
         self,
-        playback: Playback = None,
-        html: str = None,
-        feedback_form: Form = None,
+        playback: Optional[Playback] = None,
+        html: Optional[str] = None,
+        feedback_form: Optional[Form] = None,
         title="",
-        config: dict = None,
+        config: Optional[Config] = None,
         style: FrontendStyle = FrontendStyle(),
     ):
-        """
-        - playback: Playback object (may be None)
-        - html: HTML object (may be None)
-        - feedback_form: Form object (may be None)
-        - title: string setting title in header of experiment
-        - config: dictionary with following settings
-            - response_time: how long to wait until stopping the player / proceeding to the next view
-            - auto_advance: proceed to next view after player has stopped
-            - listen_first: whether participant can submit before end of sound
-            - break_round_on: result values upon which consecutive rounds in the current next_round array will be skipped
-            - continue_label: if there is no form, how to label a button to proceed to next view
-        - style: style class to add to elements in form and playback
-            - neutral: first element is blue, second is yellow, third is teal
-            - neutral-inverted: first element is yellow, second is blue, third is teal
-            - boolean: first element is green, second is red
-            - boolean-negative-first: first element is red, second is green
-        """
         self.playback = playback
         self.html = html
         self.feedback_form = feedback_form

--- a/backend/experiment/actions/trial.py
+++ b/backend/experiment/actions/trial.py
@@ -35,7 +35,7 @@ class Trial(BaseAction):  # pylint: disable=too-few-public-methods
         html (Optional[str]): HTML to be displayed in this view
         feedback_form (Optional[Form]): array of form elements
         title (Optional(str)): page title - defaults to empty
-        config (Optional[Config]): dictionary with following settings
+        config (Optional[Config]): configuration for the trial with options for response time, auto advance, listen first, show continue button, and continue label
         style (FrontendStyle): style class to add to elements in form and playback
             neutral: first element is blue, second is yellow, third is teal
             neutral-inverted: first element is yellow, second is blue, third is teal


### PR DESCRIPTION
Improve type annotations and documentation for the Trial action configuration. Add example usage to the documentation for better clarity and guidance.

Related to #1428