### PR TITLE
Pin postgres version to 14 for older installations

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 # Docker-compose definition for development
 services:
   db:
-    image: postgres:16
+    image: postgres:14
     environment:
       - POSTGRES_DB=${SQL_DATABASE}
       - POSTGRES_USER=${SQL_USER}


### PR DESCRIPTION
Pin postgres version to 14. 
`docker-compose-deploy` is still pinned to 16, as the servers' installations are quite recent. 
closes: #1459 