### PR TITLE
Fixed: Add `show_percentile` option to `Final` action & component

### DIFF
--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -47,6 +47,7 @@ class FinalActionResponse(TypedDict):
     social: Optional[SocialMediaConfigConfiguration]
     show_profile_link: bool
     show_participant_link: bool
+    show_percentile: bool
     feedback_info: Optional[Dict[str, str]]
     participant_id_only: bool
     logo: Optional[LogoConfiguration]
@@ -77,6 +78,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         show_profile_link (bool): If True, display a link to the participant's profile.
         show_participant_link (bool): If True, display a participant-related link or information.
         show_participant_id_only (bool): If True, only the participant ID is shown, without a link.
+        show_percentile (bool): If True, display the participant's percentile rank.
         feedback_info (Optional[Dict[str, str]]): Optional dictionary containing feedback-related data. For example:
                                                   {"header": "Feedback", "prompt": "Tell us what you think", "button_text": "Submit"}.
         total_score (Optional[float]): Explicit final score. If None, this is derived from the session.
@@ -113,6 +115,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         feedback_info: FeedbackInfo | None = None,
         total_score: Optional[float] = None,
         logo: Optional[LogoConfiguration] = None,
+        show_percentile: bool = False,
     ):
         self.session = session
         self.title = title
@@ -122,6 +125,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         self.show_profile_link = show_profile_link
         self.show_participant_link = show_participant_link
         self.show_participant_id_only = show_participant_id_only
+        self.show_percentile = show_percentile
         self.feedback_info = feedback_info
         self.logo = logo
         self.percentile = session.percentile_rank(exclude_unfinished=False)
@@ -154,13 +158,13 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             "social": self.get_social_media_config(self.session),
             "show_profile_link": self.show_profile_link,
             "show_participant_link": self.show_participant_link,
+            "show_percentile": self.show_percentile,
             "feedback_info": self.feedback_info,
             "participant_id_only": self.show_participant_id_only,
             "logo": self.logo,
         }
 
         if self.percentile is None:
-            response.pop("percentile")
             response.pop("rank")
 
         return response

--- a/backend/experiment/actions/final.py
+++ b/backend/experiment/actions/final.py
@@ -47,7 +47,6 @@ class FinalActionResponse(TypedDict):
     social: Optional[SocialMediaConfigConfiguration]
     show_profile_link: bool
     show_participant_link: bool
-    show_percentile: bool
     feedback_info: Optional[Dict[str, str]]
     participant_id_only: bool
     logo: Optional[LogoConfiguration]
@@ -78,7 +77,6 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         show_profile_link (bool): If True, display a link to the participant's profile.
         show_participant_link (bool): If True, display a participant-related link or information.
         show_participant_id_only (bool): If True, only the participant ID is shown, without a link.
-        show_percentile (bool): If True, display the participant's percentile rank.
         feedback_info (Optional[Dict[str, str]]): Optional dictionary containing feedback-related data. For example:
                                                   {"header": "Feedback", "prompt": "Tell us what you think", "button_text": "Submit"}.
         total_score (Optional[float]): Explicit final score. If None, this is derived from the session.
@@ -115,7 +113,7 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         feedback_info: FeedbackInfo | None = None,
         total_score: Optional[float] = None,
         logo: Optional[LogoConfiguration] = None,
-        show_percentile: bool = False,
+        percentile: Optional[float] = None,  # new argument
     ):
         self.session = session
         self.title = title
@@ -125,10 +123,9 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
         self.show_profile_link = show_profile_link
         self.show_participant_link = show_participant_link
         self.show_participant_id_only = show_participant_id_only
-        self.show_percentile = show_percentile
         self.feedback_info = feedback_info
         self.logo = logo
-        self.percentile = session.percentile_rank(exclude_unfinished=False)
+        self.percentile = percentile
 
         if total_score is None:
             self.total_score = self.session.total_score()
@@ -158,7 +155,6 @@ class Final(BaseAction):  # pylint: disable=too-few-public-methods
             "social": self.get_social_media_config(self.session),
             "show_profile_link": self.show_profile_link,
             "show_participant_link": self.show_participant_link,
-            "show_percentile": self.show_percentile,
             "feedback_info": self.feedback_info,
             "participant_id_only": self.show_participant_id_only,
             "logo": self.logo,

--- a/backend/experiment/actions/tests/test_actions_final.py
+++ b/backend/experiment/actions/tests/test_actions_final.py
@@ -70,12 +70,32 @@ class FinalTest(TestCase):
         social_info = serialized.get("social")
         self.assertEqual(social_info.get("content"), "I scored 42.0 points in Final Countdown!")
 
-    def test_final_action_without_percentile(self):
+    def test_final_action_with_percentile_disabled(self):
         final = Final(self.session)
-        final.percentile = None
+        final.percentile = 85.0
+        final.show_percentile = False
         serialized = final.action()
-        self.assertNotIn("percentile", serialized)
-        self.assertNotIn("rank", serialized)
+        self.assertEqual(serialized.get("percentile"), 85.0)
+
+    def test_final_action_with_percentile_ranges(self):
+        test_cases = [
+            95.0,
+            85.0,
+            65.0,
+            45.0,
+            25.0,
+            5.0,
+        ]
+
+        for percentile in test_cases:
+            with self.subTest(percentile=percentile):
+                final = Final(self.session)
+                final.percentile = percentile
+                final.show_percentile = True
+                serialized = final.action()
+
+                self.assertIn("percentile", serialized)
+                self.assertEqual(serialized["percentile"], percentile)
 
     def test_final_action_with_percentile(self):
         final = Final(self.session)

--- a/backend/experiment/actions/tests/test_actions_final.py
+++ b/backend/experiment/actions/tests/test_actions_final.py
@@ -73,27 +73,16 @@ class FinalTest(TestCase):
     def test_final_action_with_percentile_disabled(self):
         final = Final(self.session)
         final.percentile = 85.0
-        final.show_percentile = False
         serialized = final.action()
         self.assertEqual(serialized.get("percentile"), 85.0)
 
     def test_final_action_with_percentile_ranges(self):
-        test_cases = [
-            95.0,
-            85.0,
-            65.0,
-            45.0,
-            25.0,
-            5.0,
-        ]
-
+        test_cases = [95.0, 85.0, 65.0, 45.0, 25.0, 5.0]
         for percentile in test_cases:
             with self.subTest(percentile=percentile):
                 final = Final(self.session)
                 final.percentile = percentile
-                final.show_percentile = True
                 serialized = final.action()
-
                 self.assertIn("percentile", serialized)
                 self.assertEqual(serialized["percentile"], percentile)
 

--- a/backend/experiment/rules/matching_pairs_2025.py
+++ b/backend/experiment/rules/matching_pairs_2025.py
@@ -59,6 +59,7 @@ class MatchingPairs2025(MatchingPairsGame):
                 button={"text": "Play again", "link": self.get_play_again_url(session)},
                 rank=self.rank(session, exclude_unfinished=False),
                 feedback_info=feedback_info,
+                show_percentile=True,
             )
             return [score]
 

--- a/backend/experiment/rules/matching_pairs_2025.py
+++ b/backend/experiment/rules/matching_pairs_2025.py
@@ -59,7 +59,7 @@ class MatchingPairs2025(MatchingPairsGame):
                 button={"text": "Play again", "link": self.get_play_again_url(session)},
                 rank=self.rank(session, exclude_unfinished=False),
                 feedback_info=feedback_info,
-                show_percentile=True,
+                percentile=session.percentile_rank(exclude_unfinished=False),
             )
             return [score]
 

--- a/frontend/src/components/Final/Final.test.tsx
+++ b/frontend/src/components/Final/Final.test.tsx
@@ -185,7 +185,7 @@ describe('Final Component', () => {
         });
     });
 
-    it('Sets the rank cursor position correctly based on percentile', () => {
+    it('Sets the rank cursor position correctly when percentile is valid', () => {
         render(
             <BrowserRouter>
                 <Final
@@ -193,11 +193,9 @@ describe('Final Component', () => {
                     score={100}
                     final_text="<p>Final Text</p>"
                     percentile={50}
-                    show_percentile={true}
                 />
             </BrowserRouter>
         );
-
         const cursor = screen.getByTestId('final-rank-bar-cursor');
         expect(cursor.style.left).toBe('50%');
     });
@@ -213,11 +211,25 @@ describe('Final Component', () => {
                 />
             </BrowserRouter>
         );
-
         expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
     });
 
-    it('does not percentile/rank part when only percentile is defined', () => {
+    it('does not render percentile/rank part when percentile is out of range', () => {
+        render(
+            <BrowserRouter>
+                <Final
+                    block={{ slug: 'test-block' }}
+                    participant="participant-id"
+                    score={100}
+                    final_text="<p>Final Text</p>"
+                    percentile={150}
+                />
+            </BrowserRouter>
+        );
+        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
+    });
+
+    it('renders percentile/rank part when percentile is between 0 and 100', () => {
         render(
             <BrowserRouter>
                 <Final
@@ -229,57 +241,6 @@ describe('Final Component', () => {
                 />
             </BrowserRouter>
         );
-
-        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
-    });
-
-    it('does not render percentile/rank part when show_percentile is false', () => {
-        render(
-            <BrowserRouter>
-                <Final
-                    block={{ slug: 'test-block' }}
-                    participant="participant-id"
-                    score={100}
-                    final_text="<p>Final Text</p>"
-                    percentile={75}
-                    show_percentile={false}
-                />
-            </BrowserRouter>
-        );
-
-        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
-    });
-
-    it('renders percentile/rank part when show_percentile is true', () => {
-        render(
-            <BrowserRouter>
-                <Final
-                    block={{ slug: 'test-block' }}
-                    participant="participant-id"
-                    score={100}
-                    final_text="<p>Final Text</p>"
-                    percentile={75}
-                    show_percentile={true}
-                />
-            </BrowserRouter>
-        );
-
         expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(true);
-    });
-
-    it('defaults to not showing percentile when show_percentile is not specified', () => {
-        render(
-            <BrowserRouter>
-                <Final
-                    block={{ slug: 'test-block' }}
-                    participant="participant-id"
-                    score={100}
-                    final_text="<p>Final Text</p>"
-                    percentile={75}
-                />
-            </BrowserRouter>
-        );
-
-        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
     });
 });

--- a/frontend/src/components/Final/Final.test.tsx
+++ b/frontend/src/components/Final/Final.test.tsx
@@ -193,6 +193,7 @@ describe('Final Component', () => {
                     score={100}
                     final_text="<p>Final Text</p>"
                     percentile={50}
+                    show_percentile={true}
                 />
             </BrowserRouter>
         );
@@ -216,7 +217,7 @@ describe('Final Component', () => {
         expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
     });
 
-    it('renders percentile/rank part when percentile is defined', () => {
+    it('does not percentile/rank part when only percentile is defined', () => {
         render(
             <BrowserRouter>
                 <Final
@@ -229,6 +230,56 @@ describe('Final Component', () => {
             </BrowserRouter>
         );
 
+        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
+    });
+
+    it('does not render percentile/rank part when show_percentile is false', () => {
+        render(
+            <BrowserRouter>
+                <Final
+                    block={{ slug: 'test-block' }}
+                    participant="participant-id"
+                    score={100}
+                    final_text="<p>Final Text</p>"
+                    percentile={75}
+                    show_percentile={false}
+                />
+            </BrowserRouter>
+        );
+
+        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
+    });
+
+    it('renders percentile/rank part when show_percentile is true', () => {
+        render(
+            <BrowserRouter>
+                <Final
+                    block={{ slug: 'test-block' }}
+                    participant="participant-id"
+                    score={100}
+                    final_text="<p>Final Text</p>"
+                    percentile={75}
+                    show_percentile={true}
+                />
+            </BrowserRouter>
+        );
+
         expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(true);
+    });
+
+    it('defaults to not showing percentile when show_percentile is not specified', () => {
+        render(
+            <BrowserRouter>
+                <Final
+                    block={{ slug: 'test-block' }}
+                    participant="participant-id"
+                    score={100}
+                    final_text="<p>Final Text</p>"
+                    percentile={75}
+                />
+            </BrowserRouter>
+        );
+
+        expect(document.body.contains(screen.queryByTestId('final-rank-bar-cursor'))).toBe(false);
     });
 });

--- a/frontend/src/components/Final/Final.tsx
+++ b/frontend/src/components/Final/Final.tsx
@@ -32,7 +32,6 @@ const Final = ({
     show_participant_link,
     participant_id_only,
     show_profile_link,
-    show_percentile,
     social,
     feedback_info,
     points,
@@ -55,7 +54,7 @@ const Final = ({
                     <Rank cup={{ className: rank?.class, text: rank.text }} score={{ score, label: points }} />
                 </div>
             )}
-            {show_percentile && (
+            {(typeof percentile === 'number' && percentile >= 0 && percentile <= 100) && (
                 <div className={classNames("aha__final-rank-bar-section", rank?.class)}>
                     <div data-testid="final-rank-bar-cursor" className="aha__final-rank-bar-cursor" style={{ left: `${percentile}%` }}></div>
                 </div>

--- a/frontend/src/components/Final/Final.tsx
+++ b/frontend/src/components/Final/Final.tsx
@@ -32,6 +32,7 @@ const Final = ({
     show_participant_link,
     participant_id_only,
     show_profile_link,
+    show_percentile,
     social,
     feedback_info,
     points,
@@ -54,7 +55,7 @@ const Final = ({
                     <Rank cup={{ className: rank?.class, text: rank.text }} score={{ score, label: points }} />
                 </div>
             )}
-            {percentile !== undefined && (
+            {show_percentile && (
                 <div className={classNames("aha__final-rank-bar-section", rank?.class)}>
                     <div data-testid="final-rank-bar-cursor" className="aha__final-rank-bar-cursor" style={{ left: `${percentile}%` }}></div>
                 </div>

--- a/frontend/src/types/Action.ts
+++ b/frontend/src/types/Action.ts
@@ -78,6 +78,7 @@ export interface Final {
   show_participant_link: boolean;
   participant_id_only: boolean;
   show_profile_link: boolean;
+  show_percentile: boolean;
   social: Social;
   feedback_info?: FeedbackInfo;
   points: string;

--- a/frontend/src/types/Action.ts
+++ b/frontend/src/types/Action.ts
@@ -70,7 +70,7 @@ export interface Final {
     all_experiments: string;
     profile: string;
     play_again: string;
-  }
+  };
   button: {
     text: string;
     link: string;
@@ -78,14 +78,13 @@ export interface Final {
   show_participant_link: boolean;
   participant_id_only: boolean;
   show_profile_link: boolean;
-  show_percentile: boolean;
   social: Social;
   feedback_info?: FeedbackInfo;
   points: string;
   rank: {
     class: string;
     text: string;
-  }
+  };
   logo: {
     image: string;
     link: string;


### PR DESCRIPTION
Introduce a new option to display the participant's percentile rank in the Final action and component, along with enhanced tests to verify this functionality.

Fixes #1488
