### PR TITLE
Docs: Add link to releases page for updates and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This application provides an easy way to implement and run online listening expe
 
 - We are also happy if you file a feature request in our [issues list](https://github.com/Amsterdam-Music-Lab/aml-experiments/issues), or if you fork this repository to add your own code.
 
+- Check out our [releases page](https://github.com/Amsterdam-Music-Lab/MUSCLE/releases) for the latest updates and changes.
+
 ## Before installation
 We recommend downloading a code editor, for instance [Visual Studio Code](https://code.visualstudio.com/), and to use [git](https://git-scm.com/) to copy this repository to your machine, as this makes it easier to keep your local copy up to date.
 


### PR DESCRIPTION
Include a link to the releases page in the documentation.

Resolves #1005