### PR TITLE
Fixed: Update default experiment slug in bootstrap command to `gold-msi`

### DIFF
--- a/backend/experiment/management/commands/bootstrap.py
+++ b/backend/experiment/management/commands/bootstrap.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             management.call_command("createsuperuser", "--no-input")
             print("Created superuser")
         if Experiment.objects.count() == 0:
-            experiment = Experiment.objects.create(slug="test")
+            experiment = Experiment.objects.create(slug="gold-msi")
             phase = Phase.objects.create(experiment=experiment)
             playlist = Playlist.objects.create(name="Empty Playlist")
             block = Block.objects.create(


### PR DESCRIPTION
Change the experiment slug from "test" to "gold-msi" in the bootstrap command to reflect the current experiment configuration so that http://localhost:3000/gold-msi will match the bootstrapped experiment.