### PR TITLE
Set postgres version to 16

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 # Docker-compose definition for development
 services:
   db:
-    image: postgres:14
+    image: postgres:16
     environment:
       - POSTGRES_DB=${SQL_DATABASE}
       - POSTGRES_USER=${SQL_USER}


### PR DESCRIPTION
This PR set the Postgres database to version 16.
Be aware that older volumes created with an earlier version are not compatible and have to be converted.