### PR TITLE
bugfix: TypeError when result.score is `None`

### DIFF
--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -82,7 +82,7 @@ class BaseRules(object):
             if result.score:
                 total += 1
 
-                if result.score > 0:
+                if result.score and result.score > 0:
                     # if a result has score > 0, it was identified correctly
                     correct += 1
 

--- a/backend/experiment/rules/hooked.py
+++ b/backend/experiment/rules/hooked.py
@@ -179,12 +179,12 @@ class Hooked(BaseRules):
                     n_sync_guessed += 1
                     json_data = result.json_data
                     sync_time += json_data.get("decision_time")
-                    if result.score > 0:
+                    if result.score and result.score > 0:
                         n_sync_correct += 1
             else:
                 if result.expected_response == "old":
                     n_old_new_expected += 1
-                    if result.score > 0:
+                    if result.score and result.score > 0:
                         n_old_new_correct += 1
 
         score_message = "Well done!" if session.final_score > 0 else "Too bad!"

--- a/backend/experiment/rules/huang_2022.py
+++ b/backend/experiment/rules/huang_2022.py
@@ -208,12 +208,12 @@ class Huang2022(Hooked):
             if json_data.get('result') and json_data['result']['type'] == 'recognized':
                 n_sync_guessed += 1
                 sync_time += json_data['result']['recognition_time']
-                if result.score > 0:
+                if result.score and result.score > 0:
                     n_sync_correct += 1
             else:
                 if result.expected_response == 'old':
                     n_old_new_expected += 1
-                    if result.score > 0:
+                    if result.score and result.score > 0:
                         n_old_new_correct += 1
         thanks_message = _("Thank you for your contribution to science!")
         score_message = _(

--- a/backend/experiment/rules/toontjehoger_1_mozart.py
+++ b/backend/experiment/rules/toontjehoger_1_mozart.py
@@ -89,7 +89,7 @@ class ToontjeHoger1Mozart(BaseRules):
     def get_answer_explainer(self, session, round):
         last_result = session.last_result()
 
-        correct_answer_given = last_result.score > 0
+        correct_answer_given = last_result.score and last_result.score > 0
 
         heading = "Goed gedaan!" if correct_answer_given else "Helaas!"
 


### PR DESCRIPTION
This PR fixes an error reported by Sentry. This originally occurred in `hooked.py`, but I also found and fixed other rules files which might suffer from this bug.