### PR TITLE
fix: missing lazy import breaking consent denied and dashboard

### DIFF
--- a/frontend/src/components/views/views.ts
+++ b/frontend/src/components/views/views.ts
@@ -54,13 +54,16 @@ views.consent = {
 };
 
 views.consentDenied = {
-  component: () =>
-    import("@/components/views/ConsentDeniedView/ConsentDeniedView"),
+  component: lazy(
+    () => import("@/components/views/ConsentDeniedView/ConsentDeniedView")
+  ),
   meta: { usesOwnLayout: false },
 };
 
 views.dashboard = {
-  component: () => import("@/components/views/DashboardView/DashboardView"),
+  component: lazy(
+    () => import("@/components/views/DashboardView/DashboardView")
+  ),
   meta: {
     usesOwnLayout: true,
     getViewProps: ({ experiment, participant }) => ({


### PR DESCRIPTION
Two imports in views.tsx were not lazy, causing the consent denied and dashboard view to crash.