### PR TITLE
Bugfix: Participant.DoesNotExist raised

### DIFF
--- a/backend/experiment/views.py
+++ b/backend/experiment/views.py
@@ -15,7 +15,7 @@ from experiment.serializers import (
 from experiment.rules import BLOCK_RULES
 from experiment.actions.utils import EXPERIMENT_KEY
 from participant.models import Participant
-from participant.utils import get_participant
+from participant.utils import get_or_create_participant
 from theme.serializers import serialize_theme
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ def get_block(request: HttpRequest, slug: str) -> JsonResponse:
     if active_language.startswith("zh"):
         class_name = "chinese"
 
-    participant = get_participant(request)
+    participant = get_or_create_participant(request)
     session = Session(block=block, participant=participant)
 
     playlist = block.playlists.first()
@@ -108,7 +108,7 @@ def get_experiment(
         )
 
     request.session[EXPERIMENT_KEY] = slug
-    participant = get_participant(request)
+    participant = get_or_create_participant(request)
 
     phases = list(experiment.phases.order_by("index").all())
     if not len(phases):

--- a/backend/participant/views.py
+++ b/backend/participant/views.py
@@ -1,4 +1,5 @@
 import logging
+
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail


### PR DESCRIPTION
Sentry flags a problem in which a participant cannot be found when users start up the game. My assumption is that this happens when the `participant/` call takes longer than the `experiment/` or `block/` call. I fixed this now by using `get_or_create_participant` instead of `get_participant`, as the former does handle the raised error properly, and creates a participant if it doesn't exist yet. From experimenting with letting the `participant.current` method sleep, to enforce this call is resolved after the `experiment` or `block` call, it does seem as though this does not lead to extra participants being created.