### PR TITLE
fix: finalize experiment when max number of turnpoints is reached

### DIFF
--- a/backend/experiment/rules/duration_discrimination.py
+++ b/backend/experiment/rules/duration_discrimination.py
@@ -205,8 +205,8 @@ class DurationDiscrimination(BaseRules, PracticeMixin):
                     # register turnpoint
                     register_turnpoint(session, last_result)
                 if session.final_score == self.max_turnpoints + 1:
-                    # experiment is finished, None will be replaced by final view
-                    return None
+                    # maximum number of turnpoints reached, finalize block
+                    return self.finalize_block(session)
                 else:
                     # register decreasing difficulty
                     session.save_json_data({"direction": "decrease"})
@@ -235,7 +235,7 @@ class DurationDiscrimination(BaseRules, PracticeMixin):
                 else:
                     action = self.get_next_trial(session)
         if not action:
-            # action is None if the audio file doesn't exist
+            # action is None if the audio file doesn't exist (outlier)
             return self.finalize_block(session)
         return action
 

--- a/backend/experiment/rules/tests/test_duration_discrimination.py
+++ b/backend/experiment/rules/tests/test_duration_discrimination.py
@@ -1,6 +1,9 @@
+import random
+from unittest import skip
+
 from django.test import TestCase
 
-from experiment.actions import Explainer, Trial
+from experiment.actions import Explainer, Final, Trial
 from experiment.models import Block
 from participant.models import Participant
 from result.models import Result
@@ -83,6 +86,33 @@ class DDITest(TestCase):
         assert regular_trial.feedback_form
         section = regular_trial.playback.sections[0]
         assert section['id'] == diff_section.id
+
+    @skip(
+        "This test simulates playing through the whole experiment, uncomment this line to run"
+    )
+    def test_simulate_full_experiment(self):
+        n_games = 20
+        self.session.save_json_data(
+            {"practice_done": True, "difficulty": self.rules.start_diff}
+        )
+        for game in range(n_games):
+            for round_number in range(50):
+                print(f"Round {round_number+1} of game {game+1}")
+                actions = self.rules.next_round(self.session)
+                self.assertIsNotNone(actions)
+                if isinstance(actions, Trial):
+                    last_result = Result.objects.last()
+                    if last_result.expected_response == 'longer':
+                        last_result.score = random.choice([0, 1])
+                    else:
+                        last_result.score = random.choice([0, 2])
+                    last_result.save()
+                else:
+                    Result.objects.all().delete()
+                    self.session.final_score = 0
+                    self.session.save_json_data({"difficulty": self.rules.start_diff})
+                    self.assertIsInstance(actions, Final)
+                    break
 
 
 class AnisochronyTest(TestCase):


### PR DESCRIPTION
Sentry flagged errors coming from the Duration Discrimination experiments: the object returned from the rules' `next_round` was `None`. The problem was that instead of returning a `Final` action, the `staircasing_blocks` function returned `None`. This is of course incorrect - probably an error caused by refactoring.