### PR TITLE
That's My Song: ask questions every round after first playthrough

### DIFF
--- a/backend/experiment/rules/base.py
+++ b/backend/experiment/rules/base.py
@@ -90,6 +90,17 @@ class BaseRules(object):
         message = "You correctly identified {} out of {} recognized songs!".format(correct, total)
         return score_message + " " + message
 
+    def has_played_before(self, session):
+        """Check if the current participant has completed this game previously."""
+        previous_games = Session.objects.filter(
+            participant=session.participant,
+            block=session.block,
+            finished_at__isnull=False,
+        )
+        if previous_games.count():
+            return True
+        return False
+
     def rank(self, session, exclude_unfinished=True):
         """Get rank based on session score"""
         score = session.final_score

--- a/backend/experiment/rules/tests/test_base.py
+++ b/backend/experiment/rules/tests/test_base.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 from django.test import TestCase
+
 from experiment.models import Block
 from session.models import Session
 from participant.models import Participant
@@ -43,3 +46,13 @@ class BaseRulesTest(TestCase):
         playlist = Playlist.objects.create()
         errors = base.validate_playlist(playlist)
         self.assertEqual(errors, ["The block must have at least one section."])
+
+    def test_has_played_before(self):
+        base = BaseRules()
+        block = Block.objects.create(slug="music-lab")
+        participant = Participant.objects.create()
+        session = Session.objects.create(block=block, participant=participant)
+        self.assertFalse(base.has_played_before(session))
+        session.finished_at = datetime.now()
+        session.save()
+        self.assertTrue(base.has_played_before(session))

--- a/backend/experiment/rules/thats_my_song.py
+++ b/backend/experiment/rules/thats_my_song.py
@@ -105,11 +105,15 @@ class ThatsMySong(Hooked):
             # Create a score action.
             actions = [self.get_score(session, round_number)]
             heard_before_offset = session.json_data.get("heard_before_offset")
+            # no rounds without questions if the player has previously played
+            question_offset = (
+                0 if self.has_played_before(session) else self.question_offset
+            )
 
-            # SongSync rounds. Skip questions until Round 5 (defined in question_offset).
-            if round_number in range(1, self.question_offset):
+            # SongSync rounds. Skip questions until round defined in question_offset.
+            if round_number in range(1, question_offset):
                 actions.extend(self.next_song_sync_action(session, round_number))
-            if round_number in range(self.question_offset, heard_before_offset):
+            if round_number in range(question_offset, heard_before_offset):
                 question = self.get_single_question(session, randomize=True)
                 if question:
                     actions.append(question)


### PR DESCRIPTION
This PR ensures that players who've already completed a game will get questions after every trial when playing again. That is, until all questions have been asked. @jaburgoyne is this what you had in mind?

NB: The two demographic questions in the beginning yet have to be removed. I am planning to move these to a separate Questionnaire block, but that would mean these questions will appear after Consent, before the first Explainer. If that is as intended, the logic to ask these questions can be removed from the `thats_my_song` rules file.