### PR TITLE
fix: send `response_time` (needed for scoring reaction time)

### DIFF
--- a/frontend/src/components/Trial/Trial.tsx
+++ b/frontend/src/components/Trial/Trial.tsx
@@ -74,6 +74,7 @@ const Trial = (props: TrialAction & SharedActionProps) => {
             await onResult(
                 {
                     decision_time: getAndStoreDecisionTime(),
+                    response_time: responseTime,
                     audio_latency_ms: getAudioLatency(),
                     form,
                 },

--- a/frontend/src/hooks/useResultHandler.ts
+++ b/frontend/src/hooks/useResultHandler.ts
@@ -13,6 +13,7 @@ export interface OnResultParams {
     // If feedback form is provided
     form: Question[];
     decision_time?: number;
+    response_time?: number;
     audio_latency_ms?: number | undefined;
 }
 


### PR DESCRIPTION
Close #1701 .