### PR TITLE
fix: remove condition for showing consent

### DIFF
--- a/frontend/src/components/Consent/Consent.tsx
+++ b/frontend/src/components/Consent/Consent.tsx
@@ -27,7 +27,7 @@ const Consent = ({ title, text, experiment, participant, onNext, confirmButton, 
 
     // Listen for consent, and auto advance if already given
     useEffect(() => {
-        if (consent || (new URLSearchParams(urlQueryString).get("participant_id"))) {
+        if ( consent ) {
             onNext();
         }
     }, [consent, onNext, urlQueryString]);


### PR DESCRIPTION
Close #1700 . Removing the condition that consent is never shown for participants with known `participant_id`. This condition may just cause confusion in the future, and consent can be easily suppressed through the admin interface at this moment.