### PR TITLE
fix: divide results_count in `two_questions` rules by 2

### DIFF
--- a/backend/experiment/rules/two_questions.py
+++ b/backend/experiment/rules/two_questions.py
@@ -51,7 +51,7 @@ class TwoQuestions(BaseRules):
             )
 
     def next_round(self, session: Session):
-        round_number = session.get_rounds_passed()
+        round_number = session.result_set.count() / 2
         total_rounds = session.playlist.section_set.count()
         if round_number == 0:
             return [


### PR DESCRIPTION
Fixes an issue in the `two_questions` rules where rounds were counted by 2, instead of by 1.