### PR TITLE
Feat/improved csv export

### DIFF
--- a/backend/experiment/admin.py
+++ b/backend/experiment/admin.py
@@ -27,8 +27,11 @@ from experiment.forms import (
 from experiment.widgets import MarkdownPreviewTextInput
 from question.admin import QuestionListInline
 from question.models import QuestionList, QuestionInList
-from .utils import get_block_csv_export_as_response, get_block_json_export_as_response
-
+from .utils import (
+    get_block_csv_export_as_response,
+    get_block_json_export_as_response,
+    get_experiment_csv_export_as_response,
+)
 
 class FeedbackAdmin(admin.ModelAdmin):
     model = Feedback
@@ -304,6 +307,10 @@ class ExperimentAdmin(InlineActionsModelAdminMixin, TabbedTranslationAdmin):
         if "_export_csv" in request.POST:
             block_identifier = request.POST.get("export-block")
             return get_block_csv_export_as_response(block_identifier)
+
+        if "_export_experiment_csv" in request.POST:
+            experiment_identifier = request.POST.get("export-experiment")
+            return get_experiment_csv_export_as_response(experiment_identifier)
 
         annotated_blocks = self._annotate_blocks(obj.associated_blocks())
         stats = self._generate_stats(annotated_blocks)

--- a/backend/experiment/templates/experiment-dashboard.html
+++ b/backend/experiment/templates/experiment-dashboard.html
@@ -130,6 +130,10 @@
 <h3>
     Total feedback: {{ stats.feedback_count }}
 </h3>
+<form action="" method="post">
+    {% csrf_token %}
+    <input type="hidden" name="export-experiment" maxlength="128" id="export-experiment" value="{{ experiment.identifier }}">
+    <input type="submit" name="_export_experiment_csv" value="Export CSV of whole experiment" />
 </p>
 
 <!-- Blocks table -->
@@ -199,7 +203,7 @@
             </td>
 
             <td class="table-export">
-                <!-- Export results for this block as JSON -->
+                <!-- Export results for this block as JSON or CSV-->
                 <form action="" method="post">
                     {% csrf_token %}{% render_inline_action_fields %}
                     <input type="hidden" name="export-block" maxlength="128" id="export-block" value="{{ block.identifier }}">

--- a/backend/experiment/templates/experiment-dashboard.html
+++ b/backend/experiment/templates/experiment-dashboard.html
@@ -49,77 +49,12 @@
         font-weight: 600;
         margin: 2rem 0px 2rem 0px;
     }
-    .pop-up {
-        background-color: var(--body-bg);
-        box-shadow: 0px 0px 10px var(--body-quiet-color);
-        position: fixed;
-        padding: 2rem;
-        border-style: solid;
-        border-color: var(--body-quiet-color);
-        border-width: 1px;
-        border-radius: 1px;
-        overflow-y: scroll;
-        z-index: 1;
-    }
-    .popup::backdrop {
-        background-color: rgba(0, 0, 0, 0.25);
-    }
-    .pop-up-big {
-        top: 4.2rem;
-        width: calc(80vw - 34px);
-        height: 80vh;
-    }
-    .pop-up-small {
-        top: 6.2rem;
-        width: calc(76vw - 51px);
-        height: 70vh;
-        z-index: 1;
-    }
-    .button-full {
-        width: 100%;
-    }
-    .badge {
-        padding: 0.25rem 0.4rem;
-        font-size: 75%;
-        font-weight: 700;
-        line-height: 1;
-        text-align: center;
-        white-space: nowrap;
-        vertical-align: baseline;
-        border-radius: 0.25rem;
-    }
-    .badge-white {
-        background: var(--button-fg);
-        color: var(--button-bg);
-    }
-    .feedback-list {
-        margin-top: 4rem;
-    }
-    .feedback-row {
-        width: 66%;
-        margin: 1rem auto 0px auto;
-        padding: 1rem;
-        border-radius: 1rem;
-        background-color: var(--darkened-bg);
-    }
-    .feedback-list h2 {
-        font-size: 0.875rem;
-        color: var(--body-fg);
-        font-weight: 600;
-        text-align: center;
-    }
-    .feedback-row h3 {
-        color: var(--body-fg);
-        font-weight: 600;
-        text-align: left;
-        margin-bottom: 1rem;
-    }
 </style>
 
 <h1>
     Blocks in Experiment: <a href="{% url 'admin:experiment_experiment_change' experiment.id %}" target="_blank">{{ experiment }}</a>
 </h1>
-<div class="experiment-stats">
+<p class="experiment-stats">
 <!-- Show stats on participants, sessions and feedback -->
 <h3>
     Total participants: {{ stats.participant_count }} 
@@ -130,11 +65,13 @@
 <h3>
     Total feedback: {{ stats.feedback_count }}
 </h3>
+</p>
+<div>
 {% if stats.session_count <= 600 %}
 <form action="" method="post">
-    {% csrf_token %}
-    <input type="hidden" name="export-experiment" maxlength="128" id="export-experiment" value="{{ experiment.identifier }}">
-    <input type="submit" name="_export_experiment_csv" value="Export CSV of whole experiment" />
+    {% csrf_token %}{% render_inline_action_fields %}
+    <input type="hidden" name="export-experiment" maxlength="128" id="export-experiment" value="{{ experiment.identifier }}"/>
+    <button class="button" type="submit" name="_export_experiment_csv">Export CSV of whole experiment</button>
 </form>
 {% endif %}
 </div>
@@ -210,8 +147,8 @@
                 <form action="" method="post">
                     {% csrf_token %}{% render_inline_action_fields %}
                     <input type="hidden" name="export-block" maxlength="128" id="export-block" value="{{ block.identifier }}">
-                    <input type="submit" name="_export_json" value="Export JSON" />
-                    {% if block.n_sessions <= 200 %}<input type="submit" name="_export_csv" value="Export CSV" />{% endif %}
+                    <button class="button" type="submit" name="_export_json">Export JSON</button>
+                    {% if block.n_sessions <= 200 %}<button class="button" type="submit" name="_export_csv">Export CSV</button>{% endif %}
                 </form>
             </td>
         </tr>

--- a/backend/experiment/templates/experiment-dashboard.html
+++ b/backend/experiment/templates/experiment-dashboard.html
@@ -148,7 +148,7 @@
                     {% csrf_token %}{% render_inline_action_fields %}
                     <input type="hidden" name="export-block" maxlength="128" id="export-block" value="{{ block.identifier }}">
                     <button class="button" type="submit" name="_export_json">Export JSON</button>
-                    {% if block.n_sessions <= 200 %}<button class="button" type="submit" name="_export_csv">Export CSV</button>{% endif %}
+                    {% if block.n_sessions <= 300 %}<button class="button" type="submit" name="_export_csv">Export CSV</button>{% endif %}
                 </form>
             </td>
         </tr>

--- a/backend/experiment/templates/experiment-dashboard.html
+++ b/backend/experiment/templates/experiment-dashboard.html
@@ -119,7 +119,7 @@
 <h1>
     Blocks in Experiment: <a href="{% url 'admin:experiment_experiment_change' experiment.id %}" target="_blank">{{ experiment }}</a>
 </h1>
-<p class="experiment-stats">
+<div class="experiment-stats">
 <!-- Show stats on participants, sessions and feedback -->
 <h3>
     Total participants: {{ stats.participant_count }} 
@@ -130,11 +130,14 @@
 <h3>
     Total feedback: {{ stats.feedback_count }}
 </h3>
+{% if stats.session_count <= 600 %}
 <form action="" method="post">
     {% csrf_token %}
     <input type="hidden" name="export-experiment" maxlength="128" id="export-experiment" value="{{ experiment.identifier }}">
     <input type="submit" name="_export_experiment_csv" value="Export CSV of whole experiment" />
-</p>
+</form>
+{% endif %}
+</div>
 
 <!-- Blocks table -->
 <table>
@@ -208,7 +211,7 @@
                     {% csrf_token %}{% render_inline_action_fields %}
                     <input type="hidden" name="export-block" maxlength="128" id="export-block" value="{{ block.identifier }}">
                     <input type="submit" name="_export_json" value="Export JSON" />
-                    {% if block.n_sessions <= 100 %}<input type="submit" name="_export_csv" value="Export CSV" />{% endif %}
+                    {% if block.n_sessions <= 200 %}<input type="submit" name="_export_csv" value="Export CSV" />{% endif %}
                 </form>
             </td>
         </tr>

--- a/backend/experiment/tests/test_utils.py
+++ b/backend/experiment/tests/test_utils.py
@@ -39,26 +39,26 @@ class TestExport(TestCase):
         cls.phase = Phase.objects.create(experiment=experiment)
         cls.participant = Participant.objects.create(unique_hash=42)
         cls.playlist = Playlist.objects.create(name="TestPlaylist")
+        cls.block = Block.objects.create(
+            identifier="test-block", rules="LIKERT", phase=cls.phase
+        )
+        cls.block.playlists.add(cls.playlist)
+        song = Song.objects.create(artist="artist", name="name")
         Section.objects.bulk_create(
             [
                 Section(
                     filename=f"section_{i}",
-                    song=Song.objects.create(artist=f"artist_{i}", name=f"name_{i}"),
+                    song=song,
                     playlist=cls.playlist,
                 )
                 for i in range(5)
             ]
-        )
-        cls.block = Block.objects.create(
-            identifier="test-block", rules="LIKERT", phase=cls.phase
         )
         Question.objects.bulk_create(
             [Question("test_profile_" + str(i)) for i in range(5)]
         )
         question_list = QuestionList.objects.create(block=cls.block)
         question_list.questions.add(*Question.objects.all())
-        for playlist in cls.block.playlists.all():
-            playlist._update_sections()
         cls.session = Session.objects.create(
             block=cls.block, participant=cls.participant, playlist=cls.playlist
         )
@@ -70,7 +70,7 @@ class TestExport(TestCase):
                     expected_response=i,
                     given_response=i,
                     score=i,
-                    section=Section.objects.get(filename="section_" + str(i)),
+                    section=Section.objects.get(filename=f"section_{i}"),
                     question_identifier="test_question",
                 )
                 for i in range(5)
@@ -81,7 +81,7 @@ class TestExport(TestCase):
             [
                 Result(
                     participant=cls.participant,
-                    question_identifier="test_profile_" + str(i),
+                    question_identifier=f"test_profile_{i}",
                     given_response=i,
                 )
                 for i in range(5)
@@ -109,7 +109,7 @@ class TestExport(TestCase):
         profile_results_count = Result.objects.filter(participant__isnull=False).count()
         self.assertGreater(
             len(
-                rows[0].split(","),
+                rows[0].keys(),
             ),
             profile_results_count * 2,
         )
@@ -155,7 +155,8 @@ class TestExport(TestCase):
         csv_output = experiment_export_csv_results("test-experiment")
         reader = csv.DictReader(csv_output.split("\n"))
         rows = [r for r in reader]
-        self.assertIn("test_question2.score", rows[0])
+        response_keys = [key for key in rows[0].keys() if ".given_response" in key]
+        self.assertEqual(len(response_keys), 7)
         self.assertEqual(len(rows), 5)
 
     def test_block_json_export(self):
@@ -177,24 +178,29 @@ class TestExport(TestCase):
             self.assertEqual(Participant.objects.first().unique_hash, "42")
 
             these_profiles = json.loads(test_zip.read("profiles.json").decode("utf-8"))
-            self.assertEqual(len(these_profiles), 5)
+            self.assertEqual(
+                len(these_profiles),
+                Result.objects.filter(participant__isnull=False).count(),
+            )
 
             these_results = json.loads(test_zip.read("results.json").decode("utf-8"))
-            self.assertEqual(len(these_results), 5)
+            self.assertEqual(
+                len(these_results),
+                Result.objects.filter(participant__isnull=False).count(),
+            )
 
             these_sections = json.loads(test_zip.read("sections.json").decode("utf-8"))
-            self.assertEqual(len(these_sections), 1000)
+            self.assertEqual(len(these_sections), Section.objects.count())
 
             these_sessions = json.loads(test_zip.read("sessions.json").decode("utf-8"))
-
             self.assertEqual(len(these_sessions), 1)
-            self.assertEqual(these_sessions[0]["fields"]["block"], 4)
+            self.assertEqual(these_sessions[0]["fields"]["block"], self.block.id)
 
             these_songs = json.loads(test_zip.read("songs.json").decode("utf-8"))
-            self.assertEqual(len(these_songs), 100)
+            self.assertEqual(len(these_songs), Song.objects.count())
 
             this_feedback = json.loads(test_zip.read("feedback.json").decode("utf-8"))
-            self.assertEqual(len(this_feedback), 2)
+            self.assertEqual(len(this_feedback), Feedback.objects.count())
 
     def test_block_json_export_admin(self):
         response = get_block_json_export_as_response(self.block.identifier)

--- a/backend/experiment/tests/test_utils.py
+++ b/backend/experiment/tests/test_utils.py
@@ -69,6 +69,7 @@ class TestExport(TestCase):
                     session=cls.session,
                     expected_response=i,
                     given_response=i,
+                    score=i,
                     section=Section.objects.get(filename="section_" + str(i)),
                     question_identifier="test_question",
                 )
@@ -145,12 +146,17 @@ class TestExport(TestCase):
                     session=session,
                     section=Section.objects.get(filename="section_" + str(i)),
                     question_identifier="test_question2",
+                    given_response=i + 10,
+                    score=i + 10,
                 )
                 for i in range(5)
             ]
         )
         csv_output = experiment_export_csv_results("test-experiment")
-        self.assertIsNotNone(csv_output)
+        reader = csv.DictReader(csv_output.split("\n"))
+        rows = [r for r in reader]
+        self.assertIn("test_question2.score", rows[0])
+        self.assertEqual(len(rows), 5)
 
     def test_block_json_export(self):
         zip_buffer = block_export_json_results(self.block.identifier)

--- a/backend/experiment/tests/test_utils.py
+++ b/backend/experiment/tests/test_utils.py
@@ -7,6 +7,7 @@ from django.test import TestCase, Client
 from experiment.utils import (
     block_export_csv_results,
     block_export_json_results,
+    experiment_export_csv_results,
     format_label,
     get_block_csv_export_as_response,
     get_block_json_export_as_response,
@@ -14,9 +15,10 @@ from experiment.utils import (
 
 from experiment.models import Experiment, Phase, Block, Feedback
 from participant.models import Participant
-from session.models import Session
+from question.models import Question, QuestionList
 from result.models import Result
-
+from section.models import Playlist, Section, Song
+from session.models import Session
 
 class TestExperimentUtils(TestCase):
 
@@ -27,38 +29,63 @@ class TestExperimentUtils(TestCase):
         self.assertEqual(label, 'IV')
 
 
-class TestBlockExport(TestCase):
-    fixtures = ["playlist", "experiment"]
+class TestExport(TestCase):
 
     @classmethod
     def setUpTestData(cls):
         experiment = Experiment.objects.create(
             identifier="test-experiment", name="Test Experiment"
         )
-        phase = Phase.objects.create(experiment=experiment)
+        cls.phase = Phase.objects.create(experiment=experiment)
         cls.participant = Participant.objects.create(unique_hash=42)
-        cls.block = Block.objects.get(identifier="huang_2022")
-        cls.block.phase = phase
+        cls.playlist = Playlist.objects.create(name="TestPlaylist")
+        Section.objects.bulk_create(
+            [
+                Section(
+                    filename=f"section_{i}",
+                    song=Song.objects.create(artist=f"artist_{i}", name=f"name_{i}"),
+                    playlist=cls.playlist,
+                )
+                for i in range(5)
+            ]
+        )
+        cls.block = Block.objects.create(
+            identifier="test-block", rules="LIKERT", phase=cls.phase
+        )
+        Question.objects.bulk_create(
+            [Question("test_profile_" + str(i)) for i in range(5)]
+        )
+        question_list = QuestionList.objects.create(block=cls.block)
+        question_list.questions.add(*Question.objects.all())
         for playlist in cls.block.playlists.all():
             playlist._update_sections()
         cls.session = Session.objects.create(
-            block=cls.block,
-            participant=cls.participant,
+            block=cls.block, participant=cls.participant, playlist=cls.playlist
         )
-
-        for i in range(5):
-            Result.objects.create(
-                session=Session.objects.first(),
-                expected_response=i,
-                given_response=i,
-                question_identifier="test_question_" + str(i),
-            )
-            Result.objects.create(
-                participant=cls.participant,
-                question_identifier=i,
-                given_response=i,
-            )
-
+        # create session results
+        Result.objects.bulk_create(
+            [
+                Result(
+                    session=cls.session,
+                    expected_response=i,
+                    given_response=i,
+                    section=Section.objects.get(filename="section_" + str(i)),
+                    question_identifier="test_question",
+                )
+                for i in range(5)
+            ]
+        )
+        # create profile results
+        Result.objects.bulk_create(
+            [
+                Result(
+                    participant=cls.participant,
+                    question_identifier="test_profile_" + str(i),
+                    given_response=i,
+                )
+                for i in range(5)
+            ]
+        )
         Feedback.objects.create(
             block=cls.block,
             text="Lorem",
@@ -74,7 +101,31 @@ class TestBlockExport(TestCase):
     def test_block_csv_export(self):
         csv_output = block_export_csv_results(self.block.identifier)
         reader = csv.DictReader(csv_output.split("\n"))
-        self.assertEqual(len([r for r in reader]), 10)
+        rows = [r for r in reader]
+        session_results_count = Result.objects.filter(session__isnull=False).count()
+        self.assertEqual(len(rows), session_results_count)
+        self.assertIn("test_profile_1.score", rows[0])
+        profile_results_count = Result.objects.filter(participant__isnull=False).count()
+        self.assertGreater(
+            len(
+                rows[0].split(","),
+            ),
+            profile_results_count * 2,
+        )
+
+    def test_block_csv_export_without_profile_results(self):
+        Result.objects.exclude(participant__isnull=True).delete()
+        csv_output = block_export_csv_results(self.block.identifier)
+        reader = csv.DictReader(csv_output.split("\n"))
+        rows = [r for r in reader]
+        self.assertIsNone(rows[0].get("test_profile_0.score"))
+
+    def test_block_csv_export_without_session_results(self):
+        Result.objects.exclude(session__isnull=True).delete()
+        csv_output = block_export_csv_results(self.block.identifier)
+        reader = csv.DictReader(csv_output.split("\n"))
+        rows = [r for r in reader]
+        self.assertEqual(len(rows), 1)
 
     def test_block_csv_export_admin(self):
         response = get_block_csv_export_as_response(self.block.identifier)
@@ -82,6 +133,24 @@ class TestBlockExport(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(response.content)
         self.assertEqual(response["content-type"], "text/csv")
+
+    def test_experiment_csv_export(self):
+        block = Block.objects.create(
+            identifier="test-block-2", rules="LIKERT", phase=self.phase
+        )
+        session = Session.objects.create(block=block, participant=self.participant)
+        Result.objects.bulk_create(
+            [
+                Result(
+                    session=session,
+                    section=Section.objects.get(filename="section_" + str(i)),
+                    question_identifier="test_question2",
+                )
+                for i in range(5)
+            ]
+        )
+        csv_output = experiment_export_csv_results("test-experiment")
+        self.assertIsNotNone(csv_output)
 
     def test_block_json_export(self):
         zip_buffer = block_export_json_results(self.block.identifier)

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -195,15 +195,44 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
         block_generate_results_data_frame(block_id) for block_id in block_identifiers
     ]
     combination = pd.concat(data_frames)
-    breakpoint()
-    wide_format = combination.pivot_table(
-        index=["section__id", "session__id"],
-        values=["given_response", "score"],
-        aggfunc=agg_func,
+    keys_of_interest = [
+        "score",
+        "given_response",
+        "section__id",
+        "participant__id",
+        "question_identifier",
+    ]
+    section_data = (
+        (
+            combination[keys_of_interest]
+            .groupby(
+                ["section__id", "question_identifier", "participant__id"], dropna=False
+            )
+            .agg(agg_func)
+        )
+        .unstack("question_identifier")
+        .reset_index()
     )
-    breakpoint()
+    section_data.columns = [
+        ".".join(map(str, reversed(col))).strip(".")
+        for col in section_data.columns.to_flat_index()
+    ]
+    merged = section_data.merge(
+        combination.drop(
+            [
+                "session__id",
+                "session__final_score",
+                "created_at",
+                "given_response",
+                "expected_response",
+                "score",
+            ],
+            axis=1,
+        ),
+        on=["participant__id", "section__id"],
+    )
     csv_buffer = StringIO()
-    data_frames.to_csv(csv_buffer)
+    merged.to_csv(csv_buffer)
     return csv_buffer.getvalue()
 
 

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -217,6 +217,7 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
             .unstack("question_identifier")
             .reset_index()
         )
+        breakpoint()
         section_data.columns = [
             ".".join(map(str, reversed(col))).strip(".")
             for col in section_data.columns.to_flat_index()
@@ -224,23 +225,26 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
         profile_columns = [
             col for col in combination.columns if ".given_response" in col
         ]
-        profile_data = combination.dropna(subset=profile_columns, how="all").drop(
-            [
-                "question_identifier",
-                "session__id",
-                "session__final_score",
-                "created_at",
-                "given_response",
-                "expected_response",
-                "score",
-            ],
-            axis=1,
-        )
-        output = section_data.merge(
-            profile_data,
-            how="inner",
-            on=["participant__id", "section__id"],
-        )
+        if profile_columns:
+            profile_data = combination.dropna(subset=profile_columns, how="all").drop(
+                [
+                    "question_identifier",
+                    "session__id",
+                    "session__final_score",
+                    "created_at",
+                    "given_response",
+                    "expected_response",
+                    "score",
+                ],
+                axis=1,
+            )
+            output = section_data.merge(
+                profile_data,
+                how="inner",
+                on=["participant__id", "section__id"],
+            )
+        else:
+            output = section_data
     else:
         output = combination
     csv_buffer = StringIO()

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -1,6 +1,6 @@
-from csv import DictWriter
 from io import BytesIO, StringIO
 from os.path import join
+from typing import Union
 from zipfile import ZipFile
 
 from django.db.models.query import QuerySet
@@ -8,6 +8,7 @@ from django.db.models import F
 from django.core import serializers
 from django.http import HttpResponse
 from django.utils import timezone
+import pandas as pd
 import roman
 
 
@@ -99,7 +100,7 @@ def get_profiles_of_participants(
     return Result.objects.filter(participant__in=participants)
 
 
-def block_export_csv_results(block_identifier: str) -> StringIO:
+def block_generate_results_data_frame(block_identifier: str) -> pd.DataFrame:
     """export results and profiles in two csvs
     This export does not provide all data, but a selection of the variables
     expected to be of most interest for basic analyses
@@ -111,6 +112,7 @@ def block_export_csv_results(block_identifier: str) -> StringIO:
         "session__id",
         "session__final_score",
         "participant__id",
+        "participant__country_code",
         "question_identifier",
         "created_at",
         "expected_response",
@@ -122,9 +124,11 @@ def block_export_csv_results(block_identifier: str) -> StringIO:
         "section__tag",
         "section__group",
     ]
-    results_output = list(
-        all_results.annotate(participant__id=F("session_participant")).values(
-            *result_output_keys
+    results_output = pd.DataFrame(
+        list(
+            all_results.annotate(participant__id=F("session__participant")).values(
+                *result_output_keys
+            )
         )
     )
     all_participants = get_participants_of_sessions(all_sessions)
@@ -137,21 +141,78 @@ def block_export_csv_results(block_identifier: str) -> StringIO:
     )
     profile_output_keys = [
         "participant__id",
+        "participant__country_code",
         "question_identifier",
         "given_response",
         "score",
     ]
-    profiles_output = list(relevant_profiles.values(*profile_output_keys))
-    for participant in list(all_participants):
+    profiles_output = pd.DataFrame(list(relevant_profiles.values(*profile_output_keys)))
+    if profiles_output.empty:
+        return results_output
+    wide_profiles = profiles_output.pivot(
+        index="participant__id",
+        columns="question_identifier",
+        values=["given_response", "score"],
+    )
+    wide_profiles.columns = [
+        ".".join(map(str, reversed(col)))
+        for col in wide_profiles.columns.to_flat_index()
+    ]
+    wide_profiles = wide_profiles.reset_index()
+    if results_output.empty:
+        return wide_profiles
+    return pd.merge(results_output, wide_profiles, on="participant__id")
 
-        
-    combined_output = [*results_output, *profiles_output]
-    fieldnames = list(set([*profile_output_keys, *result_output_keys]))
+
+def block_export_csv_results(block_identifier: str) -> StringIO:
     csv_buffer = StringIO()
-    writer = DictWriter(csv_buffer, fieldnames=fieldnames, lineterminator="\n")
-    writer.writeheader()
-    writer.writerows(combined_output)
+    results_df = block_generate_results_data_frame(block_identifier)
+    results_df.to_csv(csv_buffer)
     return csv_buffer.getvalue()
+
+
+def get_block_csv_export_as_response(block_identifier: str) -> HttpResponse:
+    '''Create a download response for the admin experimenter dashboard'''
+    csv_string = block_export_csv_results(block_identifier)
+    response = HttpResponse(csv_string)
+    response["Content-Type"] = "text/csv"
+    response["Content-Disposition"] = (
+        'attachment; filename="'
+        + block_identifier
+        + "-"
+        + timezone.now().isoformat()
+        + '.csv"'
+    )
+    return response
+
+
+def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
+    experiment = Experiment.objects.get(identifier=experiment_identifier)
+    block_identifiers = experiment.associated_blocks().values_list(
+        "identifier", flat=True
+    )
+    data_frames = [
+        block_generate_results_data_frame(block_id) for block_id in block_identifiers
+    ]
+    combination = pd.concat(data_frames)
+    breakpoint()
+    wide_format = combination.pivot_table(
+        index=["section__id", "session__id"],
+        values=["given_response", "score"],
+        aggfunc=agg_func,
+    )
+    breakpoint()
+    csv_buffer = StringIO()
+    data_frames.to_csv(csv_buffer)
+    return csv_buffer.getvalue()
+
+
+def agg_func(input_value: Union[list, str, int]) -> str:
+    """return the first response by a participant"""
+    if type(input_value) is pd.Series:
+        return input_value.values[0]
+    else:
+        return input_value
 
 
 def get_block_csv_export_as_response(block_identifier: str) -> HttpResponse:

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -8,6 +8,7 @@ from django.db.models import F
 from django.core import serializers
 from django.http import HttpResponse
 from django.utils import timezone
+import numpy as np
 import pandas as pd
 import roman
 
@@ -195,31 +196,37 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
         block_generate_results_data_frame(block_id) for block_id in block_identifiers
     ]
     combination = pd.concat(data_frames)
-    keys_of_interest = [
-        "score",
-        "given_response",
-        "section__id",
-        "participant__id",
-        "question_identifier",
-    ]
-    section_data = (
-        (
-            combination[keys_of_interest]
-            .groupby(
-                ["section__id", "question_identifier", "participant__id"], dropna=False
+    if any(combination.section__id):
+        # if we have section_ids defined, aggregate data by section_id
+        keys_of_interest = [
+            "score",
+            "given_response",
+            "section__id",
+            "participant__id",
+            "question_identifier",
+        ]
+        section_data = (
+            (
+                combination[keys_of_interest]
+                .groupby(
+                    ["section__id", "question_identifier", "participant__id"],
+                    dropna=False,
+                )
+                .agg(agg_func)
             )
-            .agg(agg_func)
+            .unstack("question_identifier")
+            .reset_index()
         )
-        .unstack("question_identifier")
-        .reset_index()
-    )
-    section_data.columns = [
-        ".".join(map(str, reversed(col))).strip(".")
-        for col in section_data.columns.to_flat_index()
-    ]
-    merged = section_data.merge(
-        combination.drop(
+        section_data.columns = [
+            ".".join(map(str, reversed(col))).strip(".")
+            for col in section_data.columns.to_flat_index()
+        ]
+        profile_columns = [
+            col for col in combination.columns if ".given_response" in col
+        ]
+        profile_data = combination.dropna(subset=profile_columns, how="all").drop(
             [
+                "question_identifier",
                 "session__id",
                 "session__final_score",
                 "created_at",
@@ -228,12 +235,39 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
                 "score",
             ],
             axis=1,
-        ),
-        on=["participant__id", "section__id"],
-    )
+        )
+        output = section_data.merge(
+            profile_data,
+            how="inner",
+            on=["participant__id", "section__id"],
+        )
+    else:
+        output = combination
     csv_buffer = StringIO()
-    merged.to_csv(csv_buffer)
+    output.fillna(value=np.nan).drop_duplicates().to_csv(csv_buffer)
     return csv_buffer.getvalue()
+
+
+def block_export_csv_results(block_identifier: str) -> StringIO:
+    csv_buffer = StringIO()
+    results_df = block_generate_results_data_frame(block_identifier)
+    results_df.to_csv(csv_buffer)
+    return csv_buffer.getvalue()
+
+
+def get_experiment_csv_export_as_response(experiment_identifier: str) -> HttpResponse:
+    '''Create a download response for the admin experimenter dashboard'''
+    csv_string = experiment_export_csv_results(experiment_identifier)
+    response = HttpResponse(csv_string)
+    response["Content-Type"] = "text/csv"
+    response["Content-Disposition"] = (
+        'attachment; filename="'
+        + experiment_identifier
+        + "-"
+        + timezone.now().isoformat()
+        + '.csv"'
+    )
+    return response
 
 
 def agg_func(input_value: Union[list, str, int]) -> str:

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -206,14 +206,12 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
             "question_identifier",
         ]
         section_data = (
-            (
-                combination[keys_of_interest]
-                .groupby(
-                    ["section__id", "question_identifier", "participant__id"],
-                    dropna=False,
-                )
-                .agg(agg_func)
+            combination[keys_of_interest]
+            .groupby(
+                ["section__id", "question_identifier", "participant__id"],
+                dropna=False,
             )
+            .agg(agg_func)
             .unstack("question_identifier")
             .reset_index()
         )
@@ -228,6 +226,7 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
             profile_data = combination.dropna(subset=profile_columns, how="all").drop(
                 [
                     "question_identifier",
+                    "section__id",
                     "session__id",
                     "session__final_score",
                     "created_at",
@@ -237,17 +236,13 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
                 ],
                 axis=1,
             )
-            output = section_data.merge(
-                profile_data,
-                how="inner",
-                on=["participant__id", "section__id"],
-            )
+            output = section_data.merge(profile_data, on=["participant__id"])
         else:
             output = section_data
     else:
         output = combination
     csv_buffer = StringIO()
-    output.fillna(value=np.nan).drop_duplicates().to_csv(csv_buffer)
+    output.drop_duplicates().to_csv(csv_buffer)
     return csv_buffer.getvalue()
 
 

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -109,6 +109,7 @@ def block_export_csv_results(block_identifier: str) -> StringIO:
     all_results = get_results_of_sessions(all_sessions)
     result_output_keys = [
         "session__id",
+        "session__final_score",
         "participant__id",
         "question_identifier",
         "created_at",
@@ -122,22 +123,28 @@ def block_export_csv_results(block_identifier: str) -> StringIO:
         "section__group",
     ]
     results_output = list(
-        all_results.annotate(participant__id=F("session__participant")).values(
+        all_results.annotate(participant__id=F("session_participant")).values(
             *result_output_keys
         )
     )
     all_participants = get_participants_of_sessions(all_sessions)
-    all_profiles = get_profiles_of_participants(all_participants)
+    question_identifiers = []
+    question_lists = this_block.questionlist_set.all()
+    for ql in question_lists:
+        question_identifiers.extend(ql.questions.values_list("identifier", flat=True))
+    relevant_profiles = get_profiles_of_participants(all_participants).filter(
+        question_identifier__in=question_identifiers
+    )
     profile_output_keys = [
         "participant__id",
-        "participant__country_code",
         "question_identifier",
-        "created_at",
-        "expected_response",
         "given_response",
         "score",
     ]
-    profiles_output = list(all_profiles.values(*profile_output_keys))
+    profiles_output = list(relevant_profiles.values(*profile_output_keys))
+    for participant in list(all_participants):
+
+        
     combined_output = [*results_output, *profiles_output]
     fieldnames = list(set([*profile_output_keys, *result_output_keys]))
     csv_buffer = StringIO()

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -217,7 +217,6 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
             .unstack("question_identifier")
             .reset_index()
         )
-        breakpoint()
         section_data.columns = [
             ".".join(map(str, reversed(col))).strip(".")
             for col in section_data.columns.to_flat_index()

--- a/backend/experiment/utils.py
+++ b/backend/experiment/utils.py
@@ -207,6 +207,7 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
         ]
         section_data = (
             combination[keys_of_interest]
+            .dropna(subset="question_identifier")
             .groupby(
                 ["section__id", "question_identifier", "participant__id"],
                 dropna=False,
@@ -226,7 +227,6 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
             profile_data = combination.dropna(subset=profile_columns, how="all").drop(
                 [
                     "question_identifier",
-                    "section__id",
                     "session__id",
                     "session__final_score",
                     "created_at",
@@ -236,7 +236,13 @@ def experiment_export_csv_results(experiment_identifier: str) -> StringIO:
                 ],
                 axis=1,
             )
-            output = section_data.merge(profile_data, on=["participant__id"])
+            output = section_data.merge(
+                profile_data,
+                on=[
+                    "participant__id",
+                    "section__id",
+                ],
+            )
         else:
             output = section_data
     else:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "django-modeltranslation>=0.20.3",
     "django-nested-admin>=4.1.6",
     "markdown>=3.10.1",
+    "pandas>=3.0.3",
     "pillow>=12.2.0",
     "psycopg>=3.3.2",
     "pyyaml>=6.0.3",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,8 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -97,6 +104,7 @@ dependencies = [
     { name = "django-modeltranslation" },
     { name = "django-nested-admin" },
     { name = "markdown" },
+    { name = "pandas" },
     { name = "pillow" },
     { name = "psycopg" },
     { name = "pyyaml" },
@@ -134,6 +142,7 @@ requires-dist = [
     { name = "django-modeltranslation", specifier = ">=0.20.3" },
     { name = "django-nested-admin", specifier = ">=4.1.6" },
     { name = "markdown", specifier = ">=3.10.1" },
+    { name = "pandas", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "psycopg", specifier = ">=3.3.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -453,12 +462,125 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -541,6 +663,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1a/7d9ef4fdc13ef7f15b934c393edc97a35c281bb7d3c3329fbfcbe915a7c2/psycopg-3.3.2.tar.gz", hash = "sha256:707a67975ee214d200511177a6a80e56e654754c9afca06a7194ea6bbfde9ca7", size = 165630, upload-time = "2025-12-06T17:34:53.899Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/51/2779ccdf9305981a06b21a6b27e8547c948d85c41c76ff434192784a4c93/psycopg-3.3.2-py3-none-any.whl", hash = "sha256:3e94bc5f4690247d734599af56e51bae8e0db8e4311ea413f801fef82b14a99b", size = 212774, upload-time = "2025-12-06T17:31:41.414Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -668,6 +802,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This branch adds an option to export all experiment data in *one* csv. For more complex experiments, this will probably not include sufficient data, but for a simple experiment in which we are interested in responses per section, combined with responses per participant, this should be a helpful addition.